### PR TITLE
KK-117 | Multiple children in graphql mutation

### DIFF
--- a/src/domain/api/__tests__/client.test.ts
+++ b/src/domain/api/__tests__/client.test.ts
@@ -11,7 +11,7 @@ describe('graphql client', () => {
     global.fetch.mockResponse(
       JSON.stringify({
         data: {
-          dummy: null,
+          children: { __typename: 'ChildNodeConnection' },
         },
       })
     );
@@ -21,14 +21,7 @@ describe('graphql client', () => {
         query: gql`
           query ChildrenQuery {
             children {
-              pageInfo {
-                hasNextPage
-              }
-              edges {
-                node {
-                  firstName
-                }
-              }
+              __typename
             }
           }
         `,

--- a/src/domain/api/__tests__/client.test.ts
+++ b/src/domain/api/__tests__/client.test.ts
@@ -19,8 +19,17 @@ describe('graphql client', () => {
     try {
       await client.query({
         query: gql`
-          query DummyQuery {
-            dummy
+          query ChildrenQuery {
+            children {
+              pageInfo {
+                hasNextPage
+              }
+              edges {
+                node {
+                  firstName
+                }
+              }
+            }
           }
         `,
       });

--- a/src/domain/api/generatedTypes/ChildrenQuery.ts
+++ b/src/domain/api/generatedTypes/ChildrenQuery.ts
@@ -1,0 +1,44 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: ChildrenQuery
+// ====================================================
+
+export interface ChildrenQuery_children_pageInfo {
+  __typename: "PageInfo";
+  /**
+   * When paginating forwards, are there more items?
+   */
+  hasNextPage: boolean;
+}
+
+export interface ChildrenQuery_children_edges_node {
+  __typename: "ChildNode";
+  firstName: string;
+}
+
+export interface ChildrenQuery_children_edges {
+  __typename: "ChildNodeEdge";
+  /**
+   * The item at the end of the edge
+   */
+  node: ChildrenQuery_children_edges_node | null;
+}
+
+export interface ChildrenQuery_children {
+  __typename: "ChildNodeConnection";
+  /**
+   * Pagination data for this connection.
+   */
+  pageInfo: ChildrenQuery_children_pageInfo;
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (ChildrenQuery_children_edges | null)[];
+}
+
+export interface ChildrenQuery {
+  children: ChildrenQuery_children | null;
+}

--- a/src/domain/api/generatedTypes/globalTypes.ts
+++ b/src/domain/api/generatedTypes/globalTypes.ts
@@ -6,6 +6,24 @@
 // START Enums and Input Objects
 //==============================================================
 
+export enum RelationshipTypeEnum {
+  ADVOCATE = "ADVOCATE",
+  OTHER_GUARDIAN = "OTHER_GUARDIAN",
+  OTHER_RELATION = "OTHER_RELATION",
+  PARENT = "PARENT",
+}
+
+export interface ChildInput {
+  firstName?: string | null;
+  lastName?: string | null;
+  birthdate: any;
+  relationship?: RelationshipInput | null;
+}
+
+export interface RelationshipInput {
+  type?: RelationshipTypeEnum | null;
+}
+
 //==============================================================
 // END Enums and Input Objects
 //==============================================================

--- a/src/domain/api/generatedTypes/submitChildrenAndGuardian.ts
+++ b/src/domain/api/generatedTypes/submitChildrenAndGuardian.ts
@@ -1,0 +1,40 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { ChildInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: submitChildrenAndGuardian
+// ====================================================
+
+export interface submitChildrenAndGuardian_submitChildrenAndGuardian_children {
+  __typename: "ChildMutationOutputNode";
+  birthdate: any;
+  firstName: string;
+  lastName: string;
+}
+
+export interface submitChildrenAndGuardian_submitChildrenAndGuardian_guardian {
+  __typename: "GuardianNode";
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export interface submitChildrenAndGuardian_submitChildrenAndGuardian {
+  __typename: "SubmitChildrenAndGuardianMutationPayload";
+  children: (submitChildrenAndGuardian_submitChildrenAndGuardian_children | null)[] | null;
+  guardian: submitChildrenAndGuardian_submitChildrenAndGuardian_guardian | null;
+}
+
+export interface submitChildrenAndGuardian {
+  submitChildrenAndGuardian: submitChildrenAndGuardian_submitChildrenAndGuardian | null;
+}
+
+export interface submitChildrenAndGuardianVariables {
+  children?: (ChildInput | null)[] | null;
+  guardianFirstName: string;
+  guardianLastName: string;
+  email: string;
+}

--- a/src/domain/registration/form/RegistrationForm.tsx
+++ b/src/domain/registration/form/RegistrationForm.tsx
@@ -9,7 +9,7 @@ import styles from './registrationForm.module.scss';
 import Button from '../../../common/components/button/Button';
 import InputField from '../../../common/components/form/fields/input/InputField';
 import SelectField from '../../../common/components/form/fields/select/SelectField';
-import submitChildMutationQuery from '../mutations/submitChild';
+import submitChildrenAndGuardianMutation from '../mutations/submitChildrenAndGuardianMutation';
 import { setFormValues } from '../state/RegistrationActions';
 import { RegistrationFormValues } from '../types/RegistrationTypes';
 import { StoreState } from '../../app/types/AppTypes';
@@ -31,7 +31,9 @@ const RegistrationForm: FunctionComponent<Props> = ({
   initialValues,
 }) => {
   // TODO: Do something with the data we get from the backend.
-  const [submitChild] = useMutation(submitChildMutationQuery);
+  const [submitChildrenAndGuardian] = useMutation(
+    submitChildrenAndGuardianMutation
+  );
   const { t } = useTranslation();
   const history = useHistory();
 
@@ -48,12 +50,17 @@ const RegistrationForm: FunctionComponent<Props> = ({
           }
           onSubmit={values => {
             setFormValues(values);
+            const childInput = [
+              {
+                birthdate: values.child.birthdate,
+                firstName: values.child.firstName,
+                lastName: values.child.lastName,
+              },
+            ];
             try {
-              submitChild({
+              submitChildrenAndGuardian({
                 variables: {
-                  birthdate: values.child.birthdate,
-                  firstName: values.child.firstName,
-                  lastName: values.child.lastName,
+                  children: childInput,
                   guardianFirstName: values.guardian.firstName,
                   guardianLastName: values.guardian.lastName,
                   email: values.guardian.email,

--- a/src/domain/registration/mutations/submitChildrenAndGuardianMutation.ts
+++ b/src/domain/registration/mutations/submitChildrenAndGuardianMutation.ts
@@ -21,7 +21,6 @@ const submitChildrenAndGuardianMutation = gql`
         birthdate
         firstName
         lastName
-        firstName
       }
       guardian {
         firstName

--- a/src/domain/registration/mutations/submitChildrenAndGuardianMutation.ts
+++ b/src/domain/registration/mutations/submitChildrenAndGuardianMutation.ts
@@ -1,21 +1,15 @@
 import { gql } from 'apollo-boost';
 
-const submitChildMutationQuery = gql`
-  mutation submitChild(
-    $birthdate: Date!
-    $firstName: String
-    $lastName: String
+const submitChildrenAndGuardianMutation = gql`
+  mutation submitChildrenAndGuardian(
+    $children: [ChildInput]
     $guardianFirstName: String!
     $guardianLastName: String!
     $email: String!
   ) {
-    submitChild(
+    submitChildrenAndGuardian(
       input: {
-        child: {
-          birthdate: $birthdate
-          firstName: $firstName
-          lastName: $lastName
-        }
+        children: $children
         guardian: {
           lastName: $guardianLastName
           firstName: $guardianFirstName
@@ -23,10 +17,11 @@ const submitChildMutationQuery = gql`
         }
       }
     ) {
-      child {
+      children {
         birthdate
         firstName
         lastName
+        firstName
       }
       guardian {
         firstName
@@ -37,4 +32,4 @@ const submitChildMutationQuery = gql`
   }
 `;
 
-export default submitChildMutationQuery;
+export default submitChildrenAndGuardianMutation;


### PR DESCRIPTION
This PR seems to work with the backend and only one child. 

Now that the backend has a more "complete" schema it might be possible to create the mutations in a more fancy apollo + graphql + typescript 2019 kinda way. 