### PR TITLE
KK-153 | Use correct relationship format for submit add child mutations

### DIFF
--- a/src/common/components/form/__tests__/validationUtils.tests.tsx
+++ b/src/common/components/form/__tests__/validationUtils.tests.tsx
@@ -72,7 +72,7 @@ describe('Form validation utilities - ', () => {
 
     test('postal code is empty', () => {
       const error = validatePostalCode('');
-      expect(error).toEqual('validation.postalCode.invalidFormat');
+      expect(error).toBeUndefined();
     });
 
     test('valid postal code', () => {

--- a/src/common/components/form/validationUtils.tsx
+++ b/src/common/components/form/validationUtils.tsx
@@ -22,7 +22,7 @@ const validateRequire = (value: any, customMessage?: string) => {
  */
 const validatePostalCode = (value: string): string | undefined => {
   const valid: boolean = /^\d{5}$/.test(value);
-  if (!valid) return 'validation.postalCode.invalidFormat';
+  if (value && !valid) return 'validation.postalCode.invalidFormat';
 };
 
 /** validateDate()

--- a/src/domain/child/ChildUtils.ts
+++ b/src/domain/child/ChildUtils.ts
@@ -46,8 +46,5 @@ export const getTranslatedRelationshipOptions = (
  * TODO: Fix reducer default data to match backend typing
  */
 export const getSupportedChildData = (child: Child) => {
-  const omited = omit(child, 'homeCity');
-  return Object.assign(omited, {
-    relationship: { type: child.relationship },
-  });
+  return omit(child, 'homeCity');
 };

--- a/src/domain/child/modal/ChildFormModal.tsx
+++ b/src/domain/child/modal/ChildFormModal.tsx
@@ -156,7 +156,7 @@ const ChildFormModal: React.FunctionComponent<ChildFormModalProps> = ({
                 </div>
 
                 <EnhancedInputField
-                  name="relationship"
+                  name="relationship.type"
                   label={t('registration.form.child.relationship.input.label')}
                   component={SelectField}
                   id="registration.form.child.relationship.select"

--- a/src/domain/child/modal/__tests__/__snapshots__/ChildFormModal.test.tsx.snap
+++ b/src/domain/child/modal/__tests__/__snapshots__/ChildFormModal.test.tsx.snap
@@ -18,6 +18,9 @@ exports[`renders snapshot correctly 1`] = `
           "homeCity": "",
           "lastName": "",
           "postalCode": "",
+          "relationship": Object {
+            "type": undefined,
+          },
         }
       }
       onSubmit={[Function]}

--- a/src/domain/registration/form/__tests__/__snapshots__/RegistrationForm.test.tsx.snap
+++ b/src/domain/registration/form/__tests__/__snapshots__/RegistrationForm.test.tsx.snap
@@ -44,6 +44,9 @@ exports[`renders snapshot correctly 1`] = `
               "homeCity": "",
               "lastName": "",
               "postalCode": "",
+              "relationship": Object {
+                "type": undefined,
+              },
             },
           ],
           "guardian": Object {
@@ -51,7 +54,6 @@ exports[`renders snapshot correctly 1`] = `
             "firstName": "",
             "lastName": "",
             "phoneNumber": "",
-            "relationship": "",
           },
           "preferLanguage": "",
           "verifyInformation": false,

--- a/src/domain/registration/state/RegistrationReducers.tsx
+++ b/src/domain/registration/state/RegistrationReducers.tsx
@@ -12,6 +12,7 @@ export const defaultRegistrationData: RegistrationData = {
         homeCity: '',
         lastName: '',
         postalCode: '',
+        relationship: { type: undefined },
       },
     ],
     guardian: {
@@ -19,7 +20,6 @@ export const defaultRegistrationData: RegistrationData = {
       firstName: '',
       lastName: '',
       phoneNumber: '',
-      relationship: '',
     },
     preferLanguage: '',
     agree: false,

--- a/src/domain/registration/types/RegistrationTypes.ts
+++ b/src/domain/registration/types/RegistrationTypes.ts
@@ -6,7 +6,6 @@ export interface RegistrationFormValues {
     phoneNumber: string;
     firstName: string;
     lastName: string;
-    relationship: string;
     email: string;
   };
   preferLanguage: string;


### PR DESCRIPTION
This works for me both when registering and adding children. 

Another way to fix this is to open `src/domain/registration/form/partial/ChildFormField.tsx` and change line 92 from 
```name={`children[${childIndex}].relationship.type`}```
to
```name={`children[${childIndex}].relationship`}```

That is a smaller PR but I prefer this one that deletes lines instead. 