### PR TITLE
KK-174 | Ensure to toggle off nonEligible hook state when close modal

### DIFF
--- a/src/domain/child/modal/ChildFormModal.tsx
+++ b/src/domain/child/modal/ChildFormModal.tsx
@@ -55,7 +55,10 @@ const ChildFormModal: React.FunctionComponent<ChildFormModalProps> = ({
       <Modal
         isOpen={isOpen}
         label={nonEligible ? '' : label}
-        toggleModal={setIsOpen}
+        toggleModal={(value: boolean) => {
+          toggleNonEligible(false);
+          setIsOpen(value);
+        }}
         setFormIsFilling={setFormIsFilling}
       >
         {nonEligible ? (

--- a/src/domain/child/modal/__tests__/__snapshots__/ChildFormModal.test.tsx.snap
+++ b/src/domain/child/modal/__tests__/__snapshots__/ChildFormModal.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders snapshot correctly 1`] = `
     isOpen={false}
     label="foo"
     setFormIsFilling={[Function]}
-    toggleModal={[MockFunction]}
+    toggleModal={[Function]}
   >
     <Formik
       initialValues={


### PR DESCRIPTION
Make sure modal local state is reset anytime modal was toggled.

One does not simply: Unmounted element will not reset hook state automatically. Its state still persisted