### PR TITLE
KK-239 | Prevent horizontal scrolling/overflow on mobile

### DIFF
--- a/src/common/components/input/input.module.scss
+++ b/src/common/components/input/input.module.scss
@@ -30,6 +30,7 @@
       border-radius: 1px;
       border-color: $hel-gray;
       font-size: var(--hds-text-md);
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
This happened especially with homePreliminaryForm on Firefox.

Before:
![image](https://user-images.githubusercontent.com/5602596/73535449-3c59f680-442c-11ea-84d0-3a528dd4fba5.png)

After:
![image](https://user-images.githubusercontent.com/5602596/73535469-4aa81280-442c-11ea-866d-93f6e3a3978f.png)
