### PR TITLE
KK-214 | Use fully qualified url for og:image and twitter:image

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,13 +9,14 @@
     <meta property="og:title" content="Kulttuurin kummilapset" />
     <meta property="og:description" content="Kaikki vuodesta 2020 eteenpäin syntyvät helsinkiläiset lapset kutsutaan kulttuurin kummilapsiksi. Kummilapset saavat kutsun vuosittain kahteen tapahtumaan, kunnes lapsi aloittaa koulun. Tapahtumat ovat maksuttomia." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="%PUBLIC_URL%/images/kummilapsi-og-image.jpg" />
+    <meta property="og:image" content="https://kummilapset.hel.fi/images/kummilapsi-og-image.jpg" />
     <meta property="og:image:type" content="image/jpg" />
     <meta property="og:image:width" content="1400" />
     <meta property="og:image:height" content="1400" />
     <meta property="og:image:alt" content="Lapsi" />
+    <meta property="og:url" content="https://kummilapset.hel.fi/" />
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:image" content="%PUBLIC_URL%/images/kummilapsi-og-image.jpg" />
+    <meta property="twitter:image" content="https://kummilapset.hel.fi/images/kummilapsi-og-image.jpg" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link
       rel="apple-touch-icon"
@@ -31,15 +32,5 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>


### PR DESCRIPTION
Twitter and Facebook require a fully qualified url for these tags. Facebook still seems to work, but Twitter won't load the image.