### PR TITLE
Modal header should be centered horizontally

### DIFF
--- a/src/common/components/modal/modal.module.scss
+++ b/src/common/components/modal/modal.module.scss
@@ -83,6 +83,7 @@ $modalWidthLg: 800px;
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: center;
   margin: 0 0 $largeMargin 0;
   padding: 0 $modalPadding;
 


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/5602596/75792239-56159300-5d76-11ea-917a-544cc59e4ed4.png)

After: 

![image](https://user-images.githubusercontent.com/5602596/75792269-60379180-5d76-11ea-9e2a-ed0de9998518.png)
