### PR TITLE
KK-317 | Don't check city eligibility when editing a child

### DIFF
--- a/src/domain/child/modal/ChildFormModal.tsx
+++ b/src/domain/child/modal/ChildFormModal.tsx
@@ -120,7 +120,7 @@ const ChildFormModal: React.FunctionComponent<ChildFormModalProps> = ({
             ),
           });
 
-          const isEligible = isChildEligible(child);
+          const isEligible = isChildEligible(child, isEditForm);
           if (isEligible) {
             onSubmit(child);
           } else {

--- a/src/domain/registration/notEligible/NotEligibleUtils.ts
+++ b/src/domain/registration/notEligible/NotEligibleUtils.ts
@@ -38,10 +38,17 @@ const isCityEligible = (city: string) => {
 /**isChildEligible
  * Check is child is eligible for the Godchildren of Culture program
  * @param {child} child child info submitted from form
+ * @param {boolean} isEditing True if you are editing a child, then we don't check the city field content
  * @returns {boolean} if the child is eligible
  */
-const isChildEligible = (child: Pick<Child, 'birthdate' | 'homeCity'>) => {
-  return isBirthdateEligible(child.birthdate) && isCityEligible(child.homeCity);
+const isChildEligible = (
+  child: Pick<Child, 'birthdate' | 'homeCity'>,
+  isEditing = false
+) => {
+  return (
+    isBirthdateEligible(child.birthdate) &&
+    (isEditing || isCityEligible(child.homeCity))
+  );
 };
 
 export { getEligibleCities, isChildEligible };

--- a/src/domain/registration/notEligible/__tests__/NotEligibleUtils.test.ts
+++ b/src/domain/registration/notEligible/__tests__/NotEligibleUtils.test.ts
@@ -27,6 +27,10 @@ describe('notEligibleUtils.test.ts', () => {
     values.children[0].homeCity = 'Yokohama';
     expect(isChildEligible(values.children[0])).toEqual(false);
   });
+  test('A random city should be eligible when editing a child', () => {
+    values.children[0].homeCity = 'Yokohama';
+    expect(isChildEligible(values.children[0], true)).toEqual(true);
+  });
   test('Verify that all cities in REACT_APP_ELIGIBLE_CITIES are eligible', () => {
     const eligibleCities: string = process.env.REACT_APP_ELIGIBLE_CITIES || '';
     const cities = eligibleCities.split(',') || [];


### PR DESCRIPTION
This is a slight improvement over the current situation - we don't care what people type in the city field. We will store the postal code, though. 

Longer term solution involves either storing the city in the back end or looking the city up based on the postal code. 