### PR TITLE
Only send events from production build to sentry

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import * as serviceWorker from './serviceWorker';
 import './common/translation/i18n/i18nInit';
 Modal.setAppElement('#root');
 
-if (process.env.NODE_ENV !== 'development') {
+if (process.env.NODE_ENV === 'production') {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     environment: process.env.REACT_APP_ENVIRONMENT,


### PR DESCRIPTION
I was just reminded that process.env.NODE_ENV can is set to test when we run tests, and we absolutely do not want to send sentry events for errors in tests. 

NODE_ENV is either production, test or development, as mentioned here (so both our staging and production envs have NODE_ENV set to production)

> When you run npm start, it is always equal to 'development', when you run npm test it is always equal to 'test', and when you run npm run build to make a production bundle, it is always equal to 'production'. You cannot override NODE_ENV manually. This prevents developers from accidentally deploying a slow development build to production.

https://create-react-app.dev/docs/adding-custom-environment-variables/