### PR TITLE
KK-268 | Inform user better when login fails due to device time being off

### DIFF
--- a/src/common/components/error/Error.tsx
+++ b/src/common/components/error/Error.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import styles from './error.module.scss';
+import PageWrapper from '../../../domain/app/layout/PageWrapper';
+
+type ErrorProps = {
+  message: string;
+};
+
+const ErrorMessage = ({ message }: ErrorProps) => {
+  return (
+    <PageWrapper>
+      <div className={styles.error}>{message}</div>
+    </PageWrapper>
+  );
+};
+
+export default ErrorMessage;

--- a/src/common/components/error/error.module.scss
+++ b/src/common/components/error/error.module.scss
@@ -1,0 +1,10 @@
+@import 'styles/layout';
+@import 'styles/variables';
+
+.error {
+  margin: $baseMargin;
+  @include respond-above(sm) {
+    grid-column: 2;
+    margin: $baseMargin 0;
+  }
+}

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -7,6 +7,10 @@
   },
   "appName": "Culture Kids",
   "authentication": {
+    "deviceTimeError": {
+      "message": "Believe it or not, but we can’t allow you to log in because the clock on your device is off by more than five minutes. Please set the time and try again.",
+      "shortMessage": "Log in error. Check your device time and try again."
+    },
     "errorMessage": "An error occured while logging in. Please try again",
     "loadUserError": {
       "message": "An error occurred. Please try logging in again. "

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -8,8 +8,8 @@
   "appName": "Kulttuurin kummilapset",
   "authentication": {
     "deviceTimeError": {
-      "message": "Usko tai et usko mutta et voi kirjaudua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säätää kelloa ja kokeile uudestaan. ",
-      "shortMessage": "Log in error. Check your device time and try again."
+      "message": "Usko tai älä usko mutta et voi kirjautua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säädä kelloa ja kokeile uudestaan.",
+      "shortMessage": "Virhe kirjautuessa. Tarkista laitteesi kello ja kokeile uudestaan."
     },
     "errorMessage": "Tapahtui virhe. Yritä uudestaan",
     "loadUserError": {

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -7,6 +7,10 @@
   },
   "appName": "Kulttuurin kummilapset",
   "authentication": {
+    "deviceTimeError": {
+      "message": "Usko tai et usko mutta et voi kirjaudua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säätää kelloa ja kokeile uudestaan. ",
+      "shortMessage": "Log in error. Check your device time and try again."
+    },
     "errorMessage": "Tapahtui virhe. Yritä uudestaan",
     "loadUserError": {
       "message": "Tapahtui virhe. Yritä kirjautua uudelleen."

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -7,6 +7,10 @@
   },
   "appName": "Kulturens fadderbarn",
   "authentication": {
+    "deviceTimeError": {
+      "message": "Tro det eller inte, men vi kan inte låta dig logga in eftersom klockan på din enhet är avstängd mer än fem minuter. Ställ in tiden och försök igen.",
+      "shortMessage": "Log in error. Check your device time and try again."
+    },
     "errorMessage": "Ett fel uppstod. Försök igen",
     "loadUserError": {
       "message": "Ett fel uppstod. Försök att logga in igen."

--- a/src/domain/event/EventIsEnrolled.tsx
+++ b/src/domain/event/EventIsEnrolled.tsx
@@ -5,7 +5,6 @@ import * as Sentry from '@sentry/browser';
 import { useQuery } from '@apollo/react-hooks';
 
 import styles from './event.module.scss';
-import PageWrapper from '../app/layout/PageWrapper';
 import Button from '../../common/components/button/Button';
 import occurrenceQuery from './queries/occurrenceQuery';
 import { occurrenceQuery as OccurrenceQueryType } from '../api/generatedTypes/occurrenceQuery';
@@ -16,6 +15,7 @@ import VenueFeatures from './VenueFeatures';
 import Paragraph from '../../common/components/paragraph/Paragraph';
 import EventPage from './EventPage';
 import SuccessToast from './enrol/SuccessToast';
+import ErrorMessage from '../../common/components/error/Error';
 
 const EventIsEnrolled = () => {
   const { t } = useTranslation();
@@ -31,11 +31,7 @@ const EventIsEnrolled = () => {
     }
   );
 
-  const errorMessage = (
-    <PageWrapper>
-      <div className={styles.event}>{t('api.errorMessage')}</div>
-    </PageWrapper>
-  );
+  const errorMessage = <ErrorMessage message={t('api.errorMessage')} />;
 
   if (loading) return <LoadingSpinner isLoading={true} />;
   if (error) {

--- a/src/domain/event/enrol/Enrol.tsx
+++ b/src/domain/event/enrol/Enrol.tsx
@@ -22,6 +22,7 @@ import {
 import profileQuery from '../../profile/queries/ProfileQuery';
 import { childByIdQuery } from '../../child/queries/ChildQueries';
 import { saveChildEvents, justEnrolled } from '../state/EventActions';
+import ErrorMessage from '../../../common/components/error/Error';
 
 const Enrol: FunctionComponent = () => {
   const history = useHistory();
@@ -78,11 +79,7 @@ const Enrol: FunctionComponent = () => {
       type: toast.TYPE.ERROR,
     });
     Sentry.captureException(error);
-    return (
-      <PageWrapper>
-        <div className={styles.event}>{t('api.errorMessage')}</div>
-      </PageWrapper>
-    );
+    return <ErrorMessage message={t('api.errorMessage')} />;
   }
   if (!data?.occurrence?.id) return <div>no data</div>;
   const enrol = async () => {

--- a/src/domain/profile/Profile.tsx
+++ b/src/domain/profile/Profile.tsx
@@ -20,6 +20,7 @@ import Button from '../../common/components/button/Button';
 import EditProfileModal from './modal/EditProfileModal';
 import { clearEvent, saveChildrenEvents } from '../event/state/EventActions';
 import { defaultProfileData } from './state/ProfileReducers';
+import ErrorMessage from '../../common/components/error/Error';
 
 const Profile: FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -38,11 +39,7 @@ const Profile: FunctionComponent = () => {
     console.error(error);
     dispatch(clearProfile());
     Sentry.captureException(error);
-    return (
-      <PageWrapper>
-        <div className={styles.profile}>{t('api.errorMessage')}</div>
-      </PageWrapper>
-    );
+    return <ErrorMessage message={t('api.errorMessage')} />;
   }
 
   if (!data?.myProfile) {

--- a/src/domain/profile/children/child/ProfileChildDetail.tsx
+++ b/src/domain/profile/children/child/ProfileChildDetail.tsx
@@ -31,6 +31,7 @@ import profileQuery from '../../queries/ProfileQuery';
 import { childByIdQuery } from '../../../child/queries/ChildQueries';
 import LoadingSpinner from '../../../../common/components/spinner/LoadingSpinner';
 import { childByIdQuery as ChildByIdResponse } from '../../../api/generatedTypes/childByIdQuery';
+import ErrorMessage from '../../../../common/components/error/Error';
 export type ChildDetailEditModalPayload = Omit<EditChildInput, 'id'>;
 
 const ProfileChildDetail: React.FunctionComponent = () => {
@@ -62,11 +63,7 @@ const ProfileChildDetail: React.FunctionComponent = () => {
   if (error) {
     console.error(error);
     Sentry.captureException(error);
-    return (
-      <PageWrapper>
-        <div className={styles.profile}>{t('api.errorMessage')}</div>
-      </PageWrapper>
-    );
+    return <ErrorMessage message={t('api.errorMessage')} />;
   }
 
   const child = data?.child;


### PR DESCRIPTION
Bonus: Add a <ErrorMessage /> component for less code duplication.

How to test: 

1. Use a non-local Tunnistamo
2. Set your device time to be minimum 5 minutes early or late
3. Log in

The strings for the error messages is still TODO, but those translations will be updated later. 