### PR TITLE
KK-443, KK-261 | Automatically log in users, fix silent renew & login across tabs

### DIFF
--- a/src/domain/api/client.ts
+++ b/src/domain/api/client.ts
@@ -23,6 +23,7 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
       const errorMessage = `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`;
       Sentry.captureMessage(errorMessage);
       if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
         console.error(errorMessage);
       }
 

--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -11,7 +11,7 @@ import RegistrationForm from '../registration/form/RegistrationForm';
 import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
 import {
   isLoadingUserSelector,
-  apiTokenSelector,
+  mustRenewApiTokenSelector,
   userSelector,
 } from '../auth/state/AuthenticationSelectors';
 import Welcome from '../registration/welcome/Welcome';
@@ -33,18 +33,15 @@ const App = () => {
   const { locale } = useParams<{ locale: string }>();
   const userHasProfile = useSelector(userHasProfileSelector);
   const isSessionPromptOpen = useSelector(isSessionExpiredPromptOpen);
-  const apiToken = useSelector(apiTokenSelector);
+  const mustRenewApiToken = useSelector(mustRenewApiTokenSelector);
   const dispatch = useDispatch();
   const user = useSelector(userSelector);
 
   useEffect(() => {
-    if (apiToken) {
-      // Skip token fetch if token already existed
+    if (!mustRenewApiToken) {
       dispatch(tokenFetched());
-
-      // If no token but access token is ready for exchange
-      // start to fetch apiToken
-    } else if (user?.access_token) {
+      // Start fetching apiToken when logged in
+    } else if (user?.access_token && mustRenewApiToken) {
       dispatch(authenticateWithBackend(user.access_token));
     } else {
       // No access token, usually first time user
@@ -57,10 +54,7 @@ const App = () => {
         })
       );
     }
-    // TODO: useEffect subscribe for changes from apiToken and user data
-    // When silent-renew is fixed here in KK-261
-    // !apiToken can be removed so silent-renew will auto make api token exchange
-  }, [apiToken, dispatch, user]);
+  }, [mustRenewApiToken, dispatch, user]);
 
   return (
     <LoadingSpinner isLoading={isLoadingUser}>

--- a/src/domain/auth/authenticate.ts
+++ b/src/domain/auth/authenticate.ts
@@ -32,14 +32,20 @@ export const loginTunnistamo = (path?: string) => {
         });
         Sentry.captureException(error);
       }
+      // eslint-disable-next-line no-console
+      console.error(error);
     });
+  document.cookie = 'loggedOut; expires=Thu, 01 Jan 1970 00:00:00 GMT';
 };
 
 export const logoutTunnistamo = async () => {
   try {
+    document.cookie = 'loggedOut=1; max-age=10';
     await userManager.signoutRedirect();
-  } catch (e) {
-    Sentry.captureException(e);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    Sentry.captureException(error);
   }
 };
 
@@ -61,6 +67,8 @@ export const authenticateWithBackend = (
 
     dispatch(fetchTokenSuccess(res.data));
   } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
     dispatch(fetchTokenError(error));
     toast(i18n.t('authentication.errorMessage'), {
       type: toast.TYPE.ERROR,

--- a/src/domain/auth/getAuthenticatedUser.ts
+++ b/src/domain/auth/getAuthenticatedUser.ts
@@ -21,6 +21,8 @@ export default function (): Promise<User> {
         reject();
       }
     } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
       toast(i18n.t('api.errorMessage'), {
         type: toast.TYPE.ERROR,
       });

--- a/src/domain/auth/route/PrivateRoute.tsx
+++ b/src/domain/auth/route/PrivateRoute.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { isAuthenticatedSelector } from '../state/AuthenticationSelectors';
 import { StoreState } from '../../app/types/AppTypes';
+import { loginTunnistamo } from '../authenticate';
 
 interface AuthProps {
   isAuthenticated: boolean;
@@ -13,8 +14,19 @@ export type PrivateRouteProps = RouteProps & AuthProps;
 const PrivateRoute: FunctionComponent<PrivateRouteProps> = ({
   isAuthenticated,
   children,
+  location,
   ...rest
 }) => {
+  const justLoggedOutCookie = document.cookie
+    .split(';')
+    .some((item) => item.includes('loggedOut=1'));
+  if (!justLoggedOutCookie && !isAuthenticated) {
+    // If user opens an invitation link from an email, we want to log them in and
+    // redirect to the invitation.
+    loginTunnistamo(location?.pathname);
+  }
+
+  document.cookie = 'loggedOut=0';
   return (
     <Route
       {...rest}

--- a/src/domain/auth/state/AuthenticationSelectors.ts
+++ b/src/domain/auth/state/AuthenticationSelectors.ts
@@ -6,11 +6,21 @@ export const userAccessTokenSelector = (state: StoreState) =>
 export const apiTokenSelector = (state: StoreState) =>
   state.authentication.backend.apiToken;
 
+export const mustRenewApiTokenSelector = (state: StoreState) =>
+  state.authentication.backend.mustRenewToken;
+
 export const isLoadingUserSelector = (state: StoreState) =>
   state.authentication.tunnistamo.isLoadingUser ||
   state.authentication.backend.isFetchingToken;
 
+export const isLoggedInSelector = (state: StoreState) =>
+  !!state.authentication.tunnistamo.user?.access_token;
+
 export const isAuthenticatedSelector = (state: StoreState) =>
+  state.authentication.backend.hasProfile;
+
+export const isAuthenticatedWithApiTokenSelector = (state: StoreState) =>
+  state.authentication.tunnistamo.user?.access_token &&
   !!state.authentication.backend.apiToken;
 
 export const userSelector = (state: StoreState) =>

--- a/src/domain/auth/state/BackendAuthenticationReducer.ts
+++ b/src/domain/auth/state/BackendAuthenticationReducer.ts
@@ -1,4 +1,5 @@
 import { createReducer } from '@reduxjs/toolkit';
+import { USER_FOUND } from 'redux-oidc';
 
 import { API_AUTHENTICATION_ACTIONS } from '../constants/BackendAuthenticationActionConstants';
 import { BackendAuthenticationData } from '../types/BackendAuthenticationTypes';
@@ -9,22 +10,31 @@ export const defaultApiAuthenticationData: BackendAuthenticationData = {
   // When either token is fetched from redux store, token is fetched successfully, token is failed to fetch
   // Then the app route can render
   isFetchingToken: true,
+  mustRenewToken: true,
+  hasProfile: false,
   apiToken: null,
   errors: {},
 };
 
 export default createReducer(defaultApiAuthenticationData, {
+  // Renew backend API token after silent renew
+  [USER_FOUND]: (state, action) => {
+    state.mustRenewToken = true;
+  },
   [API_AUTHENTICATION_ACTIONS.START_FETCHING_TOKEN]: (state) =>
     Object.assign({}, state, { isFetchingToken: true }),
   [API_AUTHENTICATION_ACTIONS.FETCH_TOKEN_SUCCESS]: (state, action) =>
     Object.assign({}, state, {
       isFetchingToken: false,
+      mustRenewToken: false,
+      hasProfile: true,
       apiToken: Object.values(action.payload)[0],
     }),
   [API_AUTHENTICATION_ACTIONS.FETCH_TOKEN_ERROR]: (state, action) =>
     Object.assign({}, state, {
       isFetchingToken: false,
       apiToken: null,
+      hasProfile: false,
       errors: action.payload,
     }),
   [API_AUTHENTICATION_ACTIONS.RESET_BACKEND_AUTHENTICATION]: (state, action) =>

--- a/src/domain/auth/types/BackendAuthenticationTypes.ts
+++ b/src/domain/auth/types/BackendAuthenticationTypes.ts
@@ -1,6 +1,8 @@
 export type BackendAuthenticationData = {
   isFetchingToken: boolean;
   apiToken: string | null;
+  hasProfile: boolean;
+  mustRenewToken: boolean;
   errors: object;
 };
 

--- a/src/domain/auth/userManager.ts
+++ b/src/domain/auth/userManager.ts
@@ -1,13 +1,19 @@
 import { createUserManager } from 'redux-oidc';
-import { UserManagerSettings } from 'oidc-client';
+import { UserManagerSettings, Log, WebStorageStateStore } from 'oidc-client';
 
 const location = `${window.location.protocol}//${window.location.hostname}${
   window.location.port ? `:${window.location.port}` : ''
 }`;
 
+if (process.env.NODE_ENV === 'development') {
+  Log.logger = console;
+  Log.level = Log.INFO;
+}
+
 /* eslint-disable @typescript-eslint/camelcase */
 const settings: UserManagerSettings = {
   loadUserInfo: true,
+  userStore: new WebStorageStateStore({ store: window.localStorage }),
   // This calculates to 1 minute, good for debugging:
   // accessTokenExpiringNotificationTime: 59.65 * 60,
   authority: process.env.REACT_APP_OIDC_AUTHORITY,

--- a/src/domain/event/Event.tsx
+++ b/src/domain/event/Event.tsx
@@ -98,6 +98,7 @@ const Event = () => {
 
   if (loading) return <LoadingSpinner isLoading={true} />;
   if (error) {
+    // eslint-disable-next-line no-console
     console.error(error);
     Sentry.captureException(error);
     return (

--- a/src/domain/event/enrol/Enrol.tsx
+++ b/src/domain/event/enrol/Enrol.tsx
@@ -74,6 +74,7 @@ const Enrol: FunctionComponent = () => {
 
   if (loading) return <LoadingSpinner isLoading={true} />;
   if (error) {
+    // eslint-disable-next-line no-console
     console.error(error);
     toast(t('api.errorMessage'), {
       type: toast.TYPE.ERROR,
@@ -98,7 +99,7 @@ const Enrol: FunctionComponent = () => {
         `/profile/child/${params.childId}/occurrence/${data.occurrence.id}`
       );
     } catch (error) {
-      // TODO: KK-280 Handle errors nicely
+      // eslint-disable-next-line no-console
       console.error(error);
       toast(t('registration.submitMutation.errorMessage'), {
         type: toast.TYPE.ERROR,

--- a/src/domain/event/modal/UnenrolModal.tsx
+++ b/src/domain/event/modal/UnenrolModal.tsx
@@ -71,6 +71,7 @@ const UnenrolModal = ({
         },
       });
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error(error);
       // TODO: KK-280 Handle errors nicely
       toast(t('registration.submitMutation.errorMessage'), {

--- a/src/domain/profile/Profile.tsx
+++ b/src/domain/profile/Profile.tsx
@@ -36,6 +36,7 @@ const Profile: FunctionComponent = () => {
 
   if (loading) return <LoadingSpinner isLoading={true} />;
   if (error) {
+    // eslint-disable-next-line no-console
     console.error(error);
     dispatch(clearProfile());
     Sentry.captureException(error);

--- a/src/domain/profile/children/child/ProfileChildDetail.tsx
+++ b/src/domain/profile/children/child/ProfileChildDetail.tsx
@@ -61,6 +61,7 @@ const ProfileChildDetail: React.FunctionComponent = () => {
   }
 
   if (error) {
+    // eslint-disable-next-line no-console
     console.error(error);
     Sentry.captureException(error);
     return <ErrorMessage message={t('api.errorMessage')} />;

--- a/src/domain/registration/notEligible/NotEligibleUtils.ts
+++ b/src/domain/registration/notEligible/NotEligibleUtils.ts
@@ -3,13 +3,13 @@ import { SUPPORTED_START_BIRTHDATE } from '../../../common/time/TimeConstants';
 import { Child } from '../../child/types/ChildTypes';
 
 /** isBirthdateEligible()
- * Check if child is eligible for participation.
+ * Check if child's birthdate is eligible for participation.
  *
  * Only children born in 2020 or later are eligible for this service.
  * @param {string} birthdate in YYYY-MM-DD format.
  * @returns {boolean}
  */
-const isBirthdateEligible = (value: string) => {
+const isBirthdateEligible = (value: string): boolean => {
   const inputMoment = newMoment(value, 'YYYY-MM-DD');
   const supportedStart = newMoment(SUPPORTED_START_BIRTHDATE);
 
@@ -25,7 +25,7 @@ const isBirthdateEligible = (value: string) => {
  * Get an array of supported cities from .env
  * @returns {Array} Supported cities
  */
-const getEligibleCities = () => {
+const getEligibleCities = (): Array<string> => {
   const eligibleCities = process.env.REACT_APP_ELIGIBLE_CITIES || 'helsinki';
   return eligibleCities.toLowerCase().split(',');
 };
@@ -36,7 +36,7 @@ const isCityEligible = (city: string) => {
 };
 
 /**isChildEligible
- * Check is child is eligible for the Godchildren of Culture program
+ * Check if child is eligible for the Culture kids programme
  * @param {child} child child info submitted from form
  * @param {boolean} isEditing True if you are editing a child, then we don't check the city field content
  * @returns {boolean} if the child is eligible
@@ -44,7 +44,7 @@ const isCityEligible = (city: string) => {
 const isChildEligible = (
   child: Pick<Child, 'birthdate' | 'homeCity'>,
   isEditing = false
-) => {
+): boolean => {
   const validators = [
     { validator: isBirthdateEligible, item: child.birthdate },
   ];


### PR DESCRIPTION
* Refactor how we fetch backend api token now that we have silent renew
* If a user comes from a link to a "deep" page in their profile, automatically log them in and redirect to it
* Console.error for all errors. NOTE: `yarn build` strips console statements out so no need to worry about end users
* Fix spelling error in code comment & add some typing
