### PR TITLE
Improve accessibility by adding alt texts for icons

### DIFF
--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -188,6 +188,7 @@
       "form": {
         "header": "Register"
       },
+      "participants": "Participants",
       "occurrenceTableHeader": {
         "buttonText": "Choose",
         "date": "Date",
@@ -362,6 +363,7 @@
         "edit": {
           "text": "Update child information"
         },
+        "guardiansName": "Guardian's name",
         "page": {
           "title": "Child detail page"
         },
@@ -461,7 +463,7 @@
         },
         "firstName": {
           "input": {
-            "label": "Guardian’s first name",
+            "label": "First name",
             "placeholder": "Please enter guardian’s first name"
           }
         },
@@ -476,7 +478,7 @@
         },
         "lastName": {
           "input": {
-            "label": "Guardian’s last name",
+            "label": "Last name",
             "placeholder": "Please enter guardian’s last name"
           }
         },

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -188,6 +188,7 @@
       "form": {
         "header": "Ilmoittaudu"
       },
+      "participants": "Osallistujat",
       "occurrenceTableHeader": {
         "buttonText": "Valitse",
         "date": "Päivämäärä",
@@ -362,6 +363,7 @@
         "edit": {
           "text": "Päivitä kummilapsen tiedot"
         },
+        "guardiansName": "Lähiaikuisen nimi",
         "page": {
           "title": "Kummilapsen tiedot"
         },

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -188,6 +188,7 @@
       "form": {
         "header": "Anmäl dig"
       },
+      "participants": "Deltagare",
       "occurrenceTableHeader": {
         "buttonText": "Välj",
         "date": "Datum",
@@ -362,6 +363,7 @@
         "edit": {
           "text": "Uppdatera barnets uppgifter"
         },
+        "guardiansName": "Närstående vuxens namn",
         "page": {
           "title": "Barnets uppgifter"
         },

--- a/src/domain/event/EventEnrol.tsx
+++ b/src/domain/event/EventEnrol.tsx
@@ -43,7 +43,11 @@ const EventEnrol = ({
       <div className={styles.register}>
         <h2>{t('event.register.form.header')}</h2>
         <div className={styles.attendees}>
-          <Icon src={personIcon} className={styles.icon} />
+          <Icon
+            src={personIcon}
+            alt={t('event.register.participants')}
+            className={styles.icon}
+          />
           {participantsPerInvite}
         </div>
         <div className={styles.signup}>

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -16,7 +16,6 @@ const EventOccurrence: React.FunctionComponent<EventOccurrenceProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  // TODO: Ensure that date shows in correct locale.
   const date = formatTime(newMoment(occurrence.time), 'dd l');
   const time = formatTime(newMoment(occurrence.time), 'hh:mm');
 

--- a/src/domain/event/partial/OccurrenceInfo.tsx
+++ b/src/domain/event/partial/OccurrenceInfo.tsx
@@ -39,16 +39,19 @@ const OccurrenceInfo: FunctionComponent<Props> = ({
     {
       id: 'time',
       iconSrc: calendarIcon,
+      iconAlt: t('event.register.occurrenceTableHeader.date'),
       label: formatTime(newMoment(occurrence.time), DEFAULT_DATE_FORMAT),
     },
     {
       id: 'duration',
       iconSrc: clockIcon,
+      iconAlt: t('event.register.occurrenceTableHeader.time'),
       label: formatOccurrenceTime(occurrence.time, occurrence.event.duration),
     },
     {
       id: 'participants',
       iconSrc: personIcon,
+      iconAlt: t('event.register.participants'),
       label: t(
         `event.participantsPerInviteEnum.${occurrence.event.participantsPerInvite}`
       ),
@@ -56,6 +59,7 @@ const OccurrenceInfo: FunctionComponent<Props> = ({
     {
       id: 'venue',
       iconSrc: locationIcon,
+      iconAlt: t('event.register.occurrenceTableHeader.venue'),
       label: occurrence.venue.name || '',
     },
   ];

--- a/src/domain/event/partial/__tests__/__snapshots__/OccurrenceInfo.test.tsx.snap
+++ b/src/domain/event/partial/__tests__/__snapshots__/OccurrenceInfo.test.tsx.snap
@@ -6,24 +6,28 @@ exports[`renders childByIdQuery occurrence snapshot correctly 1`] = `
 >
   <InfoItem
     className="label"
+    iconAlt="Päivämäärä"
     iconSrc="calendar.svg"
     key="0"
     label="08.03.2020"
   />
   <InfoItem
     className="label"
+    iconAlt="Kellonaika"
     iconSrc="clock.svg"
     key="1"
     label="06.00 - 06.12"
   />
   <InfoItem
     className="label"
+    iconAlt="Osallistujat"
     iconSrc="person.svg"
     key="2"
     label="Perhe"
   />
   <InfoItem
     className="label"
+    iconAlt="Tapahtumapaikka"
     iconSrc="location.svg"
     key="3"
     label="Musiikkitalo"
@@ -37,24 +41,28 @@ exports[`renders occurrence snapshot correctly 1`] = `
 >
   <InfoItem
     className="label"
+    iconAlt="Päivämäärä"
     iconSrc="calendar.svg"
     key="0"
     label="08.03.2020"
   />
   <InfoItem
     className="label"
+    iconAlt="Kellonaika"
     iconSrc="clock.svg"
     key="1"
     label="06.00 - 06.12"
   />
   <InfoItem
     className="label"
+    iconAlt="Osallistujat"
     iconSrc="person.svg"
     key="2"
     label="Perhe"
   />
   <InfoItem
     className="label"
+    iconAlt="Tapahtumapaikka"
     iconSrc="location.svg"
     key="3"
     label="Musiikkitalo"

--- a/src/domain/profile/Profile.tsx
+++ b/src/domain/profile/Profile.tsx
@@ -75,7 +75,10 @@ const Profile: FunctionComponent = () => {
             )}
             <div className={styles.guardianInfo}>
               <div className={styles.guardianInfoRow}>
-                <Icon src={emailIcon} />
+                <Icon
+                  src={emailIcon}
+                  alt={t('registration.form.guardian.email.input.label')}
+                />
                 <span>{data.myProfile.email}</span>
               </div>
               <div className={styles.guardianInfoRow}>

--- a/src/domain/profile/children/child/ProfileChildDetail.tsx
+++ b/src/domain/profile/children/child/ProfileChildDetail.tsx
@@ -168,7 +168,10 @@ const ProfileChildDetail: FunctionComponent = () => {
                 </span>
               </div>
               <div className={styles.childInfoRow}>
-                <Icon src={personIcon} />
+                <Icon
+                  src={personIcon}
+                  alt={t('profile.child.detail.guardiansName')}
+                />
                 <span>{`${guardian.firstName} ${guardian.lastName}`}</span>
               </div>
 

--- a/src/domain/profile/events/__tests__/__snapshots__/ProfileEventsList.test.tsx.snap
+++ b/src/domain/profile/events/__tests__/__snapshots__/ProfileEventsList.test.tsx.snap
@@ -38,16 +38,19 @@ exports[`Renders snapshot correctly 1`] = `
         >
           <InfoItem
             className="label"
+            iconAlt="Päivämäärä"
             iconSrc="calendar.svg"
             label="24.02.2020"
           />
           <InfoItem
             className="label"
+            iconAlt="Kellonaika"
             iconSrc="clock.svg"
             label="09.07 - 10.07"
           />
           <InfoItem
             className="label"
+            iconAlt="Tapahtumapaikka"
             iconSrc="location.svg"
             label="aa"
           />


### PR DESCRIPTION
On the user profile page, child detail page, event sign up and confirmation pages we use icons to convey information, and they have been missing alt text to help users with screen readers.