### PR TITLE
KK-527 | Use Finnish time format

### DIFF
--- a/src/common/localization/setLocale.tsx
+++ b/src/common/localization/setLocale.tsx
@@ -1,0 +1,11 @@
+import moment from 'moment';
+import 'moment/locale/fi';
+import 'moment/locale/sv';
+
+export type Locale = 'fi' | 'sv' | 'en';
+
+function setLocale(locale: Locale) {
+  moment.locale(locale);
+}
+
+export default setLocale;

--- a/src/common/translation/i18n/i18nInit.ts
+++ b/src/common/translation/i18n/i18nInit.ts
@@ -2,46 +2,64 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
+import setLocale, { Locale } from '../../localization/setLocale';
 import en from './en.json';
 import fi from './fi.json';
 import sv from './sv.json';
 import { SUPPORT_LANGUAGES } from '../TranslationConstants';
 
-i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
-    detection: {
-      order: [
-        'path',
-        'querystring',
-        'cookie',
-        'localStorage',
-        'navigator',
-        'htmlTag',
-        'subdomain',
+// The language of the application is controlled by LanguageDetector.
+// When the language is changed, the application is reloaded. This
+// causes i18next to also be re-initialized, which means that
+// LanguageDetector is used to detect current language. One criteria is
+// the locale specified in the url.
+
+// This means that this file is the best place to keep the language and
+// locale of the application in sync. We first initialize i18next, and
+// then use the language it determines to be the most appropriate to
+// use to set the locale.
+function initI18next() {
+  i18n
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+      detection: {
+        order: [
+          'path',
+          'querystring',
+          'cookie',
+          'localStorage',
+          'navigator',
+          'htmlTag',
+          'subdomain',
+        ],
+      },
+      fallbackLng: 'fi',
+      interpolation: {
+        escapeValue: false,
+      },
+      whitelist: [
+        SUPPORT_LANGUAGES.EN,
+        SUPPORT_LANGUAGES.FI,
+        SUPPORT_LANGUAGES.SV,
       ],
-    },
-    fallbackLng: 'fi',
-    interpolation: {
-      escapeValue: false,
-    },
-    whitelist: [
-      SUPPORT_LANGUAGES.EN,
-      SUPPORT_LANGUAGES.FI,
-      SUPPORT_LANGUAGES.SV,
-    ],
-    resources: {
-      en: {
-        translation: en,
+      resources: {
+        en: {
+          translation: en,
+        },
+        fi: {
+          translation: fi,
+        },
+        sv: {
+          translation: sv,
+        },
       },
-      fi: {
-        translation: fi,
-      },
-      sv: {
-        translation: sv,
-      },
-    },
-  });
+    });
+  const language = i18n.language as Locale;
+
+  setLocale(language);
+}
+
+initI18next();
 
 export default i18n;

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -16,7 +16,7 @@ const EventOccurrence: React.FunctionComponent<EventOccurrenceProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const date = formatTime(newMoment(occurrence.time), 'dd l');
+  const date = formatTime(newMoment(occurrence.time), 'dd D.M.YYYY');
   const time = formatTime(newMoment(occurrence.time), 'hh:mm');
 
   const hasCapacity =

--- a/src/domain/event/__tests__/EventOccurrence.test.tsx
+++ b/src/domain/event/__tests__/EventOccurrence.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import moment from 'moment';
 
 import { eventQuery_event_occurrences_edges_node as OccurrenceEdgeNode } from '../../api/generatedTypes/eventQuery';
 import EventOccurrence from '../EventOccurrence';

--- a/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`renders snapshot correctly 1`] = `
   <td
     className="occurrenceDate"
   >
-    Su 3/8/2020
+    su 8.3.2020
   </td>
   <td
     className="occurrenceTime"

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,6 +2,8 @@ import Adapter from 'enzyme-adapter-react-16';
 import { configure } from 'enzyme';
 import { GlobalWithFetchMock } from 'jest-fetch-mock';
 import React from 'react';
+
+import setLocale from './common/localization/setLocale';
 import './common/test/testi18nInit';
 React.useLayoutEffect = React.useEffect;
 
@@ -23,3 +25,5 @@ jest.mock('react-router-dom', () => ({
     match: jest.fn(),
   }),
 }));
+
+setLocale('fi');


### PR DESCRIPTION
Moment uses the `en` locale by default. I changed the bootstrap code so that moment's locale and the language of the application are kept in sync.

As a small encapsulation measure I added a `setLocale` utility function which can possibly be used to configure other localisation dependent libraries (like numbers).

The file structure is maybe a bit odd here. I don't have a good intuitive feel for how internationalisation and localisation differ so I don't know which is the correct terminology here. But I did think that it didn't belong under `translations`.