### PR TITLE
KK-529 | Allow also LF as a line break

### DIFF
--- a/src/common/__tests__/__snapshots__/commonUtils.tests.tsx.snap
+++ b/src/common/__tests__/__snapshots__/commonUtils.tests.tsx.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`converts newlines to brs 1`] = `
+exports[`converts CRLFs to brs 1`] = `
+Array [
+  <p>
+    a
+  </p>,
+  <p>
+    b
+  </p>,
+]
+`;
+
+exports[`converts LFs to brs 1`] = `
 Array [
   <p>
     a

--- a/src/common/__tests__/commonUtils.tests.tsx
+++ b/src/common/__tests__/commonUtils.tests.tsx
@@ -1,6 +1,11 @@
 import { nlToParagraph } from '../commonUtils';
 
-it('converts newlines to brs', () => {
-  const string = 'a\n\rb';
+it('converts CRLFs to brs', () => {
+  const string = 'a\r\nb';
+  expect(nlToParagraph(string)).toMatchSnapshot();
+});
+
+it('converts LFs to brs', () => {
+  const string = 'a\nb';
   expect(nlToParagraph(string)).toMatchSnapshot();
 });

--- a/src/common/commonUtils.tsx
+++ b/src/common/commonUtils.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export const nlToParagraph = (text: string) => {
-  return (text || '').split('\n\r').map((item, i) => <p key={i}>{item}</p>);
+  return (text || '').split(/\r?\n/g).map((item, i) => <p key={i}>{item}</p>);
 };


### PR DESCRIPTION
Previously only CRLF was treated as a line break causing problems with content coming from Kukkuu admin.