### PR TITLE
KK-541 | Event occurrence time is shown incorrectly

### DIFF
--- a/src/common/time/TimeConstants.ts
+++ b/src/common/time/TimeConstants.ts
@@ -8,4 +8,4 @@ export const DEFAULT_DATE_FORMAT = 'D.M.YYYY';
 export const BACKEND_DATE_FORMAT = 'YYYY-MM-DD';
 
 // HH.MM
-export const DEFAULT_TIME_FORMAT = 'HH.mm';
+export const DEFAULT_TIME_FORMAT = 'HH:mm';

--- a/src/common/time/TimeConstants.ts
+++ b/src/common/time/TimeConstants.ts
@@ -2,7 +2,7 @@
 export const SUPPORTED_START_BIRTHDATE = '2020-01-01';
 
 // Finnish display time format
-export const DEFAULT_DATE_FORMAT = 'DD.MM.YYYY';
+export const DEFAULT_DATE_FORMAT = 'D.M.YYYY';
 
 // Backend allowed time format
 export const BACKEND_DATE_FORMAT = 'YYYY-MM-DD';

--- a/src/domain/event/Event.tsx
+++ b/src/domain/event/Event.tsx
@@ -15,7 +15,11 @@ import {
 import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
 import { formatOccurrenceTime } from './EventUtils';
 import { formatTime, newMoment } from '../../common/time/utils';
-import { DEFAULT_DATE_FORMAT } from '../../common/time/TimeConstants';
+import {
+  BACKEND_DATE_FORMAT,
+  DEFAULT_DATE_FORMAT,
+  DEFAULT_TIME_FORMAT,
+} from '../../common/time/TimeConstants';
 import EventEnrol from './EventEnrol';
 import EventPage from './EventPage';
 import Paragraph from '../../common/components/paragraph/Paragraph';
@@ -124,7 +128,10 @@ const Event = () => {
     .map((occurrence) => {
       return occurrence?.node?.id && occurrence.node.time
         ? {
-            value: formatTime(newMoment(occurrence.node.time), 'YYYY-MM-DD'),
+            value: formatTime(
+              newMoment(occurrence.node.time),
+              BACKEND_DATE_FORMAT
+            ),
             label: formatTime(
               newMoment(occurrence.node.time),
               DEFAULT_DATE_FORMAT
@@ -139,7 +146,10 @@ const Event = () => {
     .map((occurrence) => {
       return occurrence?.node?.id && occurrence.node.time
         ? {
-            value: formatTime(newMoment(occurrence.node.time), 'HH:mm'),
+            value: formatTime(
+              newMoment(occurrence.node.time),
+              DEFAULT_TIME_FORMAT
+            ),
             label: formatOccurrenceTime(
               occurrence.node.time,
               data.event?.duration || null

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -22,7 +22,7 @@ const EventOccurrence: React.FunctionComponent<EventOccurrenceProps> = ({
 
   const date = formatTime(
     newMoment(occurrence.time),
-    `dd ${DEFAULT_DATE_FORMAT}`
+    `ddd ${DEFAULT_DATE_FORMAT}`
   );
   const time = formatTime(newMoment(occurrence.time), DEFAULT_TIME_FORMAT);
 

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -6,6 +6,10 @@ import { eventQuery_event_occurrences_edges_node as OccurrencesEdgeNode } from '
 import { formatTime, newMoment } from '../../common/time/utils';
 import styles from './eventOccurrence.module.scss';
 import Button from '../../common/components/button/Button';
+import {
+  DEFAULT_TIME_FORMAT,
+  DEFAULT_DATE_FORMAT,
+} from '../../common/time/TimeConstants';
 
 interface EventOccurrenceProps {
   occurrence: OccurrencesEdgeNode;
@@ -16,8 +20,11 @@ const EventOccurrence: React.FunctionComponent<EventOccurrenceProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const date = formatTime(newMoment(occurrence.time), 'dd D.M.YYYY');
-  const time = formatTime(newMoment(occurrence.time), 'hh:mm');
+  const date = formatTime(
+    newMoment(occurrence.time),
+    `dd ${DEFAULT_DATE_FORMAT}`
+  );
+  const time = formatTime(newMoment(occurrence.time), DEFAULT_TIME_FORMAT);
 
   const hasCapacity =
     occurrence.remainingCapacity && occurrence.remainingCapacity > 0;

--- a/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`renders snapshot correctly 1`] = `
   <td
     className="occurrenceTime"
   >
-    06:00
+    06.00
   </td>
   <td
     className="occurrenceVenue"

--- a/src/domain/event/partial/__tests__/__snapshots__/OccurrenceInfo.test.tsx.snap
+++ b/src/domain/event/partial/__tests__/__snapshots__/OccurrenceInfo.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders childByIdQuery occurrence snapshot correctly 1`] = `
     iconAlt="Päivämäärä"
     iconSrc="calendar.svg"
     key="0"
-    label="08.03.2020"
+    label="8.3.2020"
   />
   <InfoItem
     className="label"
@@ -44,7 +44,7 @@ exports[`renders occurrence snapshot correctly 1`] = `
     iconAlt="Päivämäärä"
     iconSrc="calendar.svg"
     key="0"
-    label="08.03.2020"
+    label="8.3.2020"
   />
   <InfoItem
     className="label"

--- a/src/domain/profile/events/__tests__/__snapshots__/ProfileEventsList.test.tsx.snap
+++ b/src/domain/profile/events/__tests__/__snapshots__/ProfileEventsList.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Renders snapshot correctly 1`] = `
             className="label"
             iconAlt="Päivämäärä"
             iconSrc="calendar.svg"
-            label="24.02.2020"
+            label="24.2.2020"
           />
           <InfoItem
             className="label"


### PR DESCRIPTION
- Wen't through every format executed with moment and replaced strings with constants.
- Changed `DEFAULT_DATE_FORMAT ` not show leading zeroes.