### PR TITLE
KK-540 | Redirect to error view when accessing unknown child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# Unreleased
+
+### Added
+
+- When users access a child's information that is not attached to their account, they are redirected into a view that asks them to authenticate again
+
 # 1.2.1
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.4",
     "hds-core": "^0.12.1",
+    "hds-design-tokens": "^0.13.0",
     "hds-react": "^0.12.1",
     "helsinki-utils": "City-of-Helsinki/helsinki-utils-js.git#0.1.0",
     "i18next": "^19.7.0",

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -1,3 +1,5 @@
+@import '~hds-design-tokens/lib/all.scss';
+
 $headerHeight: 4rem;
 $footerHeight: 10rem;
 

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -575,5 +575,11 @@
         "heading": "WCs and child care facilities"
       }
     }
+  },
+  "auth": {
+    "wrongLoginMethod": {
+      "title": "Oops!",
+      "description": "It seems like you have registered to the service using another login method. Please log out of the service and try a different login method."
+    }
   }
 }

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -575,5 +575,11 @@
         "heading": "WC-tilat ja lastenhoitohuone"
       }
     }
+  },
+  "auth": {
+    "wrongLoginMethod": {
+      "title": "Hupsista!",
+      "description": "Vaikuttaisi siltä, että olet käyttänyt eri tunnistautumistapaa rekisteröityessäsi palveluun. Kirjaudu ulos palvelusta ja koita sitten kirjautua uudestaan käyttäen jollain toista tunnistautumistapaa."
+    }
   }
 }

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -579,7 +579,7 @@
   "auth": {
     "wrongLoginMethod": {
       "title": "Hupsista!",
-      "description": "Vaikuttaisi siltä, että olet käyttänyt eri tunnistautumistapaa rekisteröityessäsi palveluun. Kirjaudu ulos palvelusta ja koita sitten kirjautua uudestaan käyttäen jollain toista tunnistautumistapaa."
+      "description": "Vaikuttaisi siltä, että olet käyttänyt eri tunnistautumistapaa rekisteröityessäsi palveluun. Kirjaudu ulos palvelusta ja koita sitten kirjautua uudestaan käyttäen jotain toista tunnistautumistapaa."
     }
   }
 }

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -575,5 +575,11 @@
         "heading": "Toaletter och skötrum för barn"
       }
     }
+  },
+  "auth": {
+    "wrongLoginMethod": {
+      "title": "Hoppsan!",
+      "description": "Det verkar som om du har använt en annan autentiseringsmetod när du registrerar dig för tjänsten. Logga ut från tjänsten och försök sedan logga in igen med en annan autentiseringsmetod."
+    }
   }
 }

--- a/src/domain/api/generatedTypes/profileChildrenQuery.ts
+++ b/src/domain/api/generatedTypes/profileChildrenQuery.ts
@@ -1,0 +1,41 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: profileChildrenQuery
+// ====================================================
+
+export interface profileChildrenQuery_myProfile_children_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+}
+
+export interface profileChildrenQuery_myProfile_children_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: profileChildrenQuery_myProfile_children_edges_node | null;
+}
+
+export interface profileChildrenQuery_myProfile_children {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (profileChildrenQuery_myProfile_children_edges | null)[];
+}
+
+export interface profileChildrenQuery_myProfile {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  children: profileChildrenQuery_myProfile_children;
+}
+
+export interface profileChildrenQuery {
+  myProfile: profileChildrenQuery_myProfile | null;
+}

--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -7,6 +7,7 @@ import Home from '../home/Home';
 import NotFound from './notFound/NotFound';
 import NotEligible from '../registration/notEligible/NotEligible';
 import PrivateRoute from '../auth/route/PrivateRoute';
+import WrongLoginMethod from '../auth/WrongLoginMethod';
 import RegistrationForm from '../registration/form/RegistrationForm';
 import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
 import {
@@ -66,6 +67,11 @@ const App = () => {
           exact
           path={`/${locale}/registration/not-eligible`}
           component={NotEligible}
+        />
+        <Route
+          exact
+          path={`/${locale}/wrong-login-method`}
+          component={WrongLoginMethod}
         />
         <Route
           exact

--- a/src/domain/app/header/userDropdown/UserDropdown.tsx
+++ b/src/domain/app/header/userDropdown/UserDropdown.tsx
@@ -10,9 +10,9 @@ import Dropdown from '../../../../common/components/dropdown/Dropdown';
 import { profileQuery as ProfileQueryType } from '../../../api/generatedTypes/profileQuery';
 import personIcon from '../../../../assets/icons/svg/person.svg';
 import { isAuthenticatedSelector } from '../../../auth/state/AuthenticationSelectors';
-import { loginTunnistamo, logoutTunnistamo } from '../../../auth/authenticate';
+import { loginTunnistamo } from '../../../auth/authenticate';
+import useLogout from '../../../auth/useLogout';
 import UserMenu from '../userMenu/UserMenu';
-import { flushAllState } from '../../../auth/state/AuthenticationUtils';
 import profileQuery from '../../../profile/queries/ProfileQuery';
 import { saveProfile } from '../../../profile/state/ProfileActions';
 import {
@@ -32,6 +32,7 @@ const UserDropdown: FunctionComponent<UserDropdownProps> = ({
   const history = useHistory();
   const isAuthenticated = useSelector(isAuthenticatedSelector);
   const dispatch = useDispatch();
+  const doLogout = useLogout();
 
   const { loading, error, data } = useQuery<ProfileQueryType>(profileQuery, {
     skip: !isAuthenticated,
@@ -55,13 +56,7 @@ const UserDropdown: FunctionComponent<UserDropdownProps> = ({
     label: t('authentication.logout.text'),
     id: 'logoutButton',
     onClick: () => {
-      trackEvent({ category: 'action', action: 'Log out' });
-
-      // Flush all cached state
-      flushAllState({});
-
-      // Log out
-      logoutTunnistamo();
+      doLogout();
     },
   };
 

--- a/src/domain/app/layout/InfoPageLayout.tsx
+++ b/src/domain/app/layout/InfoPageLayout.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import adultFaceIcon from '../../../assets/icons/svg/adultFace.svg';
+import Icon from '../../../common/components/icon/Icon';
+import PageWrapper from '../../app/layout/PageWrapper';
+import Button from '../../../common/components/button/Button';
+import styles from './infoPageLayout.module.scss';
+
+type Props = {
+  title: string;
+  description: string;
+  icon?: string;
+  callToAction?: {
+    label: string;
+    onClick: () => void;
+  };
+};
+
+const InfoPageLayout = ({
+  title,
+  description,
+  callToAction,
+  icon = adultFaceIcon,
+}: Props) => {
+  return (
+    <PageWrapper title={title}>
+      <div className={styles.infoPageLayout}>
+        <h1 className={styles.infoPageLayoutTitle}>{title}</h1>
+        <Icon className={styles.infoPageLayoutFace} src={icon} />
+        <p className={styles.infoPageLayoutDescription}>{description}</p>
+        {callToAction && (
+          <Button
+            className={styles.callToActionButton}
+            onClick={callToAction.onClick}
+          >
+            {callToAction.label}
+          </Button>
+        )}
+      </div>
+    </PageWrapper>
+  );
+};
+
+export default InfoPageLayout;

--- a/src/domain/app/layout/infoPageLayout.module.scss
+++ b/src/domain/app/layout/infoPageLayout.module.scss
@@ -1,0 +1,39 @@
+@import 'styles/layout';
+@import 'styles/variables';
+
+.infoPageLayout {
+  @include respond-below(md) {
+    margin: 0 $baseMargin $largeMargin $baseMargin;
+  }
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  color: $color-black-90;
+
+  .infoPageLayoutFace {
+    height: $spacing-5-xl;
+    width: $spacing-5-xl;
+    margin: $spacing-l 0;
+  }
+
+  .infoPageLayoutTitle {
+    font-size: $fontsize-heading-xl;
+  }
+
+  .infoPageLayoutDescription {
+    max-width: $container-width-m;
+    margin-top: 0;
+
+    font-size: $fontsize-body-l;
+    text-align: center;
+  }
+}
+
+.callToActionButton {
+  margin: 2 * $baseMargin;
+  width: 100%;
+  max-width: $container-width-s;
+}

--- a/src/domain/auth/WrongLoginMethod.tsx
+++ b/src/domain/auth/WrongLoginMethod.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import useLogout from './useLogout';
+import InfoPageLayout from '../app/layout/InfoPageLayout';
+
+const WrongLoginMethod = () => {
+  const { t } = useTranslation();
+  const logout = useLogout();
+
+  const handleCallToActionClick = () => {
+    logout();
+  };
+
+  return (
+    <InfoPageLayout
+      title={t('auth.wrongLoginMethod.title')}
+      description={t('auth.wrongLoginMethod.description')}
+      callToAction={{
+        label: t('authentication.logout.text'),
+        onClick: handleCallToActionClick,
+      }}
+    />
+  );
+};
+
+export default WrongLoginMethod;

--- a/src/domain/auth/route/ProtectedRoute.tsx
+++ b/src/domain/auth/route/ProtectedRoute.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Route, Redirect, RouteProps, useLocation } from 'react-router-dom';
+
+type Authorization = (() => Promise<boolean>) | boolean;
+
+function useAuthorization(authorization: Authorization): [boolean, boolean] {
+  const [isAuthorized, setAuthorized] = React.useState<boolean | null>(null);
+  const [isLoading, setLoading] = React.useState<boolean>(true);
+
+  React.useEffect(() => {
+    let ignore = false;
+
+    if (typeof authorization === 'function') {
+      authorization()
+        .then((result) => {
+          if (!ignore) {
+            setAuthorized(result);
+          }
+        })
+        .finally(() => {
+          if (!ignore) {
+            setLoading(false);
+          }
+        });
+    }
+
+    return () => {
+      ignore = true;
+    };
+  });
+
+  if (typeof authorization === 'boolean') {
+    return [false, authorization];
+  }
+
+  return [isLoading, Boolean(isAuthorized)];
+}
+
+type Props = RouteProps & {
+  isAuthorized: Authorization;
+  redirectTo?: string;
+  loading?: React.ReactElement | null;
+};
+
+const ProtectedRoute = ({
+  isAuthorized: authorization,
+  redirectTo = '/home',
+  loading: loadingPlaceholder = null,
+  ...rest
+}: Props) => {
+  const location = useLocation();
+  const [loading, isAuthorized] = useAuthorization(authorization);
+
+  if (loading) {
+    return loadingPlaceholder;
+  }
+
+  if (!isAuthorized) {
+    return (
+      <Redirect
+        to={{
+          pathname: redirectTo,
+          state: { from: location },
+        }}
+      />
+    );
+  }
+
+  return <Route {...rest} />;
+};
+
+export default ProtectedRoute;

--- a/src/domain/auth/useLogout.ts
+++ b/src/domain/auth/useLogout.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useMatomo } from '@datapunt/matomo-tracker-react';
+
+import { logoutTunnistamo } from './authenticate';
+import { flushAllState } from './state/AuthenticationUtils';
+
+function useLogout() {
+  const { trackEvent } = useMatomo();
+
+  const logout = React.useCallback(() => {
+    trackEvent({ category: 'action', action: 'Log out' });
+
+    // Flush all cached state
+    flushAllState({});
+
+    // Log out
+    logoutTunnistamo();
+  }, [trackEvent]);
+
+  return logout;
+}
+
+export default useLogout;

--- a/src/domain/profile/queries/ProfileChildrenQuery.ts
+++ b/src/domain/profile/queries/ProfileChildrenQuery.ts
@@ -1,0 +1,17 @@
+import gql from 'graphql-tag';
+
+const profileChildrenQuery = gql`
+  query profileChildrenQuery {
+    myProfile {
+      id
+      children {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }
+`;
+export default profileChildrenQuery;

--- a/src/domain/profile/route/ProfileChildRoutes.tsx
+++ b/src/domain/profile/route/ProfileChildRoutes.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Switch, Route, RouteComponentProps } from 'react-router-dom';
+
+import Event from '../../event/Event';
+import ProfileChildDetail from '../children/child/ProfileChildDetail';
+import Enrol from '../../event/enrol/Enrol';
+import EventIsEnrolled from '../../event/EventIsEnrolled';
+
+const ProfileChildRoute = ({ match: { path } }: RouteComponentProps) => {
+  return (
+    <Switch>
+      <Route exact component={ProfileChildDetail} path={path} />
+      <Route exact component={Event} path={`${path}/event/:eventId`} />
+      <Route exact component={Event} path={`${path}/event/:eventId/past`} />
+      <Route
+        exact
+        component={EventIsEnrolled}
+        path={`${path}/occurrence/:occurrenceId`}
+      />
+      <Route
+        exact
+        component={Enrol}
+        path={`${path}/event/:eventId/occurrence/:occurrenceId/enrol`}
+      />
+    </Switch>
+  );
+};
+export default ProfileChildRoute;

--- a/src/domain/profile/route/ProfileRoute.tsx
+++ b/src/domain/profile/route/ProfileRoute.tsx
@@ -1,44 +1,28 @@
-import React, { FunctionComponent } from 'react';
-import { Switch, Route } from 'react-router-dom';
+import React from 'react';
+import { Switch, Route, useRouteMatch } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import Profile from '../Profile';
-import Event from '../../event/Event';
-import ProfileChildDetail from '../children/child/ProfileChildDetail';
 import { getCurrentLanguage } from '../../../common/translation/TranslationUtils';
-import Enrol from '../../event/enrol/Enrol';
-import EventIsEnrolled from '../../event/EventIsEnrolled';
+import ProtectedRoute from '../../auth/route/ProtectedRoute';
+import ProfileChildRoutes from './ProfileChildRoutes';
+import useIsChildOfProfile from './useIsChildOfProfile';
 
-const ProfileRoute: FunctionComponent = () => {
+const ProfileRoute = () => {
   const { i18n } = useTranslation();
   const currentLocale = getCurrentLanguage(i18n);
+  const childRoutePath = `/${currentLocale}/profile/child/:childId`;
+  const match = useRouteMatch<{ childId: string }>(childRoutePath);
+  const [queryIsChildOfProfile] = useIsChildOfProfile();
+
   return (
     <Switch>
-      <Route
-        exact
-        component={ProfileChildDetail}
-        path={`/${currentLocale}/profile/child/:childId`}
-      />
       <Route component={Profile} exact path={`/${currentLocale}/profile`} />
-      <Route
-        exact
-        component={Event}
-        path={`/${currentLocale}/profile/child/:childId/event/:eventId`}
-      />
-      <Route
-        exact
-        component={Event}
-        path={`/${currentLocale}/profile/child/:childId/event/:eventId/past`}
-      />
-      <Route
-        exact
-        component={EventIsEnrolled}
-        path={`/${currentLocale}/profile/child/:childId/occurrence/:occurrenceId`}
-      />
-      <Route
-        exact
-        component={Enrol}
-        path={`/${currentLocale}/profile/child/:childId/event/:eventId/occurrence/:occurrenceId/enrol`}
+      <ProtectedRoute
+        isAuthorized={() => queryIsChildOfProfile(match?.params.childId)}
+        redirectTo="/wrong-login-method"
+        component={ProfileChildRoutes}
+        path={`/${currentLocale}/profile/child/:childId`}
       />
     </Switch>
   );

--- a/src/domain/profile/route/ProfileRoute.tsx
+++ b/src/domain/profile/route/ProfileRoute.tsx
@@ -22,7 +22,7 @@ const ProfileRoute = () => {
         isAuthorized={() => queryIsChildOfProfile(match?.params.childId)}
         redirectTo="/wrong-login-method"
         component={ProfileChildRoutes}
-        path={`/${currentLocale}/profile/child/:childId`}
+        path={childRoutePath}
       />
     </Switch>
   );

--- a/src/domain/profile/route/useIsChildOfProfile.ts
+++ b/src/domain/profile/route/useIsChildOfProfile.ts
@@ -1,0 +1,41 @@
+import { useApolloClient } from '@apollo/react-hooks';
+
+import { profileChildrenQuery as ProfileChildrenQueryType } from '../../api/generatedTypes/profileChildrenQuery';
+import profileChildrenQuery from '../../profile/queries/ProfileChildrenQuery';
+
+function getIsChildOfProfile(
+  childId: string,
+  data?: ProfileChildrenQueryType
+): boolean | null {
+  if (!data) {
+    return null;
+  }
+
+  const childrenIds = data.myProfile?.children.edges
+    .map((edge) => edge?.node?.id)
+    .filter((id): id is string => typeof id === 'string');
+
+  return Boolean(childrenIds?.includes(childId));
+}
+
+type Result = [(childId?: string) => Promise<boolean>];
+
+function useIsChildOfProfile(): Result {
+  const client = useApolloClient();
+
+  const queryIsChildOfProfile = async (childId?: string): Promise<boolean> => {
+    if (!childId) {
+      return false;
+    }
+
+    const { data } = await client.query<ProfileChildrenQueryType>({
+      query: profileChildrenQuery,
+    });
+
+    return Boolean(getIsChildOfProfile(childId, data));
+  };
+
+  return [queryIsChildOfProfile];
+}
+
+export default useIsChildOfProfile;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6570,6 +6570,11 @@ hds-core@0.12.1, hds-core@^0.12.1:
   resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-0.12.1.tgz#f467d8274c672741e937ae58a7dd20f49525f7df"
   integrity sha512-os28NxPnBJ896XZUvwAHdrpMHCRtcF5k68SfauoCn+oq7f9I/+6YQfx/3MNobBkjUkOZopBUgzh2Vm/1BGZKZQ==
 
+hds-design-tokens@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/hds-design-tokens/-/hds-design-tokens-0.13.0.tgz#de4d4d156716a29dd38af0bcc7d281b62ea1b539"
+  integrity sha512-ZtoVGV/FEiX/43DhktPnesRXZ2Rsx0PMCqkvr33YLheDe3pFWk7+TmZ5xV4/983zDJ9oSN1lfx2EUcfflvs6AA==
+
 hds-react@^0.12.1:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-0.12.1.tgz#e44fcec15ca7f475a3c4f6535c7672986ba88a44"


### PR DESCRIPTION
The user can login to the service using other services like Google or
Facebook. Once they have logged in using a service, they must always
use the same one if they want to access the "kukkuu" account that is
created then.

Sometimes users login with a service they did not use during their
initial sign up process. In this scenario, they are not able to access
their original data.

A usecase that's especially problematic is when the user receives a
link into their mail they can use to sign up their child into an event.
If they login by using the wrong service, they end up in a view that
doesn't work and gives little in the way of clues as to why.

After this commit, the user would be redirected into the wrong login
method page, which guides them to sign in again.

----

I've tested these things by hand:
* Links like this lead to a redirect to the error page: http://localhost:3000/fi/profile/child/ihan-mita-vaan/event/ihan-mita-vaan
* From my own profile, I am able to access my children's profile page
* Any link like this will lead to a redirect to the error page: http://localhost:3000/fi/profile/child/imagined-id
* Logging out works from the main navigation
* Logging out works from the error page

I've not written tests. This behaviour should likely be tested with `e2e` because it relies on GraphQL, but TestCafe has not been integrated yet.