### PR TITLE
KK-542 | Use replace when redirecting user according to state

### DIFF
--- a/src/domain/auth/OidcCallback.tsx
+++ b/src/domain/auth/OidcCallback.tsx
@@ -18,7 +18,7 @@ function OidcCallback(props: RouteChildrenProps) {
   });
 
   const onSuccess = (user: User) => {
-    if (user.state.path) props.history.push(user.state.path);
+    if (user.state.path) props.history.replace(user.state.path);
     else props.history.replace('/profile');
   };
 


### PR DESCRIPTION
If push is used instead of replace, the callback page is retained
within the history. The user can then access it by using the back
button, which will lead to an error.

These errors are problematic, because they flood Sentry and may be
hiding other usecases which lead to the same error. The user experience
when backing into the callback page is also poor in general and may
mislead the user.

The original `.push` code was added in conjunction with some registration flow improvements. I tested that registration still works as expected.