### PR TITLE
KK-551 | Hide second link on event invitation card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - When users access a child's information that is not attached to their account, they are redirected into a view that asks them to authenticate again
 
+### Changed
+
+- Event invitation card to only have one link on mobile
+- Event invitation card to list button as its last element
+
 # 1.3.0
 
 ### Added

--- a/src/common/components/card/Card.tsx
+++ b/src/common/components/card/Card.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode, ReactElement } from 'react';
+import React, { ReactNode, ReactElement } from 'react';
 
 import angleDownIcon from '../../../assets/icons/svg/angleDown.svg';
 import styles from './card.module.scss';
@@ -18,7 +18,7 @@ interface CardProps {
   title: string;
 }
 
-const Card: FunctionComponent<CardProps> = ({
+const Card = ({
   action,
   actionText,
   alt = '',
@@ -29,7 +29,7 @@ const Card: FunctionComponent<CardProps> = ({
   primaryAction,
   primaryActionText,
   title,
-}) => {
+}: CardProps) => {
   return (
     <div
       className={styles.wrapper}
@@ -45,6 +45,7 @@ const Card: FunctionComponent<CardProps> = ({
 
       <div className={styles.middle}>
         <h3 className={styles.title}>{title}</h3>
+        {children}
         <div className={styles.focalPoint}>
           {primaryAction && (
             <Button className={styles.primaryActionButton}>
@@ -53,7 +54,6 @@ const Card: FunctionComponent<CardProps> = ({
           )}
           {focalContent && focalContent}
         </div>
-        {children}
       </div>
 
       <div className={styles.end}>

--- a/src/common/components/card/card.module.scss
+++ b/src/common/components/card/card.module.scss
@@ -72,7 +72,10 @@ $imageMaxSize: 300px;
 }
 
 .end {
+  display: none;
+
   @include respond-above(sm) {
+    display: block;
     justify-self: center;
     & .actionText {
       display: none;


### PR DESCRIPTION
The event invitation card should no longer display two links on mobile. The button element should also be displayed last.