### PR TITLE
KK-550 | Fix mobile layout for event enrollment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Registration form final approval text
 - Provide better accessible name for profile menu
+- Mobile layout for event enrollment
 
 # 1.3.0
 

--- a/src/domain/event/enrol/enrol.module.scss
+++ b/src/domain/event/enrol/enrol.module.scss
@@ -35,12 +35,20 @@ h1 {
 }
 
 .occurrenceInfo {
+  box-sizing: border-box;
   background: var(--color-black-5);
   padding: $basePadding;
+  width: 100%;
+
+  @include respond-above(sm) {
+    width: unset;
+  }
 }
 
 .actions {
-  width: 60%;
+  @include respond-above(sm) {
+    width: 60%;
+  }
   button {
     margin-top: $baseMargin;
     width: 100%;

--- a/src/domain/event/event.module.scss
+++ b/src/domain/event/event.module.scss
@@ -69,7 +69,10 @@
   form {
     display: grid;
     grid-gap: $baseMargin;
-    grid-template-columns: auto auto;
+    grid-template-columns: auto;
+    @include respond-above(xs) {
+      grid-template-columns: auto auto;
+    }
     @include respond-above(md) {
       grid-template-columns: 2fr 1fr 50%;
     }


### PR DESCRIPTION
- Event page should no longer overflow on mobile. In other words, the page should not have a horizontal scroll bar on mobile.
- Buttons and event information should now be extended to page margins on mobile