### PR TITLE
KK-546 | Fix vague naming of profile menu for screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Registration form final approval text
+- Provide better accessible name for profile menu
 
 # 1.3.0
 

--- a/src/common/components/dropdown/Dropdown.tsx
+++ b/src/common/components/dropdown/Dropdown.tsx
@@ -10,6 +10,10 @@ interface DropdownOption {
   id: string;
   label: string;
   icon?: string;
+  // If the icon is something else than decorative, a label should be
+  // provided for it that can be used to communicate its meaning to
+  // screen readers.
+  iconLabel?: string;
   onClick?: () => void;
 }
 
@@ -58,10 +62,11 @@ const Dropdown: FunctionComponent<DropdownProps> = ({
                 alt={t('navbar.menuButton.label')}
               />
             }
-            aria-label={t(
-              isOpen ? 'common.menu.closeMenuText' : 'common.menu.openMenuText'
-            )}
             aria-expanded={isOpen}
+            aria-haspopup="true"
+            aria-label={`${itemDisplayedOnNavbar.label} ${
+              itemDisplayedOnNavbar.iconLabel || ''
+            }`}
             onClick={() => {
               toggleDropdown(!isOpen);
             }}

--- a/src/domain/app/header/userDropdown/UserDropdown.tsx
+++ b/src/domain/app/header/userDropdown/UserDropdown.tsx
@@ -66,6 +66,7 @@ const UserDropdown: FunctionComponent<UserDropdownProps> = ({
       ? data?.myProfile?.firstName
       : t('navbar.profileDropdown.profile.text'),
     icon: personIcon,
+    iconLabel: t('navbar.profileDropdown.icon.label'),
   };
 
   const frontPage = {


### PR DESCRIPTION
Previously the profile menu relied on the `aria-label` attribute in order to communicate its state. Moreover, the naming applied to it was relatively vague. It was simply named as "menu".

In these changes I've adjusted the use of aria-attributes. I've added `aria-haspopup` and removed the use of state within the `aria-label`. The `aria-expanded` attribute already communicates this. We've also adjusted the button naming. Instead of "menu" the accessible content is now read as _label of button_ + _label of icon_. In the case of the user menu, for instance, 

>George profile menu

I checked the mobile menu as well while doing these changes. Unfortunately it ended up being less simple than the regular navigation changes. I think I need more context before I am able to make a proper fix.