### PR TITLE
KK-549 | Fix empty child list on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Registration form final approval text
 - Provide better accessible name for profile menu
 - Mobile layout for event enrollment
+- Profile view missing children on mobile
 
 # 1.3.0
 

--- a/src/domain/app/header/userDropdown/UserDropdown.tsx
+++ b/src/domain/app/header/userDropdown/UserDropdown.tsx
@@ -1,25 +1,16 @@
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
-import { useQuery } from '@apollo/react-hooks';
-import * as Sentry from '@sentry/browser';
 
 import Dropdown from '../../../../common/components/dropdown/Dropdown';
-import { profileQuery as ProfileQueryType } from '../../../api/generatedTypes/profileQuery';
 import personIcon from '../../../../assets/icons/svg/person.svg';
 import { isAuthenticatedSelector } from '../../../auth/state/AuthenticationSelectors';
 import { loginTunnistamo } from '../../../auth/authenticate';
 import useLogout from '../../../auth/useLogout';
 import UserMenu from '../userMenu/UserMenu';
-import profileQuery from '../../../profile/queries/ProfileQuery';
-import { saveProfile } from '../../../profile/state/ProfileActions';
-import {
-  clearEvent,
-  saveChildrenEvents,
-} from '../../../event/state/EventActions';
-import { defaultProfileData } from '../../../profile/state/ProfileReducers';
+import useProfile from '../../../profile/hooks/useProfile';
 
 export interface UserDropdownProps {
   isSmallScreen: boolean;
@@ -31,26 +22,12 @@ const UserDropdown: FunctionComponent<UserDropdownProps> = ({
   const { t } = useTranslation();
   const history = useHistory();
   const isAuthenticated = useSelector(isAuthenticatedSelector);
-  const dispatch = useDispatch();
   const doLogout = useLogout();
 
-  const { loading, error, data } = useQuery<ProfileQueryType>(profileQuery, {
-    skip: !isAuthenticated,
-  });
+  const { loading, data } = useProfile();
   const { trackEvent } = useMatomo();
 
-  useEffect(() => {
-    dispatch(saveProfile(data?.myProfile || defaultProfileData));
-    dispatch(clearEvent());
-    dispatch(saveChildrenEvents(data?.myProfile?.children || undefined));
-  }, [data, dispatch]);
-
   if (loading) return <></>;
-  if (error) {
-    // eslint-disable-next-line no-console
-    console.error(error);
-    Sentry.captureException(error);
-  }
 
   const logout = {
     label: t('authentication.logout.text'),
@@ -62,8 +39,8 @@ const UserDropdown: FunctionComponent<UserDropdownProps> = ({
 
   const user = {
     id: 'userButton',
-    label: data?.myProfile?.firstName
-      ? data?.myProfile?.firstName
+    label: data?.firstName
+      ? data?.firstName
       : t('navbar.profileDropdown.profile.text'),
     icon: personIcon,
     iconLabel: t('navbar.profileDropdown.icon.label'),

--- a/src/domain/profile/Profile.tsx
+++ b/src/domain/profile/Profile.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { useQuery } from '@apollo/react-hooks';
 import { Redirect } from 'react-router-dom';
 import * as Sentry from '@sentry/browser';
 import { IconCogwheel } from 'hds-react';
 
-import { profileQuery as ProfileQueryType } from '../api/generatedTypes/profileQuery';
 import { clearProfile } from './state/ProfileActions';
-import profileQuery from './queries/ProfileQuery';
+import useProfile from './hooks/useProfile';
 import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
 import ProfileChildrenList from './children/ProfileChildrenList';
 import PageWrapper from '../app/layout/PageWrapper';
@@ -22,7 +20,7 @@ import Button from '../../common/components/button/Button';
 
 const Profile = () => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const { loading, error, data } = useQuery<ProfileQueryType>(profileQuery);
+  const { loading, error, data } = useProfile();
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
@@ -35,7 +33,7 @@ const Profile = () => {
     return <ErrorMessage message={t('api.errorMessage')} />;
   }
 
-  if (!data?.myProfile) {
+  if (!data) {
     // User has logged in, but not created a profile, send them to front page for registration.
     return <Redirect to="/" />;
   }
@@ -47,7 +45,7 @@ const Profile = () => {
           <div className={styles.profileContent}>
             <div className={styles.heading}>
               <h1>
-                {data.myProfile.firstName} {data.myProfile.lastName}
+                {data.firstName} {data.lastName}
               </h1>
               <Button
                 variant="supplementary"
@@ -62,7 +60,7 @@ const Profile = () => {
               <EditProfileModal
                 isOpen={isOpen}
                 setIsOpen={setIsOpen}
-                initialValues={data.myProfile}
+                initialValues={data}
               />
             )}
             <div className={styles.guardianInfo}>
@@ -71,14 +69,14 @@ const Profile = () => {
                   src={emailIcon}
                   alt={t('registration.form.guardian.email.input.label')}
                 />
-                <span>{data.myProfile.email}</span>
+                <span>{data.email}</span>
               </div>
               <div className={styles.guardianInfoRow}>
                 <Icon
                   src={phoneIcon}
                   alt={t('profile.child.detail.phoneNumber')}
                 />
-                <span>{data.myProfile.phoneNumber}</span>
+                <span>{data.phoneNumber}</span>
               </div>
             </div>
             <ProfileChildrenList />

--- a/src/domain/profile/children/child/ProfileChildDetail.tsx
+++ b/src/domain/profile/children/child/ProfileChildDetail.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 import { useParams, useHistory } from 'react-router';
 import { useMutation, useQuery } from '@apollo/react-hooks';
 import { toast } from 'react-toastify';
@@ -16,7 +15,7 @@ import birthdateIcon from '../../../../assets/icons/svg/birthdayCake.svg';
 import Icon from '../../../../common/components/icon/Icon';
 import { formatTime, newMoment } from '../../../../common/time/utils';
 import { DEFAULT_DATE_FORMAT } from '../../../../common/time/TimeConstants';
-import { profileSelector } from '../../state/ProfileSelectors';
+import useProfile from '../../hooks/useProfile';
 import ProfileEvents from '../../events/ProfileEvents';
 import ProfileChildDetailEditModal from './modal/ProfileChildDetailEditModal';
 import { deleteChild_deleteChild as DeleteChildPayload } from '../../../api/generatedTypes/deleteChild';
@@ -37,7 +36,7 @@ export type ChildDetailEditModalPayload = Omit<EditChildInput, 'id'>;
 const ProfileChildDetail: FunctionComponent = () => {
   const { t } = useTranslation();
   const params = useParams<{ childId: string }>();
-  const guardian = useSelector(profileSelector);
+  const { data: guardian } = useProfile();
   const history = useHistory();
   const { loading, error, data } = useQuery<ChildByIdResponse>(childByIdQuery, {
     variables: {

--- a/src/domain/profile/hooks/useProfile.ts
+++ b/src/domain/profile/hooks/useProfile.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@apollo/react-hooks';
+import { useDispatch, useSelector } from 'react-redux';
+import * as Sentry from '@sentry/browser';
+
+import { isAuthenticatedSelector } from '../../auth/state/AuthenticationSelectors';
+import { profileQuery as ProfileQueryType } from '../../api/generatedTypes/profileQuery';
+import { clearEvent, saveChildrenEvents } from '../../event/state/EventActions';
+import profileQuery from '../queries/ProfileQuery';
+import { clearProfile, saveProfile } from '../state/ProfileActions';
+import { defaultProfileData } from '../state/ProfileReducers';
+import { profileSelector } from '../state/ProfileSelectors';
+
+function useProfile() {
+  const dispatch = useDispatch();
+  const isAuthenticated = useSelector(isAuthenticatedSelector);
+  const profile = useSelector(profileSelector);
+
+  const result = useQuery<ProfileQueryType>(profileQuery, {
+    skip: !isAuthenticated,
+    onCompleted: (data) => {
+      dispatch(saveProfile(data?.myProfile || defaultProfileData));
+      dispatch(clearEvent());
+      dispatch(saveChildrenEvents(data?.myProfile?.children || undefined));
+    },
+    onError: (error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      dispatch(clearProfile());
+      Sentry.captureException(error);
+    },
+  });
+
+  return { ...result, data: profile };
+}
+
+export default useProfile;


### PR DESCRIPTION
Previously the logged in user's profile was synced into the redux state
when the details for their user menu were fetched. On mobile, this menu
is not rendered by default, so their details were not ever synced and
they ended up seeing an empty list of children instead.

It's a bit odd that the user details are stored in two places: (1) in
Apollo's state and in (2) Kukkuu's redux state. I think that ideally
this duplication would not exist. But because I don't understand enough
of the context of the application yet, I didn't remove this
duplication entirely.

As a fix I created the useProfile hook. It fetches the profile and
stores it into the redux state--roughly the logic that was contained
within the user menu before. After this change, the profile is loaded
whenever it is accessed so there's no chance that a view will request
the profile before it has been requested. Further, this structure will
make the consumers of profile data more agnostic about its source which
will make it easier to refactor state management later.