### PR TITLE
KK-563 | Fix child list not updating after adding a new child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 # 1.4.0
 
+### Fixed
+
+- Child list not showing changes without a refresh
+
 ### Changed
 
 - [#289](https://github.com/City-of-Helsinki/kukkuu-ui/pull/289) Event invitation card to only have one link on mobile

--- a/src/domain/profile/children/ProfileChildrenList.tsx
+++ b/src/domain/profile/children/ProfileChildrenList.tsx
@@ -1,27 +1,33 @@
-import React, { FunctionComponent, Fragment, useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 import { useMutation } from '@apollo/react-hooks';
 import { toast } from 'react-toastify';
 import * as Sentry from '@sentry/browser';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 import { IconPlusCircle } from 'hds-react';
 
+import { profileQuery_myProfile_children as Children } from '../../api/generatedTypes/profileQuery';
 import styles from './profileChildrenList.module.scss';
 import ProfileChild from './child/ProfileChild';
-import { profileChildrenSelector } from '../state/ProfileSelectors';
 import AddNewChildFormModal from '../../registration/modal/AddNewChildFormModal';
 import { addChildMutation } from '../../child/mutation/ChildMutation';
 import { getSupportedChildData } from '../../child/ChildUtils';
 import LoadingSpinner from '../../../common/components/spinner/LoadingSpinner';
 import profileQuery from '../queries/ProfileQuery';
+import useProfile, { ProfileQueryResult } from '../hooks/useProfile';
 import { getProjectsFromProfileQuery } from '../ProfileUtil';
 import { UpdateChildMutationInput } from '../../api/generatedTypes/globalTypes';
 import Button from '../../../common/components/button/Button';
 
-const ProfileChildrenList: FunctionComponent = () => {
+function getChildrenFromProfile({
+  data,
+}: ProfileQueryResult): Children | null | undefined {
+  return data?.children;
+}
+
+const ProfileChildrenList = () => {
   const { t } = useTranslation();
-  const children = useSelector(profileChildrenSelector);
+  const children = getChildrenFromProfile(useProfile());
   const [isOpen, setIsOpen] = useState(false);
   const [addChild, { loading: mutationLoading }] = useMutation(
     addChildMutation,

--- a/src/domain/profile/children/child/ProfileChildDetail.tsx
+++ b/src/domain/profile/children/child/ProfileChildDetail.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useHistory } from 'react-router';
 import { useMutation, useQuery } from '@apollo/react-hooks';
@@ -33,7 +33,7 @@ import ErrorMessage from '../../../../common/components/error/Error';
 import Button from '../../../../common/components/button/Button';
 export type ChildDetailEditModalPayload = Omit<EditChildInput, 'id'>;
 
-const ProfileChildDetail: FunctionComponent = () => {
+const ProfileChildDetail = () => {
   const { t } = useTranslation();
   const params = useParams<{ childId: string }>();
   const { data: guardian } = useProfile();
@@ -166,7 +166,7 @@ const ProfileChildDetail: FunctionComponent = () => {
                   src={personIcon}
                   alt={t('profile.child.detail.guardiansName')}
                 />
-                <span>{`${guardian.firstName} ${guardian.lastName}`}</span>
+                <span>{`${guardian?.firstName} ${guardian?.lastName}`}</span>
               </div>
 
               <div className={styles.eventWrapper}>


### PR DESCRIPTION
The child list used data from the redux store. The child add modal
relied on Apollo's refetchQueries to update related data. However,
refetched queries are not at any point synced into the redux store.

This behaviour may have broken in 054e284 where we changed the
synchronising mechanism between Apollo and redux from useEffect to
a callback. The callback is only fired when that particular hook makes
a query. The data the hook returns in turn changes when the cached data
changes. In this way the useEffect approach will more consistently keep
the two states in sync.

Using useEffect in such a way is an anti-pattern. Apollo likely
provides some other mechanism which allows us to subrscibe to state
changes, but I doubt that they are worth it when we can just as well
use source the data from Apollo's state.