### PR TITLE
KK-567 | Handle child already enrolled error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+### Added
+
+- Error handling for child already enrolled error
+
 ### Changed
 
 - Show no other button than log out for logged in unregistered users

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -149,6 +149,9 @@
       "text": "Check that the information below is correct for the event you wish to attend."
     },
     "enroll": {
+      "error": {
+        "childAlreadyJoined": "This child has already been enrolled in this event."
+      },
       "buttonText": "Register for event"
     },
     "heading": "Register",

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -149,6 +149,9 @@
       "text": "Tarkista, että alla olevat tiedot vastaavat tapahtumaa, johon haluat osallistua."
     },
     "enroll": {
+      "error": {
+        "childAlreadyJoined": "Lapsi on jo ilmoittautunut tapahtumaan."
+      },
       "buttonText": "Ilmoittaudu tapahtumaan"
     },
     "heading": "Ilmoittaudu",

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -149,6 +149,9 @@
       "text": "Kontrollera att informationen nedan motsvarar de evenemang du vill delta i."
     },
     "enroll": {
+      "error": {
+        "childAlreadyJoined": "Detta barn har redan anmält sig till detta evenemang."
+      },
       "buttonText": "Anmäl dig till evenemanget"
     },
     "heading": "Anmäl dig",

--- a/src/domain/event/enrol/Enrol.tsx
+++ b/src/domain/event/enrol/Enrol.tsx
@@ -24,6 +24,7 @@ import { childByIdQuery } from '../../child/queries/ChildQueries';
 import { saveChildEvents, justEnrolled } from '../state/EventActions';
 import ErrorMessage from '../../../common/components/error/Error';
 import Button from '../../../common/components/button/Button';
+import { GQLErrors } from './EnrolConstants';
 
 function check<D>(data: D, resultFactory: (data: D) => boolean): boolean {
   return resultFactory(data);
@@ -34,7 +35,7 @@ function containsAlreadyJoinedError(
 ): boolean {
   return errors.some(
     (error: GraphQLError) =>
-      error.extensions?.code === 'CHILD_ALREADY_JOINED_EVENT_ERROR'
+      error.extensions?.code === GQLErrors.CHILD_ALREADY_JOINED_EVENT_ERROR
   );
 }
 

--- a/src/domain/event/enrol/EnrolConstants.ts
+++ b/src/domain/event/enrol/EnrolConstants.ts
@@ -1,0 +1,5 @@
+export const GQLErrors = Object.freeze({
+  CHILD_ALREADY_JOINED_EVENT_ERROR: 'CHILD_ALREADY_JOINED_EVENT_ERROR',
+} as const);
+
+export type GQLErrorsType = typeof GQLErrors[keyof typeof GQLErrors];


### PR DESCRIPTION
When the user attempts to enrol a child into an event the child is already enrolled in they will be redirected to the event page and a warning notification will be shown to them.

### Reproduction

While logged in into a kukkuu account that has a child

1) Go to child page
2) Go to event page
3) Select occurrence
4) Copy URL
5) Paste URL into a new tab
6) In the first tab, enrol
7) in the second tab, enrol

(In the second tab) Expect to be redirected into the event page and see a warning toast.