### PR TITLE
KK-573 | Fix application crash when unenrolling

### DIFF
--- a/src/domain/event/mutations/unenrolOccurrenceMutation.ts
+++ b/src/domain/event/mutations/unenrolOccurrenceMutation.ts
@@ -19,7 +19,7 @@ const unenrolOccurrenceMutation = gql`
             }
           }
         }
-        occurrences(upcoming: true) {
+        occurrences(upcomingWithLeeway: true) {
           edges {
             node {
               id


### PR DESCRIPTION
I wasn't able to understand why the crash did happen in detail. As a
result of trial and error, I was able to find out that the crash
happens because the mutation I update here and the query updated
in f3900586 fall out of sync.

This may be due to:
- Some special behaviour in Apollo I do not understand
- The interop between redux and Apollo
- Some other underlying bug that this configuration reveals, but I
  wasn't able to pinpoint