### PR TITLE
KK-561 | Fix postal code validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Redirect to registration for users who don't have a profile yet
+- Postal code validation
 
 # 1.4.0
 

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -474,6 +474,9 @@
         },
         "postalCode": {
           "input": {
+            "error": {
+              "length": "Postal code has to be 5 characters long"
+            },
             "label": "Child's postal code",
             "placeholder": "Enter child's postal code"
           }

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -474,6 +474,9 @@
         },
         "postalCode": {
           "input": {
+            "error": {
+              "length": "Postinumeron täytyy olla 5 merkkiä pitkä"
+            },
             "label": "Lapsen postinumero",
             "placeholder": "Lisää lapsen postinumero"
           }

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -474,6 +474,9 @@
         },
         "postalCode": {
           "input": {
+            "error": {
+              "length": "Postnummer måste vara 5 tecken långt"
+            },
             "label": "Barnets postnummer",
             "placeholder": "Ange barnets postnummer"
           }

--- a/src/domain/child/form/ChildForm.tsx
+++ b/src/domain/child/form/ChildForm.tsx
@@ -17,7 +17,10 @@ import FormikTextInput from '../../../common/components/formikWrappers/FormikTex
 
 const schema = yup.object().shape({
   homeCity: yup.string().required('validation.general.required'),
-  postalCode: yup.string().required('validation.general.required'),
+  postalCode: yup
+    .string()
+    .length(5, 'registration.form.child.postalCode.input.error.length')
+    .required('validation.general.required'),
   birthdate: yup.object().shape({
     day: yup.string().required('validation.general.required'),
   }),

--- a/src/domain/registration/form/RegistrationForm.tsx
+++ b/src/domain/registration/form/RegistrationForm.tsx
@@ -61,6 +61,7 @@ const schema = yup.object().shape({
       postalCode: yup
         .string()
         .required('validation.general.required')
+        .length(5, 'registration.form.child.postalCode.input.error.length')
         .matches(/\b\d{5}\b/g, 'validation.postalCode.invalidFormat'),
       relationship: yup.object().shape({
         type: yup.string().required('validation.general.required').nullable(),


### PR DESCRIPTION
Previously the UI had a more lenient validation for the postal code
compared with the backend. This made it possible for users to submit
the form with data that was considered invalid by the backend.