### PR TITLE
KK-513 | Fix free spot notification subscriptions

### DIFF
--- a/src/common/test/initModal.ts
+++ b/src/common/test/initModal.ts
@@ -1,0 +1,10 @@
+import Modal from 'react-modal';
+
+function initModal() {
+  const div = document.createElement('div');
+
+  document.body.appendChild(div);
+  Modal.setAppElement(div);
+}
+
+export default initModal;

--- a/src/common/test/testingLibraryUtils.tsx
+++ b/src/common/test/testingLibraryUtils.tsx
@@ -1,13 +1,13 @@
 import React, { ReactElement } from 'react';
-import { render, RenderOptions } from '@testing-library/react';
+import { render, RenderOptions, RenderResult } from '@testing-library/react';
 import { MockedResponse } from '@apollo/client/testing';
 
 import TestProviders from './TestProviders';
 
 const customRender = (
   ui: ReactElement,
-  mocks: MockedResponse[],
-  options: RenderOptions
+  mocks?: MockedResponse[],
+  options?: RenderOptions
 ) =>
   render(ui, {
     wrapper: ({ children }) => (
@@ -15,6 +15,19 @@ const customRender = (
     ),
     ...options,
   });
+
+export const selectHdsButton = (buttonLabel: HTMLElement): HTMLElement => {
+  return buttonLabel.closest('button') as HTMLElement;
+};
+
+export const selectHdsButtonByText = (
+  render: RenderResult,
+  text: string
+): HTMLElement => {
+  const { getByText } = render;
+
+  return selectHdsButton(getByText(text));
+};
 
 // re-export everything
 export * from '@testing-library/react';

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -209,6 +209,9 @@
       "form": {
         "header": "Register"
       },
+      "occurrenceTableBody": {
+        "full": "FULL"
+      },
       "occurrenceTableHeader": {
         "buttonText": "Choose",
         "date": "Date",

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -134,10 +134,11 @@
   },
   "enrollment": {
     "button": {
-      "cancelNotificationSubscription": "Cancel notifications",
+      "cancelNotificationSubscription": "Cancel notification",
       "occurrenceFullSubscribeToNotifications": "Full - Subscribe to notifications",
       "queue": "Join queue",
-      "selectOccurence": "Choose"
+      "selectOccurence": "Choose",
+      "subscribeToNotifications": "Subscribe to notifications"
     },
     "confirmationPage": {
       "cancel": {

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -152,7 +152,7 @@
       },
       "description": {
         "text": "Check that the information below is correct for the event you wish to attend.",
-        "full": "Unfortunately this event is full. If you want you can subscribe to notifications in case of cancellations."
+        "full": "Unfortunately this event is full. Subscribe to receive a notification of available places."
       }
     },
     "enroll": {

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -172,7 +172,7 @@
     },
     "notificationSubscriptionModal": {
       "cancel": "Cancel",
-      "description": "You will receive a notification via email when places become available for the event <b>{{eventName}} {{date}} at {{time}}</b>. Available places are given out in the order they have been signed up for.",
+      "description": "You will receive a notification via email when places become available for the event <b>{{eventName}} {{date}} at {{time}}</b>. Available places are given to those who first register for them.",
       "subscribe": "Subscribe",
       "title": "Subscribe to receive a notification of available places"
     },

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -134,10 +134,11 @@
   },
   "enrollment": {
     "button": {
-      "cancelNotificationSubscription": "Peru ilmoitusten tilaus",
+      "cancelNotificationSubscription": "Peru ilmoituksen tilaus",
       "occurrenceFullSubscribeToNotifications": "Täynnä - Tilaa ilmoitus",
       "queue": "Jonoon",
-      "selectOccurence": "Valitse"
+      "selectOccurence": "Valitse",
+      "subscribeToNotifications": "Tilaa ilmoitus"
     },
     "confirmationPage": {
       "cancel": {

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -209,6 +209,9 @@
       "form": {
         "header": "Ilmoittaudu"
       },
+      "occurrenceTableBody": {
+        "full": "TÄYNNÄ"
+      },
       "occurrenceTableHeader": {
         "buttonText": "Valitse",
         "date": "Päivämäärä",

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -152,7 +152,7 @@
       },
       "description": {
         "text": "Tarkista, että alla olevat tiedot vastaavat tapahtumaa, johon haluat osallistua.",
-        "full": "Valitettavasti tämä tapahtuma on täynnä. Halutessasi voit tilata ilmoituksen paikkojen vapautumisesta!"
+        "full": "Valitettavasti tämä tapahtuma on täynnä. Tilaa ilmoitus vapautuvista paikoista."
       }
     },
     "enroll": {

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -134,10 +134,11 @@
   },
   "enrollment": {
     "button": {
-      "cancelNotificationSubscription": "Avbryt aviseringar",
+      "cancelNotificationSubscription": "Avbryt avisering",
       "occurrenceFullSubscribeToNotifications": "Fullt - Prenumerera på aviseringar",
       "queue": "Ställ dig i kö",
-      "selectOccurence": "Välj"
+      "selectOccurence": "Välj",
+      "subscribeToNotifications": "Prenumerera på aviseringar"
     },
     "confirmationPage": {
       "cancel": {

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -209,6 +209,9 @@
       "form": {
         "header": "Anmäl dig"
       },
+      "occurrenceTableBody": {
+        "full": "FULLT"
+      },
       "occurrenceTableHeader": {
         "buttonText": "Välj",
         "date": "Datum",

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -152,7 +152,7 @@
       },
       "description": {
         "text": "Kontrollera att informationen nedan motsvarar de evenemang du vill delta i.",
-        "full": "Tyvärr är det här evenemanget fullt. Om du vill kan du prenumerera på aviseringar vid avbokningar."
+        "full": "Tyvärr är det här evenemanget fullt. Prenumerera för att få ett meddelande om tillgängliga platser."
       }
     },
     "enroll": {

--- a/src/domain/event/EventNotificationSubscriptionModal.tsx
+++ b/src/domain/event/EventNotificationSubscriptionModal.tsx
@@ -6,12 +6,20 @@ import {
   DEFAULT_DATE_FORMAT,
   DEFAULT_TIME_FORMAT,
 } from '../../common/time/TimeConstants';
-import { occurrenceQuery_occurrence as Occurrence } from '../api/generatedTypes/occurrenceQuery';
 import ConfirmModal from '../../common/components/confirm/ConfirmModal';
 import useSubscribeToFreeSpotNotificationMutation from './useSubscribeToFreeSpotNotificationMutation';
 
+export type Occurrence = {
+  id: string | null;
+  time: string | null;
+  event: {
+    name: string | null;
+  };
+};
+
 type Props = {
   childId: string;
+  eventId: string;
   eventOccurrence: Occurrence;
   isOpen: boolean;
   onSubscribed?: () => void;
@@ -20,27 +28,36 @@ type Props = {
 
 const EventNotificationSubscriptionModal = ({
   childId,
+  eventId,
   eventOccurrence,
   isOpen,
   onSubscribed,
   setIsOpen,
 }: Props) => {
   const { t } = useTranslation();
-  const [subscribe] = useSubscribeToFreeSpotNotificationMutation();
+  const [subscribe] = useSubscribeToFreeSpotNotificationMutation(
+    eventId,
+    childId
+  );
 
   const handleAnswer = async (consented: boolean) => {
     if (consented) {
-      const { errors } = await subscribe({
-        variables: {
-          input: {
-            occurrenceId: eventOccurrence.id,
-            childId,
+      try {
+        await subscribe({
+          variables: {
+            input: {
+              occurrenceId: eventOccurrence.id,
+              childId,
+            },
           },
-        },
-      });
+        });
 
-      if (!errors && onSubscribed) {
-        onSubscribed();
+        if (onSubscribed) {
+          onSubscribed();
+        }
+      } catch (e) {
+        // Default error handling is enabled in
+        // useSubscribeToFreeSpotNotificationMutation
       }
     }
   };

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -10,9 +10,7 @@ import {
   DEFAULT_TIME_FORMAT,
   DEFAULT_DATE_FORMAT,
 } from '../../common/time/TimeConstants';
-import eventQuery from './queries/eventQuery';
-import useSubscribeToFreeSpotNotificationMutation from './useSubscribeToFreeSpotNotificationMutation';
-import useUnsubscribeFromFreeSpotNotificationMutation from './useUnsubscribeFromFreeSpotNotificationMutation';
+import EventOccurrenceNotificationControlButton from './EventOccurrenceNotificationControlButton';
 
 type UrlParams = {
   childId: string;
@@ -26,31 +24,6 @@ type EventOccurrenceProps = {
 const EventOccurrence = ({ occurrence }: EventOccurrenceProps) => {
   const { t } = useTranslation();
   const { childId, eventId } = useParams<UrlParams>();
-  const [subscribe] = useSubscribeToFreeSpotNotificationMutation();
-  const [unsubscribe] = useUnsubscribeFromFreeSpotNotificationMutation();
-
-  const mutationVariables = {
-    variables: {
-      input: { childId, occurrenceId: occurrence.id },
-    },
-    refetchQueries: [
-      {
-        query: eventQuery,
-        variables: {
-          id: eventId,
-          childId,
-        },
-      },
-    ],
-  };
-
-  const handleSubscribe = () => {
-    subscribe(mutationVariables);
-  };
-
-  const handleUnsubscribe = () => {
-    unsubscribe(mutationVariables);
-  };
 
   const date = formatTime(
     newMoment(occurrence.time),
@@ -61,8 +34,9 @@ const EventOccurrence = ({ occurrence }: EventOccurrenceProps) => {
   const hasCapacity = Boolean(
     occurrence.remainingCapacity && occurrence.remainingCapacity > 0
   );
-  const childHasSubscription =
-    occurrence.childHasFreeSpotNotificationSubscription;
+  const childHasSubscription = Boolean(
+    occurrence.childHasFreeSpotNotificationSubscription
+  );
 
   return (
     <tr className={styles.occurrence}>
@@ -89,23 +63,17 @@ const EventOccurrence = ({ occurrence }: EventOccurrenceProps) => {
             </Button>
           </Link>
         )}
-        {!hasCapacity && !childHasSubscription && (
-          <Button
-            className={styles.fullButton}
-            variant="disabled"
-            onClick={handleSubscribe}
-          >
-            {t('enrollment.button.occurrenceFullSubscribeToNotifications')}
-          </Button>
-        )}
-        {!hasCapacity && childHasSubscription && (
-          <Button
-            className={styles.fullButton}
-            variant="secondary"
-            onClick={handleUnsubscribe}
-          >
-            {t('enrollment.button.cancelNotificationSubscription')}
-          </Button>
+        {!hasCapacity && (
+          <EventOccurrenceNotificationControlButton
+            childId={childId}
+            eventId={eventId}
+            isSubscribed={childHasSubscription}
+            occurrence={occurrence}
+            unsubscribeLabel={t(
+              'enrollment.button.cancelNotificationSubscription'
+            )}
+            subscribeLabel={t('enrollment.button.subscribeToNotifications')}
+          />
         )}
       </td>
     </tr>

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -70,7 +70,9 @@ const EventOccurrence = ({ occurrence }: EventOccurrenceProps) => {
       <td className={styles.occurrenceTime}>{time}</td>
       <td className={styles.occurrenceVenue}>{occurrence.venue.name}</td>
       <td className={styles.remainingCapacity}>
-        {occurrence?.remainingCapacity}
+        {hasCapacity
+          ? occurrence?.remainingCapacity
+          : t('event.register.occurrenceTableBody.full')}
       </td>
       <td className={styles.occurrenceSubmit}>
         {

--- a/src/domain/event/EventOccurrenceNotificationControlButton.tsx
+++ b/src/domain/event/EventOccurrenceNotificationControlButton.tsx
@@ -30,7 +30,7 @@ const EventNotificationControlButton = ({
   subscribeLabel,
   unsubscribeLabel,
 }: Props) => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [unsubscribe] = useUnsubscribeFromFreeSpotNotificationMutation(
     eventId,
     childId

--- a/src/domain/event/EventOccurrenceNotificationControlButton.tsx
+++ b/src/domain/event/EventOccurrenceNotificationControlButton.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+
+import Button from '../../common/components/button/Button';
+import EventNotificationSubscriptionModal, {
+  Occurrence,
+} from './EventNotificationSubscriptionModal';
+import useUnsubscribeFromFreeSpotNotificationMutation from './useUnsubscribeFromFreeSpotNotificationMutation';
+import styles from './eventOccurrenceNotificationControlButton.module.css';
+
+type Props = {
+  childId: string;
+  eventId: string;
+  isSubscribed: boolean;
+  occurrence: Occurrence;
+  onUnsubscribed?: () => void;
+  onSubscribe?: () => void;
+  onSubscribed?: () => void;
+  subscribeLabel: string;
+  unsubscribeLabel: string;
+};
+
+const EventNotificationControlButton = ({
+  childId,
+  eventId,
+  isSubscribed,
+  occurrence,
+  onUnsubscribed,
+  onSubscribe,
+  onSubscribed,
+  subscribeLabel,
+  unsubscribeLabel,
+}: Props) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [unsubscribe] = useUnsubscribeFromFreeSpotNotificationMutation(
+    eventId,
+    childId
+  );
+
+  const handleSubscribe = () => {
+    if (onSubscribe) {
+      onSubscribe();
+    }
+
+    setIsModalOpen(true);
+  };
+
+  const handleSubscribed = () => {
+    if (onSubscribed) {
+      onSubscribed();
+    }
+
+    setIsModalOpen(false);
+  };
+
+  const handleUnsubscribe = async () => {
+    try {
+      await unsubscribe({
+        variables: {
+          input: {
+            childId,
+            occurrenceId: occurrence.id,
+          },
+        },
+      });
+
+      if (onUnsubscribed) {
+        onUnsubscribed();
+      }
+    } catch (e) {
+      // Default error handling is toggled on in
+      // useUnsubscribeFromFreeSpotNotificationMutation
+    }
+  };
+
+  return (
+    <>
+      {!isSubscribed && (
+        <Button
+          variant="disabled"
+          onClick={handleSubscribe}
+          className={styles.button}
+        >
+          {subscribeLabel}
+        </Button>
+      )}
+      {isSubscribed && (
+        <Button
+          onClick={handleUnsubscribe}
+          variant="secondary"
+          className={styles.button}
+        >
+          {unsubscribeLabel}
+        </Button>
+      )}
+      <EventNotificationSubscriptionModal
+        childId={childId}
+        eventId={eventId}
+        eventOccurrence={occurrence}
+        isOpen={isModalOpen}
+        onSubscribed={handleSubscribed}
+        setIsOpen={setIsModalOpen}
+      />
+    </>
+  );
+};
+
+export default EventNotificationControlButton;

--- a/src/domain/event/__tests__/EventOccurrence.test.tsx
+++ b/src/domain/event/__tests__/EventOccurrence.test.tsx
@@ -44,36 +44,37 @@ it('renders button for signing up to an event', () => {
   expect(wrapper.text().includes('Valitse')).toEqual(true);
 });
 
-describe('when event is full and child has not subscribed to notifications', () => {
-  const getFullEventWrapper = () =>
+describe('when event is full', () => {
+  const getFullEventWrapper = (
+    childHasFreeSpotNotificationSubscription = false
+  ) =>
     getWrapper({
       occurrence: {
         ...mockedNode,
         remainingCapacity: 0,
-        childHasFreeSpotNotificationSubscription: false,
+        childHasFreeSpotNotificationSubscription,
       },
     });
 
-  it('renders button for subscribing', () => {
+  it('should show full label instead of remaining capacity', () => {
     const wrapper = getFullEventWrapper();
 
-    expect(wrapper.text().includes('Täynnä - Tilaa ilmoitus')).toEqual(true);
+    expect(wrapper.text().includes('TÄYNNÄ')).toEqual(true);
   });
-});
 
-describe('when event is full and child has not subscribed to notifications', () => {
-  const getFullEventWrapper = () =>
-    getWrapper({
-      occurrence: {
-        ...mockedNode,
-        remainingCapacity: 0,
-        childHasFreeSpotNotificationSubscription: true,
-      },
+  describe('and child has not subscribed to notifications', () => {
+    it('renders button for subscribing', () => {
+      const wrapper = getFullEventWrapper();
+
+      expect(wrapper.text().includes('Täynnä - Tilaa ilmoitus')).toEqual(true);
     });
+  });
 
-  it('renders button for subscribing', () => {
-    const wrapper = getFullEventWrapper();
+  describe('and child has not subscribed to notifications', () => {
+    it('renders button for subscribing', () => {
+      const wrapper = getFullEventWrapper(true);
 
-    expect(wrapper.text().includes('Peru ilmoitusten tilaus')).toEqual(true);
+      expect(wrapper.text().includes('Peru ilmoitusten tilaus')).toEqual(true);
+    });
   });
 });

--- a/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
@@ -1,137 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders snapshot correctly 1`] = `
-<table>
-  <tbody>
-    <EventOccurrence
-      key="T2NjdXJyZW5jZU5vZGU6Mg=="
-      occurrence={
-        Object {
-          "childHasFreeSpotNotificationSubscription": false,
-          "event": Object {
-            "id": "zzaaz",
-            "name": "event name",
-          },
-          "id": "T2NjdXJyZW5jZU5vZGU6Mg==",
-          "remainingCapacity": 99,
-          "time": "2020-03-08T04:00:00+00:00",
-          "venue": Object {
-            "address": "",
-            "id": "auppss",
-            "name": "Musiikkitalo",
-          },
-        }
-      }
-    >
+<div>
+  <table>
+    <tbody>
       <tr
-        className="occurrence"
+        class="occurrence"
       >
         <td
-          className="occurrenceDate"
+          class="occurrenceDate"
         >
           su 8.3.2020
         </td>
         <td
-          className="occurrenceTime"
+          class="occurrenceTime"
         >
           04:00
         </td>
         <td
-          className="occurrenceVenue"
+          class="occurrenceVenue"
         >
           Musiikkitalo
         </td>
         <td
-          className="remainingCapacity"
+          class="remainingCapacity"
         >
           99
         </td>
         <td
-          className="occurrenceSubmit"
+          class="occurrenceSubmit"
         >
-          <Link
-            className="linkButton"
-            to="zzaaz/occurrence/T2NjdXJyZW5jZU5vZGU6Mg==/enrol"
+          <a
+            class="linkButton"
+            href="/zzaaz/occurrence/T2NjdXJyZW5jZU5vZGU6Mg==/enrol"
           >
-            <LinkAnchor
-              className="linkButton"
-              href="/zzaaz/occurrence/T2NjdXJyZW5jZU5vZGU6Mg==/enrol"
-              navigate={[Function]}
+            <button
+              class="Button-module_button__3wgee button_hds-button__2A0je Button-module_primary__3bo_T button_hds-button--primary__2NVvO submitButton"
+              type="submit"
             >
-              <a
-                className="linkButton"
-                href="/zzaaz/occurrence/T2NjdXJyZW5jZU5vZGU6Mg==/enrol"
-                onClick={[Function]}
+              <span
+                class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
               >
-                <Button
-                  className="submitButton"
-                  type="submit"
-                >
-                  <ForwardRef
-                    className="submitButton"
-                    style={
-                      Object {
-                        "--background-color": "var(--color-summer)",
-                        "--background-color-focus": "var(--color-summer)",
-                        "--background-color-hover": "var(--color-summer-dark-50)",
-                        "--background-color-hover-focus": "var(--color-summer-dark-50)",
-                        "--background-selected": "var(--color-summer)",
-                        "--border-color": "var(--color-summer)",
-                        "--border-color-focus": "var(--color-summer-dark-50)",
-                        "--border-color-hover": "var(--color-summer-dark-50)",
-                        "--border-color-hover-focus": "var(--color-summer-dark-50)",
-                        "--border-color-selected": "var(--color-summer)",
-                        "--border-color-selected-focus": "var(--color-summer)",
-                        "--border-color-selected-hover": "var(--color-summer-dark-50)",
-                        "--border-color-selected-hover-focus": "var(--color-summer)",
-                        "--color": "var(--color-black)",
-                        "--color-focus": "var(--color-black-90)",
-                        "--color-hover": "var(--color-black)",
-                        "--color-hover-focus": "var(--color-black-90)",
-                      }
-                    }
-                    type="submit"
-                  >
-                    <button
-                      className="Button-module_button__3wgee button_hds-button__2A0je Button-module_primary__3bo_T button_hds-button--primary__2NVvO submitButton"
-                      disabled={false}
-                      style={
-                        Object {
-                          "--background-color": "var(--color-summer)",
-                          "--background-color-focus": "var(--color-summer)",
-                          "--background-color-hover": "var(--color-summer-dark-50)",
-                          "--background-color-hover-focus": "var(--color-summer-dark-50)",
-                          "--background-selected": "var(--color-summer)",
-                          "--border-color": "var(--color-summer)",
-                          "--border-color-focus": "var(--color-summer-dark-50)",
-                          "--border-color-hover": "var(--color-summer-dark-50)",
-                          "--border-color-hover-focus": "var(--color-summer-dark-50)",
-                          "--border-color-selected": "var(--color-summer)",
-                          "--border-color-selected-focus": "var(--color-summer)",
-                          "--border-color-selected-hover": "var(--color-summer-dark-50)",
-                          "--border-color-selected-hover-focus": "var(--color-summer)",
-                          "--color": "var(--color-black)",
-                          "--color-focus": "var(--color-black-90)",
-                          "--color-hover": "var(--color-black)",
-                          "--color-hover-focus": "var(--color-black-90)",
-                        }
-                      }
-                      type="submit"
-                    >
-                      <span
-                        className="Button-module_label__2zMLC button_hds-button__label__2EQa-"
-                      >
-                        Valitse
-                      </span>
-                    </button>
-                  </ForwardRef>
-                </Button>
-              </a>
-            </LinkAnchor>
-          </Link>
+                Valitse
+              </span>
+            </button>
+          </a>
         </td>
       </tr>
-    </EventOccurrence>
-  </tbody>
-</table>
+    </tbody>
+  </table>
+</div>
 `;

--- a/src/domain/event/enrol/Enrol.tsx
+++ b/src/domain/event/enrol/Enrol.tsx
@@ -6,36 +6,33 @@ import styles from './enrol.module.scss';
 import { occurrenceQuery_occurrence as OccurrenceType } from '../../api/generatedTypes/occurrenceQuery';
 import OccurrenceInfo from '../partial/OccurrenceInfo';
 import Button from '../../../common/components/button/Button';
-import EventNotificationSubscriptionModal from '../EventNotificationSubscriptionModal';
+import EventOccurrenceNotificationControlButton from '../EventOccurrenceNotificationControlButton';
 
 type Props = {
   childId: string;
-  isSubscriptionModalOpen: boolean;
   occurrence: OccurrenceType;
   onCancel: () => void;
   onEnrol: () => void;
-  onUnsubscribe: () => void;
-  onSubscribe: () => void;
-  onSubscribed: () => void;
-  setIsSubscriptionModalOpen: (isOpen: boolean) => void;
+  onUnsubscribed?: () => void;
+  onSubscribe?: () => void;
+  onSubscribed?: () => void;
 };
 
 const Enrol = ({
   childId,
-  isSubscriptionModalOpen,
   occurrence,
   onCancel,
   onEnrol,
-  onUnsubscribe,
+  onUnsubscribed,
   onSubscribe,
   onSubscribed,
-  setIsSubscriptionModalOpen,
 }: Props) => {
   const { t } = useTranslation();
 
   const isFull = occurrence.remainingCapacity === 0;
-  const isChildHasActiveSubscription =
-    occurrence.childHasFreeSpotNotificationSubscription;
+  const isChildHasActiveSubscription = Boolean(
+    occurrence.childHasFreeSpotNotificationSubscription
+  );
   const eventName = occurrence.event.name;
 
   return (
@@ -63,28 +60,28 @@ const Enrol = ({
               {t('enrollment.confirmationPage.confirm.button')}
             </Button>
           )}
-          {isFull && !isChildHasActiveSubscription && (
-            <Button variant="disabled" onClick={onSubscribe}>
-              {t('enrollment.button.occurrenceFullSubscribeToNotifications')}
-            </Button>
-          )}
-          {isFull && isChildHasActiveSubscription && (
-            <Button onClick={onUnsubscribe} variant="secondary">
-              {t('enrollment.button.cancelNotificationSubscription')}
-            </Button>
+          {isFull && (
+            <EventOccurrenceNotificationControlButton
+              childId={childId}
+              eventId={occurrence.event.id}
+              isSubscribed={isChildHasActiveSubscription}
+              occurrence={occurrence}
+              onUnsubscribed={onUnsubscribed}
+              onSubscribe={onSubscribe}
+              onSubscribed={onSubscribed}
+              unsubscribeLabel={t(
+                'enrollment.button.cancelNotificationSubscription'
+              )}
+              subscribeLabel={t(
+                'enrollment.button.occurrenceFullSubscribeToNotifications'
+              )}
+            />
           )}
           <Button onClick={onCancel} variant="secondary">
             {t('enrollment.confirmationPage.cancel.button')}
           </Button>
         </div>
       </div>
-      <EventNotificationSubscriptionModal
-        childId={childId}
-        eventOccurrence={occurrence}
-        isOpen={isSubscriptionModalOpen}
-        onSubscribed={onSubscribed}
-        setIsOpen={setIsSubscriptionModalOpen}
-      />
     </>
   );
 };

--- a/src/domain/event/enrol/EnrolConstants.ts
+++ b/src/domain/event/enrol/EnrolConstants.ts
@@ -1,5 +1,6 @@
 export const GQLErrors = Object.freeze({
   CHILD_ALREADY_JOINED_EVENT_ERROR: 'CHILD_ALREADY_JOINED_EVENT_ERROR',
+  OCCURRENCE_IS_FULL_ERROR: 'OCCURRENCE_IS_FULL_ERROR',
 } as const);
 
 export type GQLErrorsType = typeof GQLErrors[keyof typeof GQLErrors];

--- a/src/domain/event/enrol/EnrolPage.tsx
+++ b/src/domain/event/enrol/EnrolPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
@@ -23,7 +23,6 @@ import { childByIdQuery } from '../../child/queries/ChildQueries';
 import { saveChildEvents, justEnrolled } from '../state/EventActions';
 import ErrorMessage from '../../../common/components/error/Error';
 import { GQLErrors } from './EnrolConstants';
-import useUnsubscribeFromFreeSpotNotificationMutation from '../useUnsubscribeFromFreeSpotNotificationMutation';
 import Enrol from './Enrol';
 
 function containsAlreadyJoinedError(
@@ -48,16 +47,11 @@ const EnrolPage = () => {
   const history = useHistory();
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const [
-    isNotificationSubscriptionModalOpen,
-    setIsNotificationSubscriptionModalOpen,
-  ] = useState<boolean>(false);
   const params = useParams<{
     childId: string;
     eventId: string;
     occurrenceId: string;
   }>();
-  const [unsubscribe] = useUnsubscribeFromFreeSpotNotificationMutation();
   const { loading, error, data, refetch: refetchOccurrence } = useQuery<
     OccurrenceQueryType
   >(occurrenceQuery, {
@@ -156,23 +150,8 @@ const EnrolPage = () => {
     history.push(`/profile/child/${params.childId}/event/${params.eventId}`);
   };
 
-  const handleSubscriptionStart = () => {
-    setIsNotificationSubscriptionModalOpen(true);
-  };
-
-  const handleUnsubscribe = async () => {
-    const { errors } = await unsubscribe({
-      variables: {
-        input: {
-          childId: params.childId,
-          occurrenceId: data?.occurrence?.id,
-        },
-      },
-    });
-
-    if (!errors) {
-      goToEvent();
-    }
+  const handleUnsubscribed = async () => {
+    goToEvent();
   };
 
   return (
@@ -182,15 +161,12 @@ const EnrolPage = () => {
       title={'Enrol'}
     >
       <Enrol
-        isSubscriptionModalOpen={isNotificationSubscriptionModalOpen}
         childId={params.childId}
         occurrence={data.occurrence}
         onCancel={() => history.goBack()}
         onEnrol={() => enrol()}
-        onUnsubscribe={handleUnsubscribe}
-        onSubscribe={handleSubscriptionStart}
+        onUnsubscribed={handleUnsubscribed}
         onSubscribed={() => goToEvent()}
-        setIsSubscriptionModalOpen={setIsNotificationSubscriptionModalOpen}
       />
     </PageWrapper>
   );

--- a/src/domain/event/enrol/__tests__/Enrol.test.tsx
+++ b/src/domain/event/enrol/__tests__/Enrol.test.tsx
@@ -110,7 +110,7 @@ describe('<Enrol />', () => {
       expect(
         queryByText(
           // eslint-disable-next-line max-len
-          'Valitettavasti tämä tapahtuma on täynnä. Halutessasi voit tilata ilmoituksen paikkojen vapautumisesta!'
+          'Valitettavasti tämä tapahtuma on täynnä. Tilaa ilmoitus vapautuvista paikoista.'
         )
       ).not.toEqual(null);
     });

--- a/src/domain/event/eventOccurrence.module.scss
+++ b/src/domain/event/eventOccurrence.module.scss
@@ -21,7 +21,9 @@ tr {
   td {
     padding: $basePadding 0;
     &.occurrenceSubmit {
-      min-width: 7rem;
+      // Needs to be wide enough to facilitate the widest possible,
+      // button label in each language
+      min-width: 17rem;
     }
     &.remainingCapacity {
       text-align: center;

--- a/src/domain/event/eventOccurrenceNotificationControlButton.module.css
+++ b/src/domain/event/eventOccurrenceNotificationControlButton.module.css
@@ -1,0 +1,3 @@
+.button {
+  width: 100%;
+}

--- a/src/domain/event/useSubscribeToFreeSpotNotificationMutation.tsx
+++ b/src/domain/event/useSubscribeToFreeSpotNotificationMutation.tsx
@@ -2,12 +2,25 @@ import subscribeToFreeSpotNotificationMutation from './mutations/subscribeToFree
 // eslint-disable-next-line max-len
 import { subscribeToFreeSpotNotificationMutation as SubscribeToFreeSpotNotificationMutation } from '../api/generatedTypes/subscribeToFreeSpotNotificationMutation';
 import useMutation from '../api/useMutation';
+import eventQuery from './queries/eventQuery';
 
-function useSubscribeToFreeSpotNotificationMutation() {
+function useSubscribeToFreeSpotNotificationMutation(
+  eventId: string,
+  childId: string
+) {
   return useMutation<SubscribeToFreeSpotNotificationMutation>(
     subscribeToFreeSpotNotificationMutation,
     {
       useDefaultErrorHandling: true,
+      refetchQueries: [
+        {
+          query: eventQuery,
+          variables: {
+            id: eventId,
+            childId,
+          },
+        },
+      ],
     }
   );
 }

--- a/src/domain/event/useUnsubscribeFromFreeSpotNotificationMutation.ts
+++ b/src/domain/event/useUnsubscribeFromFreeSpotNotificationMutation.ts
@@ -2,12 +2,25 @@ import UnsubscribeFromFreeSpotNotificationMutation from './mutations/unsubscribe
 // eslint-disable-next-line max-len
 import { unsubscribeFromFreeSpotNotificationMutation } from '../api/generatedTypes/unsubscribeFromFreeSpotNotificationMutation';
 import useMutation from '../api/useMutation';
+import eventQuery from './queries/eventQuery';
 
-function useUnsubscribeFromFreeSpotNotificationMutation() {
+function useUnsubscribeFromFreeSpotNotificationMutation(
+  eventId: string,
+  childId: string
+) {
   return useMutation<unsubscribeFromFreeSpotNotificationMutation>(
     UnsubscribeFromFreeSpotNotificationMutation,
     {
       useDefaultErrorHandling: true,
+      refetchQueries: [
+        {
+          query: eventQuery,
+          variables: {
+            id: eventId,
+            childId,
+          },
+        },
+      ],
     }
   );
 }


### PR DESCRIPTION
## Description

This PR contains code changes which try to generalise the notification control button enough so that it can be shared between the enrolment and occurrence list pages. Currently the component contains the subscription, unsubscription and subscription confirmation modal components. Depending on the status of the user's subscription, one of the two buttons is shown. Because the confirmation modal should always be shown when subscribing, I thought that it'd be convenient to also include it into this component. The downside is that the modal is declared multiple times, although that shouldn't be a huge caveat.

I also refactored the tests I previously implemented tests with `enzyme` that I now replaced with `testing-library`, because `enzyme` is inconvenient for integration level test cases.

## Context

In this PR I make fixes to the behaviour of the KK-513 PR which
* Fix issues that were noted during review
* Address KK-560

**Issues noticed during review**
The occurrence listing page had a few design details which were wrong
* When an occurrence is full, the number in the "free places" column should be replaced with the text "FULL" (_see figure 1_)
* The button for subscribing should not contain the information about the events capacity status. E.g., instead of the label "Full - Subscribe to notifications", the button should be labeled "Subscribe to notifications" (_see figure 2_)
* When subscribing from the occurrence list view, no confirmation modal was shown to the user (_see figure 3_)

**KK-560**
This PR also handles KK-560. The ticket in question was tracked in order to ensure that the user experience when trying to enrol into a full event is optimised. Previously the user was shown a generic error message and they weren't able to recover from the error.

Now the user no longer sees a generic error message. Instead the page (enrolment page, figure 5) is refreshed, in which case it will update to reflect that the event has become full. This can occur when the event becomes full between the time the page has loaded and the user finishes the enrolment procedure.

[KK-560](https://helsinkisolutionoffice.atlassian.net/browse/KK-560)
[KK-513](https://helsinkisolutionoffice.atlassian.net/browse/KK-513)

## How Has This Been Tested?

I've extended the existing test cases to cover the user flow into the phase after which they toggle on the modal.

## Manual Testing Instructions for Reviewers

As a logged in user with an existing child

1. Clicks on child
2. Select "Upouusi tapahtuma" (one occurrence should be full, this may change as people play with the data)
    a. Observe that instead of 0 free places you see "FULL". Observer that
    b. Observe that instead the button label does not contain the word "Full"
3. Click on "Subscribe to notifications"
    a. Expect a confirmation dialog to show
    b. Expect for it to fill criteria for accessibility
4. On confirmation modal, click subscribe
   a. Expect for modal to close
   b. Expect notification subscription button to change into unsubscription button
5. Click on unsubscription button
   a. Expect button to change into subscribe button

KK-560 can't be conveniently tested without access to the admin and therefore I won't provide instructions. As general context, the tested has to access the enrolment page for an occurrence, do nothing there, go to the admin and set the capacity override so that the occurrence becomes full, and then enrol.

## Screenshots

<img width="975" alt="Screenshot 2020-10-02 at 9 07 47" src="https://user-images.githubusercontent.com/9090689/94892985-c8765f00-048e-11eb-949d-f3c020665d2a.png">

_Figure 1_

<img width="975" alt="Screenshot 2020-10-02 at 9 09 57" src="https://user-images.githubusercontent.com/9090689/94893119-14c19f00-048f-11eb-9db9-8a4b247b271c.png">

_Figure 2_

<img width="1043" alt="Screenshot 2020-10-02 at 9 12 15" src="https://user-images.githubusercontent.com/9090689/94893246-636f3900-048f-11eb-96b6-5b01afe07650.png">

_Figure 3_
