### PR TITLE
KK-585 | Handle unhandled error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Show no other button than log out for logged in unregistered users
 - Update accessibility statement
 - Show events as upcoming events also for a while after they have started
+- No longer display an error when a user subscribes to notifications for an occurrence they have already subscribed to, instead refresh the page to fetch current most data
+- Display a more specific error message when a user subscribes to notification for an occurrence which has available capacity
 
 ### Fixed
 

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -158,6 +158,7 @@
     },
     "enroll": {
       "error": {
+        "capacityHasChanged": "The available capacity of the event has changed. Please refresh your browser.",
         "childAlreadyJoined": "This child has already been enrolled in this event."
       },
       "buttonText": "Register for event"

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -158,6 +158,7 @@
     },
     "enroll": {
       "error": {
+        "capacityHasChanged": "Tapahtuman vapaa kapasiteetti on muuttunut. Ole hyvä ja päivitä tämä sivu.",
         "childAlreadyJoined": "Lapsi on jo ilmoittautunut tapahtumaan."
       },
       "buttonText": "Ilmoittaudu tapahtumaan"

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -158,6 +158,7 @@
     },
     "enroll": {
       "error": {
+        "capacityHasChanged": "Evenemangets kapacitet har förändrats. Uppdatera din webbläsare.",
         "childAlreadyJoined": "Detta barn har redan anmält sig till detta evenemang."
       },
       "buttonText": "Anmäl dig till evenemanget"

--- a/src/domain/api/useDefaultErrorHandler.ts
+++ b/src/domain/api/useDefaultErrorHandler.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+import * as Sentry from '@sentry/browser';
+import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
+
+function useDefaultErrorHandler() {
+  const { t } = useTranslation();
+
+  const defaultErrorHandler = useCallback(
+    (error: Error) => {
+      toast.error(t('api.errorMessage'));
+      Sentry.captureException(error);
+    },
+    [t]
+  );
+
+  return defaultErrorHandler;
+}
+
+export default useDefaultErrorHandler;

--- a/src/domain/api/utils/getIsError.ts
+++ b/src/domain/api/utils/getIsError.ts
@@ -1,0 +1,7 @@
+import { GraphQLError } from 'graphql';
+
+function getIsError(graphQLError: GraphQLError, errorType: string): boolean {
+  return graphQLError.extensions?.code === errorType;
+}
+
+export default getIsError;

--- a/src/domain/event/EventConstants.ts
+++ b/src/domain/event/EventConstants.ts
@@ -1,0 +1,7 @@
+export const SubscribeToFreeSpotNotificationGQLErrors = Object.freeze({
+  ALREADY_SUBSCRIBED_ERROR: 'ALREADY_SUBSCRIBED_ERROR',
+  OCCURRENCE_IS_NOT_FULL_ERROR: 'OCCURRENCE_IS_NOT_FULL_ERROR',
+} as const);
+
+// eslint-disable-next-line max-len
+export type SubscribeToFreeSpotNotificationGQLErrorsType = typeof SubscribeToFreeSpotNotificationGQLErrors[keyof typeof SubscribeToFreeSpotNotificationGQLErrors];

--- a/src/domain/event/useSubscribeToFreeSpotNotificationMutation.tsx
+++ b/src/domain/event/useSubscribeToFreeSpotNotificationMutation.tsx
@@ -1,13 +1,25 @@
+import { ApolloError } from '@apollo/client';
+import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router';
+
 import subscribeToFreeSpotNotificationMutation from './mutations/subscribeToFreeSpotNotificationMutation';
 // eslint-disable-next-line max-len
 import { subscribeToFreeSpotNotificationMutation as SubscribeToFreeSpotNotificationMutation } from '../api/generatedTypes/subscribeToFreeSpotNotificationMutation';
 import useMutation from '../api/useMutation';
+import useDefaultErrorHandler from '../api/useDefaultErrorHandler';
+import getIsError from '../api/utils/getIsError';
 import eventQuery from './queries/eventQuery';
+import { SubscribeToFreeSpotNotificationGQLErrors } from './EventConstants';
 
 function useSubscribeToFreeSpotNotificationMutation(
   eventId: string,
   childId: string
 ) {
+  const defaultErrorHandler = useDefaultErrorHandler();
+  const { t } = useTranslation();
+  const history = useHistory();
+
   return useMutation<SubscribeToFreeSpotNotificationMutation>(
     subscribeToFreeSpotNotificationMutation,
     {
@@ -21,6 +33,30 @@ function useSubscribeToFreeSpotNotificationMutation(
           },
         },
       ],
+      onError: (error: ApolloError) => {
+        error.graphQLErrors?.forEach((graphQLError) => {
+          if (
+            getIsError(
+              graphQLError,
+              SubscribeToFreeSpotNotificationGQLErrors.ALREADY_SUBSCRIBED_ERROR
+            )
+          ) {
+            // Reload in order to refresh page data. The current page is
+            // likely just out of date. After a refresh, the user should
+            // see an UI which reflects the correct subscription status.
+            history.go(0);
+          } else if (
+            getIsError(
+              graphQLError,
+              SubscribeToFreeSpotNotificationGQLErrors.OCCURRENCE_IS_NOT_FULL_ERROR
+            )
+          ) {
+            toast.error(t('enrollment.enroll.error.capacityHasChanged'));
+          } else {
+            defaultErrorHandler(error);
+          }
+        });
+      },
     }
   );
 }


### PR DESCRIPTION
## Description

Previously two error messages were not handled for subscriptions: `ALREADY_SUBSCRIBED_ERROR` and `OCCURRENCE_IS_NOT_FULL_ERROR`. This PR add error handling logic which should help the user recover from these errors.

## Context

After this change users facing the `ALREADY_SUBSCRIBED_ERROR` no longer see a generic error message. Instead the page is refreshed which should update stale data and show, that what they want, to subscribe to notifications, is already taking place. In other words we don't directly inform the user about the error at all.

`OCCURRENCE_IS_NOT_FULL_ERROR` can take place when the user attempts to subscribe to notifications for an event that has free places left. This can potentially happen when user 1 loads the page and leaves it open for a while, and in the meanwhile user 2 cancels their enrolment. In these instances we show an error message that informs the user about a changed capacity.

[KK-585](https://helsinkisolutionoffice.atlassian.net/browse/KK-585)

## How Has This Been Tested?

I've tested this by hand. Testing this with automated tests would require mocking the GraphQL API which isn not ideal.

## Manual Testing Instructions for Reviewers

_As a user subscribing to notifications of an occurrence I have already subscribed to, I do not want to see an error message, because everything is as I want it to be._

1. As a registered logged in user in your god children profile
2. Select a child
3. Select an event
4. Ensure that there's a full occurrence you can subscribe to 
     - if there are no full occurrences, change capacity from admin, or subscribe with another account first
6. Open the same view in another tab
7. Click on the subscribe to notification button
8. Go to second tab and click on the subscribe to notifications button
9. Expect no error to be shown and the button to change, reflecting the fact that you are subscribed

_As a user subscribing to notifications of an occurrence that's no longer full, I want to be informed that I can possibly sign up for the occurrence._

1. As a registered logged in user in your god children profile
3. Select a child
5. Select an event
7. Ensure that there's a full occurrence 
    - if there are no full occurrences, change capacity from admin, or subscribe with another account first
11. Change capacity from admin, or unsubscribe with another account
12. Click the subscribe to notifications button
13. Expect to see an error that guides the user to refresh the page