### PR TITLE
KK-586 | Fix users being asked for their child's birthday twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Postal code validation
 - Crashes on iPhones with iOS version older than 11.3
 - Can not read property year of undefined error
+- User being asked child's birthday twice while registering
 
 # 1.4.0
 

--- a/src/domain/app/header/userDropdown/UserDropdown.tsx
+++ b/src/domain/app/header/userDropdown/UserDropdown.tsx
@@ -44,7 +44,12 @@ const UserDropdown = ({ isSmallScreen }: UserDropdownProps) => {
   const isAuthenticated = useSelector(isAuthenticatedSelector);
   const doLogout = useLogout();
 
-  const { loading, data } = useProfile();
+  // Skip the redirect to the short registration form when using profile
+  // here. Because the menu is used on all pages, it's difficult to
+  // control redirects. Previously this hook call would redirect users
+  // away from the registration form, which is a page where we do not
+  // want to for this check to take place.
+  const { loading, data } = useProfile(true);
   const { trackEvent } = useMatomo();
 
   if (loading) return <></>;

--- a/src/domain/profile/hooks/useProfile.ts
+++ b/src/domain/profile/hooks/useProfile.ts
@@ -21,7 +21,7 @@ export type ProfileQueryResult = Omit<
   data: Profile | null | undefined;
 };
 
-function useProfile(): ProfileQueryResult {
+function useProfile(skipRedirect = false): ProfileQueryResult {
   const { i18n } = useTranslation();
   const history = useHistory();
   const dispatch = useDispatch();
@@ -45,7 +45,7 @@ function useProfile(): ProfileQueryResult {
       // This query should be skipped when the user is not
       // authenticated. However, it seems that this does not always
       // hold and we have to check authentication again in the callback.
-      if (isAuthenticated && !data?.myProfile) {
+      if (!skipRedirect && isAuthenticated && !data?.myProfile) {
         history.replace(`/${i18n.language}/home#register`);
       }
     },


### PR DESCRIPTION
## Description

In these changes I add a skip condition to the `useProfile` hook. This is then used in the `UserDropdown` to stop uses of this hook from resulting in redirects. The idea is that this component already knows how to render itself in each profile condition--it does not need the profile to function. Instead, other calls of this hook which do require the profile are given the responsibility to cause a redirect.

## Context

This resolves the root cause of the fixed bug as well--user's are no longer redirected away from the `registration/form` page. Previously the `useProfile` call in the menu could cause for this to happen depending on the order in which calls finished.

[KK-586](https://helsinkisolutionoffice.atlassian.net/browse/KK-586)

## How Has This Been Tested?

I've tested this manually in order to avoid mocking the API. This is a good test candidate for e2e tests. [KK-591](https://helsinkisolutionoffice.atlassian.net/browse/KK-591)

## Manual Testing Instructions for Reviewers
On the home page without logging in or a registered account.

1. Click the "Register" button
2. Expect to be taken to the "short" form where you must provide your child's birthday and city
3. Authenticate at Tunnistamo
4. Expect to be redirected to the long registration form
