### PR TITLE
KK-601 | Fix back to event selection button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Crashes on iPhones with iOS version older than 11.3
 - Can not read property year of undefined error
 - User being asked child's birthday twice while registering
+- Back to event selection button not working when accessing the enrolment confirmation page through an invitation link
 
 # 1.4.0
 

--- a/src/domain/event/enrol/EnrolPage.tsx
+++ b/src/domain/event/enrol/EnrolPage.tsx
@@ -45,7 +45,10 @@ function containsOccurrenceFullError(
 
 const EnrolPage = () => {
   const history = useHistory();
-  const { t } = useTranslation();
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
   const dispatch = useDispatch();
   const params = useParams<{
     childId: string;
@@ -63,7 +66,7 @@ const EnrolPage = () => {
 
   const goToOccurrence = () =>
     history.replace(
-      `/profile/child/${params.childId}/occurrence/${data?.occurrence?.id}`
+      `/${language}/profile/child/${params.childId}/occurrence/${data?.occurrence?.id}`
     );
 
   // If redirect to /profile, need to do refetchquery
@@ -147,7 +150,9 @@ const EnrolPage = () => {
   };
 
   const goToEvent = () => {
-    history.push(`/profile/child/${params.childId}/event/${params.eventId}`);
+    history.push(
+      `/${language}/profile/child/${params.childId}/event/${params.eventId}`
+    );
   };
 
   const handleUnsubscribed = async () => {

--- a/src/domain/event/enrol/EnrolPage.tsx
+++ b/src/domain/event/enrol/EnrolPage.tsx
@@ -163,7 +163,7 @@ const EnrolPage = () => {
       <Enrol
         childId={params.childId}
         occurrence={data.occurrence}
-        onCancel={() => history.goBack()}
+        onCancel={() => goToEvent()}
         onEnrol={() => enrol()}
         onUnsubscribed={handleUnsubscribed}
         onSubscribed={() => goToEvent()}


### PR DESCRIPTION
## Description

In these changes we start to use a specific URL when we direct users back to event selection (occurrence list page). We also change the redirection urls from language naive to language aware versions, which allows us to avoid doing unnecessary redirects, which cause the UI to feel slow.

## Context

When the user accessed the enrolment confirmation view through an email invitation link and chose to back to event selection, they would be thrown out of the application entirely. This was because the back to event selection button used `history.goBack` instead of the event page url.

[KK-601](https://helsinkisolutionoffice.atlassian.net/browse/kk-601)

## How Has This Been Tested?

This has been tested manually by opening the enrolment confirmation page in place of an unrelated tab, pressing the back to event selection button, and observing that the user was taken back to event selection.

I have also tested that the redirection to the view of the occurrence after a successful enrolment works.

## Manual Testing Instructions for Reviewers

As a user who has been invited to an event

1. Click the invitation link from your email
2. In the enrolment confirmation view, click go back to event list
3. Expect to be taken back to the occurrence list
