### PR TITLE
Add more context to "No matching state" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# [Unreleased]
+
+### Added
+
+- More context information to "No matching state found" error
+
 # 1.5.0
 
 ### Added


### PR DESCRIPTION
## Description

This change adds contextual data to Sentry error capture. It stores a boolean value into Sentry that describes whether the user is already logged in.

## Context

This data will allow us to test our hypothesis for why Sentry captures so many "State not found errors". These errors happen when users access the `/callback` view with a `state` parameter that doesn't point into an oidc object in local storage.

Our null hypothesis (H<sub>0</sub>) is that the mean of signed users receiving this error is less or equal to mean of the amount of non-signed in users who receive it.

Our alternative hypothesis (H<sub>a</sub>) is that the mean of signed in users receiving this error is greater than the mean of non-signed in users who receive it.

We will compare the means without any rigorous application of statistics and will rather use intuition and visualisations. We will let data accumulate for an unknown amount of time from a few weeks to a month.

If H<sub>a</sub> is true, we ca argue that the error has its root in the interaction design. For instance, the user may not understand that they are signed in, they may have attempted to change the account they have signed in with, and so on. in this scenario we have to put more effort into finding the problematic interaction and address it. Note that some cases may still remain which are not covered by this interaction.

 If H<sub>0</sub> is true, we have to find another hypothesis to test as the hypothesis does not cover enough cases to warrant the expense of resources.

Sentry issue [\#9987](https://sentry.hel.ninja/aok/kukkuu-ui/issues/9987/)