### PR TITLE
KK-606 | Hide clear all button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - More context information to "No matching state found" error
 
+### Changed
+
+- Hide clear all button from languages spoken at home
+
 # 1.5.0
 
 ### Added

--- a/src/domain/languages/LanguagesCombobox.tsx
+++ b/src/domain/languages/LanguagesCombobox.tsx
@@ -24,7 +24,7 @@ const LanguagesCombobox = (props: Props) => {
     return <LoadingSpinner isLoading={true} />;
   }
 
-  return <Combobox {...props} options={languageOptions} />;
+  return <Combobox {...props} clearable={false} options={languageOptions} />;
 };
 
 export default LanguagesCombobox;


### PR DESCRIPTION
## Description

Hides the "clear" button from the language spoken at home select in the profile update dialog and registration view.

## Context

The "clear" button is superfluous because users will likely never select so many options that it'd be helpful.

[KK-606](https://helsinkisolutionoffice.atlassian.net/browse/KK-606)

## How Has This Been Tested?

I've checked that the clear all button was no longer shown in the profile edit modal.

## Manual Testing Instructions for Reviewers

As a signed in user in your profile view

1. Click edit profile
1. If you do not have languages spoken at home selected, select one
1. Expect to not see an "x" button for clearing all options