### PR TITLE
KK-658 | Hide city input when editing a child

### DIFF
--- a/src/domain/child/form/ChildForm.tsx
+++ b/src/domain/child/form/ChildForm.tsx
@@ -119,12 +119,7 @@ const ChildForm: FunctionComponent<ChildFormProps> = ({
       validationSchema={schema}
       onSubmit={onFormSubmit}
     >
-      {({
-        isSubmitting,
-        values,
-        errors,
-        touched,
-      }: FormikProps<ChildFormValues>) => (
+      {({ isSubmitting, values }: FormikProps<ChildFormValues>) => (
         <Form id="childForm" noValidate>
           he
           <FieldArray
@@ -141,15 +136,17 @@ const ChildForm: FunctionComponent<ChildFormProps> = ({
             }}
           />
           <div className={styles.childInfo}>
-            <FormikTextInput
-              id="homeCity"
-              name="homeCity"
-              label={t('homePage.preliminaryForm.childHomeCity.input.label')}
-              required={true}
-              placeholder={t(
-                'homePage.preliminaryForm.childHomeCity.input.placeholder'
-              )}
-            />
+            {!isEditForm && (
+              <FormikTextInput
+                id="homeCity"
+                name="homeCity"
+                label={t('homePage.preliminaryForm.childHomeCity.input.label')}
+                required={true}
+                placeholder={t(
+                  'homePage.preliminaryForm.childHomeCity.input.placeholder'
+                )}
+              />
+            )}
             <FormikTextInput
               className={styles.formField}
               id="postalCode"

--- a/src/domain/child/form/__tests__/ChildForm.test.jsx
+++ b/src/domain/child/form/__tests__/ChildForm.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { render } from '../../../../common/test/testingLibraryUtils';
-import ChildForm from '../ChildForm';
+import ChildForm, { CHILD_FORM_TYPES } from '../ChildForm';
 
 const defaultProps = {
   initialValues: {},
@@ -10,6 +10,14 @@ const getWrapper = (props) =>
   render(<ChildForm {...defaultProps} {...props} />);
 
 describe('<ChildForm />', () => {
+  it('as a user I do not want to see the city control when editing', () => {
+    const { queryByLabelText } = getWrapper({
+      formType: CHILD_FORM_TYPES.EDIT,
+    });
+
+    expect(queryByLabelText('Lapsen kotipaikkakunta')).toBeFalsy();
+  });
+
   describe('implementation details', () => {
     it('the form should have the noValidate prop so that browser validation is not used', () => {
       const { container } = getWrapper();


### PR DESCRIPTION
## Description

Hides the city input when editing a child.

## Context

[KK-658](https://helsinkisolutionoffice.atlassian.net/browse/KK-658)

## How Has This Been Tested?

I've added a unit test that checks the omission of the field.

## Manual Testing Instructions for Reviewers

As a logged in user

1. Navigate to one of your children
1. Click the edit information button
1. Expect not to see the city control
