### PR TITLE
KK-661 | Do not browser validate child form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Hide clear all button from languages spoken at home
+- Child forms are no longer validate with browser validation
 
 ### Fixed
 

--- a/src/domain/child/form/ChildForm.tsx
+++ b/src/domain/child/form/ChildForm.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Formik, FieldArray, FormikErrors, FormikProps } from 'formik';
+import { Formik, FieldArray, FormikErrors, FormikProps, Form } from 'formik';
 import { useTranslation } from 'react-i18next';
 import classnames from 'classnames';
 import * as yup from 'yup';
@@ -121,12 +121,12 @@ const ChildForm: FunctionComponent<ChildFormProps> = ({
     >
       {({
         isSubmitting,
-        handleSubmit,
         values,
         errors,
         touched,
       }: FormikProps<ChildFormValues>) => (
-        <form onSubmit={handleSubmit} id="childForm">
+        <Form id="childForm" noValidate>
+          he
           <FieldArray
             name="birthdate"
             render={(props) => {
@@ -229,7 +229,7 @@ const ChildForm: FunctionComponent<ChildFormProps> = ({
               {t('profile.child.detail.delete.text')}
             </Button>
           )}
-        </form>
+        </Form>
       )}
     </Formik>
   );

--- a/src/domain/child/form/__tests__/ChildForm.test.jsx
+++ b/src/domain/child/form/__tests__/ChildForm.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { render } from '../../../../common/test/testingLibraryUtils';
+import ChildForm from '../ChildForm';
+
+const defaultProps = {
+  initialValues: {},
+};
+const getWrapper = (props) =>
+  render(<ChildForm {...defaultProps} {...props} />);
+
+describe('<ChildForm />', () => {
+  describe('implementation details', () => {
+    it('the form should have the noValidate prop so that browser validation is not used', () => {
+      const { container } = getWrapper();
+
+      expect(container.querySelector('#childForm').noValidate).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds the `noValidate` attribute to the child form. This ignores browser validation so that it doesn't block our custom validation.

I also refactored the view to use `<Form />` from `formik` which automatically binds the `onSubmit` and `onReset` events.

## Context

[KK-661](https://helsinkisolutionoffice.atlassian.net/browse/KK-661)

## How Has This Been Tested?

I've tested this manually. I don't think that a meaningful test can be written to check the actual user interaction. Instead I tested that the child's form element has `noValidate` set to `true`.

## Manual Testing Instructions for Reviewers

As a logged in user

1. Click add a new child
1. Fill a the birthday 02-02-2010
1. Fill other required fields
1. Submit
1. Expect to see a view where you are being told that your child is not eligible
