### PR TITLE
KK-660 | Add temporary link for giving feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - More context information to "No matching state found" error
+- Temporary link for giving feedback
 
 ### Changed
 

--- a/browser-tests/utils/settings.ts
+++ b/browser-tests/utils/settings.ts
@@ -18,4 +18,4 @@ export const testUsername = (): string =>
 export const testUserPassword = (): string =>
   getEnvOrError('BROWSER_TESTS_USER_PASSWORD');
 
-export const envUrl = (): string => getEnvOrError('BROWSER_ENV_URL');
+export const envUrl = (): string => getEnvOrError('BROWSER_TESTS_ENV_URL');

--- a/src/common/components/giveFeedbackButton/GiveFeedbackButton.tsx
+++ b/src/common/components/giveFeedbackButton/GiveFeedbackButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import 'hds-core/lib/components/button/button.css';
+
+import styles from './giveFeedbackButton.module.scss';
+
+const feedbackFormLink =
+  // eslint-disable-next-line max-len
+  'https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Kulttuurin+kummilapset';
+
+const buttonClassName = [
+  'hds-button',
+  'hds-button--secondary',
+  'hds-button__label',
+  'hds-button--theme-black',
+  styles.buttonLink,
+].join(' ');
+
+const GiveFeedbackButton = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.container}>
+      <a href={feedbackFormLink} className={buttonClassName}>
+        {t('feedback.giveFeedback.label')}
+      </a>
+    </div>
+  );
+};
+
+export default GiveFeedbackButton;

--- a/src/common/components/giveFeedbackButton/GiveFeedbackButton.tsx
+++ b/src/common/components/giveFeedbackButton/GiveFeedbackButton.tsx
@@ -4,10 +4,6 @@ import 'hds-core/lib/components/button/button.css';
 
 import styles from './giveFeedbackButton.module.scss';
 
-const feedbackFormLink =
-  // eslint-disable-next-line max-len
-  'https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Kulttuurin+kummilapset';
-
 const buttonClassName = [
   'hds-button',
   'hds-button--secondary',
@@ -21,7 +17,7 @@ const GiveFeedbackButton = () => {
 
   return (
     <div className={styles.container}>
-      <a href={feedbackFormLink} className={buttonClassName}>
+      <a href={t('feedback.giveFeedback.link')} className={buttonClassName}>
         {t('feedback.giveFeedback.label')}
       </a>
     </div>

--- a/src/common/components/giveFeedbackButton/giveFeedbackButton.module.scss
+++ b/src/common/components/giveFeedbackButton/giveFeedbackButton.module.scss
@@ -1,0 +1,13 @@
+@import 'styles/variables';
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: $spacing-layout-l;
+}
+
+.buttonLink {
+  text-decoration: none;
+  align-self: center;
+}

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -624,7 +624,8 @@
   },
   "feedback": {
     "giveFeedback": {
-      "label": "Give feedback of the Culture Kids service"
+      "label": "Give feedback of the Culture Kids service",
+      "link": "https://docs.google.com/forms/d/e/1FAIpQLSfpPCeAdiT9pcMRazxqA9DW-mbqoN2kNwaV53XydjzHWdyFKw/viewform?usp=pp_url&entry.1982410290=Kulttuurin%20kummilapset"
     }
   }
 }

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -621,5 +621,10 @@
       "title": "Oops!",
       "description": "It seems like you have registered to the service using another login method. Please log out of the service and try a different login method."
     }
+  },
+  "feedback": {
+    "giveFeedback": {
+      "label": "Give feedback of the Culture Kids service"
+    }
   }
 }

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -624,7 +624,8 @@
   },
   "feedback": {
     "giveFeedback": {
-      "label": "Anna palautetta Kulttuurin kummilapset -palvelusta"
+      "label": "Anna palautetta Kulttuurin kummilapset -palvelusta",
+      "link": "https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Kulttuurin+kummilapset"
     }
   }
 }

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -621,5 +621,10 @@
       "title": "Hupsista!",
       "description": "Vaikuttaisi siltä, että olet käyttänyt eri tunnistautumistapaa rekisteröityessäsi palveluun. Kirjaudu ulos palvelusta ja koita sitten kirjautua uudestaan käyttäen jotain toista tunnistautumistapaa."
     }
+  },
+  "feedback": {
+    "giveFeedback": {
+      "label": "Anna palautetta Kulttuurin kummilapset -palvelusta"
+    }
   }
 }

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -621,5 +621,10 @@
       "title": "Hoppsan!",
       "description": "Det verkar som om du har använt en annan autentiseringsmetod när du registrerar dig för tjänsten. Logga ut från tjänsten och försök sedan logga in igen med en annan autentiseringsmetod."
     }
+  },
+  "feedback": {
+    "giveFeedback": {
+      "label": "Ge respons om Kulturens fadderbarn tjänsten"
+    }
   }
 }

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -624,7 +624,8 @@
   },
   "feedback": {
     "giveFeedback": {
-      "label": "Ge respons om Kulturens fadderbarn tjänsten"
+      "label": "Ge respons om Kulturens fadderbarn tjänsten",
+      "link": "https://docs.google.com/forms/d/e/1FAIpQLSf0mf1gIUZ-k768RkOdBQm3bjp6TCDWQa1Wc1r_3WiYbDXLAA/viewform?usp=pp_url&entry.1982410290=Kulttuurin%20kummilapset"
     }
   }
 }

--- a/src/domain/profile/Profile.tsx
+++ b/src/domain/profile/Profile.tsx
@@ -5,18 +5,19 @@ import { Redirect } from 'react-router-dom';
 import * as Sentry from '@sentry/browser';
 import { IconCogwheel } from 'hds-react';
 
-import { clearProfile } from './state/ProfileActions';
-import useProfile from './hooks/useProfile';
 import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
-import ProfileChildrenList from './children/ProfileChildrenList';
-import PageWrapper from '../app/layout/PageWrapper';
-import styles from './profile.module.scss';
 import Icon from '../../common/components/icon/Icon';
-import phoneIcon from '../../assets/icons/svg/mobile.svg';
-import emailIcon from '../../assets/icons/svg/envelope.svg';
-import EditProfileModal from './modal/EditProfileModal';
 import ErrorMessage from '../../common/components/error/Error';
 import Button from '../../common/components/button/Button';
+import GiveFeedbackButton from '../../common/components/giveFeedbackButton/GiveFeedbackButton';
+import phoneIcon from '../../assets/icons/svg/mobile.svg';
+import emailIcon from '../../assets/icons/svg/envelope.svg';
+import PageWrapper from '../app/layout/PageWrapper';
+import { clearProfile } from './state/ProfileActions';
+import useProfile from './hooks/useProfile';
+import ProfileChildrenList from './children/ProfileChildrenList';
+import EditProfileModal from './modal/EditProfileModal';
+import styles from './profile.module.scss';
 
 const Profile = () => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -81,6 +82,7 @@ const Profile = () => {
             </div>
             <ProfileChildrenList />
           </div>
+          <GiveFeedbackButton />
         </div>
       </div>
     </PageWrapper>

--- a/src/domain/profile/children/child/ProfileChildDetail.tsx
+++ b/src/domain/profile/children/child/ProfileChildDetail.tsx
@@ -6,31 +6,33 @@ import { toast } from 'react-toastify';
 import * as Sentry from '@sentry/browser';
 import { IconCogwheel } from 'hds-react';
 
-import styles from './profileChildDetail.module.scss';
 import PageWrapper from '../../../app/layout/PageWrapper';
 import backIcon from '../../../../assets/icons/svg/arrowLeft.svg';
 import personIcon from '../../../../assets/icons/svg/person.svg';
 import childIcon from '../../../../assets/icons/svg/childFaceHappy.svg';
 import birthdateIcon from '../../../../assets/icons/svg/birthdayCake.svg';
 import Icon from '../../../../common/components/icon/Icon';
+import GiveFeedbackButton from '../../../../common/components/giveFeedbackButton/GiveFeedbackButton';
 import { formatTime, newMoment } from '../../../../common/time/utils';
 import { DEFAULT_DATE_FORMAT } from '../../../../common/time/TimeConstants';
-import useProfile from '../../hooks/useProfile';
-import ProfileEvents from '../../events/ProfileEvents';
-import ProfileChildDetailEditModal from './modal/ProfileChildDetailEditModal';
+import ErrorMessage from '../../../../common/components/error/Error';
+import Button from '../../../../common/components/button/Button';
 import { deleteChild_deleteChild as DeleteChildPayload } from '../../../api/generatedTypes/deleteChild';
 import { UpdateChildMutationInput as EditChildInput } from '../../../api/generatedTypes/globalTypes';
 import { updateChild_updateChild as EditChildPayload } from '../../../api/generatedTypes/updateChild';
+import { childByIdQuery as ChildByIdResponse } from '../../../api/generatedTypes/childByIdQuery';
+import { childByIdQuery } from '../../../child/queries/ChildQueries';
+import LoadingSpinner from '../../../../common/components/spinner/LoadingSpinner';
 import {
   deleteChildMutation,
   editChildMutation,
 } from '../../../child/mutation/ChildMutation';
+import useProfile from '../../hooks/useProfile';
+import ProfileEvents from '../../events/ProfileEvents';
 import profileQuery from '../../queries/ProfileQuery';
-import { childByIdQuery } from '../../../child/queries/ChildQueries';
-import LoadingSpinner from '../../../../common/components/spinner/LoadingSpinner';
-import { childByIdQuery as ChildByIdResponse } from '../../../api/generatedTypes/childByIdQuery';
-import ErrorMessage from '../../../../common/components/error/Error';
-import Button from '../../../../common/components/button/Button';
+import ProfileChildDetailEditModal from './modal/ProfileChildDetailEditModal';
+import styles from './profileChildDetail.module.scss';
+
 export type ChildDetailEditModalPayload = Omit<EditChildInput, 'id'>;
 
 const ProfileChildDetail = () => {
@@ -178,6 +180,7 @@ const ProfileChildDetail = () => {
               <p>{t('profile.children.noChild.text')}</p>
             </div>
           )}
+          <GiveFeedbackButton />
         </div>
       </div>
     </PageWrapper>


### PR DESCRIPTION
## Description

Adds a link to a feedback form that will be removed at some point. I needed to pull button styles from `hds-core` because I think that there's no link button in HDS.

## Context

[KK-660](https://helsinkisolutionoffice.atlassian.net/browse/KK-660)

## How Has This Been Tested?

I've tested this by hand.

## Manual Testing Instructions for Reviewers

Expect to see a link-button in profile and child profile pages

## Screenshots

<img width="1211" alt="Screenshot 2020-11-19 at 14 03 00" src="https://user-images.githubusercontent.com/9090689/99663890-fd0a9e00-2a6f-11eb-84ff-b2bc6ebfa5a7.png">
<img width="1211" alt="Screenshot 2020-11-19 at 14 03 09" src="https://user-images.githubusercontent.com/9090689/99663893-ff6cf800-2a6f-11eb-93ab-d4fc67858220.png">
