### PR TITLE
[develop] Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 # [Unreleased]
 
+# 1.6.0
+
 ### Added
 
-- Support for event groups
-- Logo of Kaapeli to the home page
+- [#330](https://github.com/City-of-Helsinki/kukkuu-ui/pull/330) Support for event groups
+- [#332](https://github.com/City-of-Helsinki/kukkuu-ui/pull/332) Logo of Kaapeli to the home page
 
 # 1.5.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kukkuu-ui",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "license": "MIT",
   "contributors": [
     "Bernt Andreas Drange",


### PR DESCRIPTION
# 1.6.0

### Added

- [#330](https://github.com/City-of-Helsinki/kukkuu-ui/pull/330) Support for event groups
- [#332](https://github.com/City-of-Helsinki/kukkuu-ui/pull/332) Logo of Kaapeli to the home page