### PR TITLE
Chore | Use GitHub flow instead of GitFlow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ master ]
   pull_request:
 
 jobs:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,8 +1,8 @@
 name: Build & Production
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'release-*'
 
 env:
   CONTAINER_REGISTRY: ghcr.io

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,7 +2,7 @@ name: Build & Staging
 on:
   push:
     branches:
-      - develop
+      - master
 
 env:
   CONTAINER_REGISTRY: ghcr.io

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ build-staging:
     DOCKER_BUILD_ARG_REACT_APP_API_URI: 'https://kukkuu.test.kuva.hel.ninja/graphql'
   only:
     refs:
-      - develop
+      - master
 
 build-production:
   extends: .build
@@ -39,7 +39,7 @@ build-production:
     DOCKER_BUILD_ARG_REACT_APP_API_URI: 'https://kukkuu.test.kuva.hel.ninja/graphql'
   only:
     refs:
-      - master
+      - /^release-.*$/
 
 review:
   variables:
@@ -49,6 +49,3 @@ review:
 staging:
   variables:
     DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-staging'
-  only:
-    refs:
-      - develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # [Unreleased]
 
+### Changed
+
+- Use GitHub flow instead of GitFlow
+
 # 1.6.0
 
 ### Added


### PR DESCRIPTION
## Description

Transitions this repository into using GitHub flow that is recommended in best practices.

Because a new version was just release, and the development and master branches are in sync as content goes, this is an easy time to make the transition.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[Best Practices: Version Control](https://dev.hel.fi/version-control#git-workflow)
