### PR TITLE
KK-713 | Use translation sheet managed by executive office

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # [Unreleased]
 
+### Changed
+
+- Into using a translation sheet that is managed by executive office
+
 # 1.6.1
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "lint": "eslint --ext js,ts,tsx src",
     "format:scss": "prettier --config .prettierrc.json --write src/**/*.scss",
     "start": "react-scripts start",
-    "update-translations": "fetch-translations 18dpV7aA-t_6zMRUO5hP7DMfx0q4hdu-AlLpRjkB_0zI -l en,fi,sv -o src/common/translation/i18n",
+    "update-translations": "fetch-translations 1b5qAamjhmSNiME3matBINaeyz8TvoRWVB6wU5HvKy4g -l en,fi,sv -o src/common/translation/i18n",
     "test": "TZ=UTC react-scripts test --env=jest-environment-jsdom-fourteen",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "test:browser": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/ --live --lang=fi-FI",


### PR DESCRIPTION
## Description

Changes the translation sheet to one that is managed under the XO's account.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-713](https://helsinkisolutionoffice.atlassian.net/browse/KK-713)

## How Has This Been Tested?

I changed the sheet id and rant he translation script. The script worked and did not cause any changes = I'm happy.

## Manual Testing Instructions for Reviewers

You can try running the script locally. Hit me up if you want to edit the sheet.
