### PR TITLE
KK-682 | Fix children list screen reader content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Into using a translation sheet that is managed by executive office
 - Adjusted some translations
 
+### Fixed
+
+- [Accessibility] Use same text content for screen readers and visual users in child list
+
 # 1.6.1
 
 ### Changed

--- a/browser-tests/childrenFeature.ts
+++ b/browser-tests/childrenFeature.ts
@@ -33,7 +33,7 @@ function buildEditChild() {
   };
 }
 
-const childName = /Hertta Citron .*/;
+const childName = /.* Hertta Citron .*/;
 
 fixture`Children feature`
   .page(route())
@@ -50,9 +50,11 @@ fixture`Children feature`
 
 test('As a guardian I want to see a list of my children and to be able to select one', async (t) => {
   // The list displays the expected fields
-  await t.expect(godchildrenProfilePage.children.count).gte(2);
+  await t.expect(godchildrenProfilePage.child(childName).exists).ok();
   await selectChild(t, childName);
-  await t.expect(childrenProfilePage.childName.textContent).match(childName);
+  await t
+    .expect(childrenProfilePage.childName.textContent)
+    .match(/Hertta Citron .*/);
 });
 
 test('As a guardian I want to edit the details of my child', async (t) => {
@@ -92,6 +94,7 @@ test('As a guardian I want to add and delete a child', async (t) => {
     relationship,
   } = t.ctx.addChild;
   const newChildName = `${firstName} ${lastName}`;
+  const newChildNameRegepx = new RegExp(`${newChildName} .*`);
 
   // Open child add modal
   await t.click(godchildrenProfilePage.addChildButton);
@@ -117,8 +120,8 @@ test('As a guardian I want to add and delete a child', async (t) => {
   await t.wait(1000); // 1s
 
   // Assert that the child can be found
-  await t.expect(godchildrenProfilePage.child(newChildName).exists).ok();
+  await t.expect(godchildrenProfilePage.child(newChildNameRegepx).exists).ok();
 
   // Remove the created child
-  await deleteChild(t, newChildName);
+  await deleteChild(t, newChildNameRegepx);
 });

--- a/browser-tests/childrenFeature.ts
+++ b/browser-tests/childrenFeature.ts
@@ -117,7 +117,7 @@ test('As a guardian I want to add and delete a child', async (t) => {
     .click(addChildModal.submitButton);
 
   // Wait a bit extra so the UI has time to complete its refresh
-  await t.wait(1000); // 1s
+  await t.wait(1500); // 1.5s
 
   // Assert that the child can be found
   await t.expect(godchildrenProfilePage.child(newChildNameRegepx).exists).ok();

--- a/browser-tests/eventGroupsFeature.ts
+++ b/browser-tests/eventGroupsFeature.ts
@@ -10,7 +10,7 @@ fixture`Event groups feature`.page(route()).beforeEach(async (t) => {
 
 test('As a user I can use event groups to find events', async (t) => {
   // Select first child
-  await t.click(godchildrenProfilePage.children.nth(0));
+  await t.click(godchildrenProfilePage.child(/.* Hertta Citron .*/));
 
   // Expect to see event group invitations
   await t.expect(childrenProfilePage.selectEventGroupButtons.count).gt(0);

--- a/browser-tests/pages/godchildrenProfilePage.ts
+++ b/browser-tests/pages/godchildrenProfilePage.ts
@@ -5,22 +5,10 @@ import { envUrl } from '../utils/settings';
 import { deleteChild as childProfilePageDeleteChild } from './childrenProfilePage';
 
 export const godchildrenProfilePage = {
-  children: screen.getAllByRole('button', {
-    name: /Näytä Kummilapsen .* tiedot/,
-  }),
-  child: (name: string | RegExp) => {
-    let labelName;
-
-    if (name instanceof RegExp) {
-      labelName = new RegExp(`Näytä Kummilapsen ${name.source} tiedot`);
-    } else {
-      labelName = `Näytä Kummilapsen ${name} tiedot`;
-    }
-
-    return screen.getAllByRole('button', {
-      name: labelName,
-    });
-  },
+  child: (name: string | RegExp) =>
+    screen.getAllByRole('button', {
+      name: name,
+    }),
   editProfileButton: screen.getByRole('button', { name: 'Muokkaa tietoja' }),
   profileName: Selector('h1'),
   addChildButton: screen.getByRole('button', { name: 'Lisää lapsi' }),
@@ -58,7 +46,10 @@ export async function selectChild(
   await t.click(godchildrenProfilePage.child(childName));
 }
 
-export async function deleteChild(t: TestController, childName: string) {
+export async function deleteChild(
+  t: TestController,
+  childName: string | RegExp
+) {
   await selectChild(t, childName);
   await childProfilePageDeleteChild(t);
 }

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -436,8 +436,7 @@
         "text": "New invitation!"
       },
       "navigateToDetail": {
-        "buttonLabel": "Navigate to {{childName}} detail",
-        "buttonLabelWithoutName": "Navigate to child detail"
+        "buttonLabel": "Navigate to child detail"
       }
     },
     "children": {

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -436,8 +436,7 @@
         "text": "Uusi kutsu!"
       },
       "navigateToDetail": {
-        "buttonLabel": "Näytä Kummilapsen {{childName}} tiedot",
-        "buttonLabelWithoutName": "Näytä Kummilapsen tiedot"
+        "buttonLabel": "Näytä Kummilapsen tiedot"
       }
     },
     "children": {

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -436,8 +436,7 @@
         "text": "Ny inbjudan!"
       },
       "navigateToDetail": {
-        "buttonLabel": "Visa Fadderbarnets {{childName}} uppgifter",
-        "buttonLabelWithoutName": "Visa Fadderbarnets uppgifter"
+        "buttonLabel": "Visa Fadderbarnets uppgifter"
       }
     },
     "children": {

--- a/src/domain/profile/children/child/ProfileChild.tsx
+++ b/src/domain/profile/children/child/ProfileChild.tsx
@@ -29,13 +29,6 @@ const ProfileChild: React.FunctionComponent<ProfileChildProps> = ({
 
   return (
     <button
-      aria-label={
-        isNamed
-          ? t('profile.child.navigateToDetail.buttonLabel', {
-              childName: childName,
-            })
-          : t('profile.child.navigateToDetail.buttonLabelWithoutName')
-      }
       className={styles.childWrapper}
       onClick={() => history.push(`/profile/child/${child.id}`)}
     >


### PR DESCRIPTION
## Description

Use same content for screen reader as for visual users.

Removes aria-label from children in child list so that the content of the button is read aloud with screen readers.

Refactors browser test because the change caused some selector patterns to become unusbale.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-682](https://helsinkisolutionoffice.atlassian.net/browse/KK-682)

## How Has This Been Tested?

With VoiceOver and Safari.

## Manual Testing Instructions for Reviewers

Expect screen reader users to have access to all the information visual users do.
