### PR TITLE
KK-684 | Fix incorrect tab order in occurrence list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - [Accessibility] Use same text content for screen readers and visual users in child list
 - [Accessibility] Announce title on page changes
+- [Accessibility] Incorrect tab order in occurrence list table
 
 # 1.6.1
 

--- a/src/common/test/testingLibraryUtils.tsx
+++ b/src/common/test/testingLibraryUtils.tsx
@@ -29,6 +29,15 @@ export const selectHdsButtonByText = (
   return selectHdsButton(getByText(text));
 };
 
+export const selectAllHdsButtonByText = (
+  render: RenderResult,
+  text: string
+): HTMLElement => {
+  const { getAllByText } = render;
+
+  return selectHdsButton(getAllByText(text)[0]);
+};
+
 // re-export everything
 export * from '@testing-library/react';
 

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -30,6 +30,12 @@ const EventOccurrence = ({ occurrence }: EventOccurrenceProps) => {
     `ddd ${DEFAULT_DATE_FORMAT}`
   );
   const time = formatTime(newMoment(occurrence.time), DEFAULT_TIME_FORMAT);
+  const machineReadableDate = formatTime(newMoment(occurrence.time));
+  const machineReadableTime = formatTime(
+    newMoment(occurrence.time),
+    'HH:mm:ss.SSS'
+  );
+  const machineReadableDateTime = `${machineReadableDate} ${machineReadableTime}`;
 
   const hasCapacity = Boolean(
     occurrence.remainingCapacity && occurrence.remainingCapacity > 0
@@ -37,46 +43,60 @@ const EventOccurrence = ({ occurrence }: EventOccurrenceProps) => {
   const childHasSubscription = Boolean(
     occurrence.childHasFreeSpotNotificationSubscription
   );
+  const remainingCapacity = hasCapacity
+    ? occurrence?.remainingCapacity
+    : t('event.register.occurrenceTableBody.full');
+  const submitCell = (
+    <>
+      {
+        // TODO: KK-300 Make the back-button not confusing
+      }
+
+      {hasCapacity && (
+        <Link
+          className={styles.linkButton}
+          to={`${occurrence.event.id}/occurrence/${occurrence.id}/enrol`}
+        >
+          <Button type="submit" className={styles.submitButton}>
+            {t('event.register.occurrenceTableHeader.buttonText')}
+          </Button>
+        </Link>
+      )}
+      {!hasCapacity && (
+        <EventOccurrenceNotificationControlButton
+          childId={childId}
+          eventId={eventId}
+          isSubscribed={childHasSubscription}
+          occurrence={occurrence}
+          unsubscribeLabel={t(
+            'enrollment.button.cancelNotificationSubscription'
+          )}
+          subscribeLabel={t('enrollment.button.subscribeToNotifications')}
+        />
+      )}
+    </>
+  );
 
   return (
-    <tr className={styles.occurrence}>
-      <td className={styles.occurrenceDate}>{date}</td>
-      <td className={styles.occurrenceTime}>{time}</td>
-      <td className={styles.occurrenceVenue}>{occurrence.venue.name}</td>
-      <td className={styles.remainingCapacity}>
-        {hasCapacity
-          ? occurrence?.remainingCapacity
-          : t('event.register.occurrenceTableBody.full')}
-      </td>
-      <td className={styles.occurrenceSubmit}>
-        {
-          // TODO: KK-300 Make the back-button not confusing
-        }
-
-        {hasCapacity && (
-          <Link
-            className={styles.linkButton}
-            to={`${occurrence.event.id}/occurrence/${occurrence.id}/enrol`}
-          >
-            <Button type="submit" className={styles.submitButton}>
-              {t('event.register.occurrenceTableHeader.buttonText')}
-            </Button>
-          </Link>
-        )}
-        {!hasCapacity && (
-          <EventOccurrenceNotificationControlButton
-            childId={childId}
-            eventId={eventId}
-            isSubscribed={childHasSubscription}
-            occurrence={occurrence}
-            unsubscribeLabel={t(
-              'enrollment.button.cancelNotificationSubscription'
-            )}
-            subscribeLabel={t('enrollment.button.subscribeToNotifications')}
-          />
-        )}
-      </td>
-    </tr>
+    <>
+      <tr className={[styles.occurrence, styles.isMobile].join(' ')}>
+        <td className={styles.occurrenceVenue}>
+          {occurrence.venue.name}{' '}
+          <time dateTime={machineReadableDateTime}>
+            {date} {time}
+          </time>
+        </td>
+        <td className={styles.remainingCapacity}>{remainingCapacity}</td>
+        <td className={styles.occurrenceSubmit}>{submitCell}</td>
+      </tr>
+      <tr className={styles.occurrence}>
+        <td className={styles.occurrenceDate}>{date}</td>
+        <td className={styles.occurrenceTime}>{time}</td>
+        <td className={styles.occurrenceVenue}>{occurrence.venue.name}</td>
+        <td className={styles.remainingCapacity}>{remainingCapacity}</td>
+        <td className={styles.occurrenceSubmit}>{submitCell}</td>
+      </tr>
+    </>
   );
 };
 

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -80,7 +80,7 @@ const EventOccurrence = ({ occurrence }: EventOccurrenceProps) => {
   return (
     <>
       <tr className={[styles.occurrence, styles.isMobile].join(' ')}>
-        <td className={styles.occurrenceVenue}>
+        <td>
           {occurrence.venue.name}{' '}
           <time dateTime={machineReadableDateTime}>
             {date} {time}
@@ -90,9 +90,9 @@ const EventOccurrence = ({ occurrence }: EventOccurrenceProps) => {
         <td className={styles.occurrenceSubmit}>{submitCell}</td>
       </tr>
       <tr className={styles.occurrence}>
-        <td className={styles.occurrenceDate}>{date}</td>
-        <td className={styles.occurrenceTime}>{time}</td>
-        <td className={styles.occurrenceVenue}>{occurrence.venue.name}</td>
+        <td>{date}</td>
+        <td>{time}</td>
+        <td>{occurrence.venue.name}</td>
         <td className={styles.remainingCapacity}>{remainingCapacity}</td>
         <td className={styles.occurrenceSubmit}>{submitCell}</td>
       </tr>

--- a/src/domain/event/__tests__/EventOccurrence.test.tsx
+++ b/src/domain/event/__tests__/EventOccurrence.test.tsx
@@ -4,7 +4,8 @@ import {
   render,
   fireEvent,
   waitFor,
-  selectHdsButtonByText,
+  selectAllHdsButtonByText,
+  screen,
 } from '../../../common/test/testingLibraryUtils';
 import initModal from '../../../common/test/initModal';
 import { eventQuery_event_occurrences_edges_node as OccurrenceEdgeNode } from '../../api/generatedTypes/eventQuery';
@@ -45,9 +46,9 @@ it('renders snapshot correctly', () => {
 });
 
 it('renders button for signing up to an event', () => {
-  const { queryByText } = getWrapper();
+  getWrapper();
 
-  expect(queryByText('Valitse')).not.toEqual(null);
+  expect(screen.queryAllByText('Valitse')[0]).not.toEqual(null);
 });
 
 describe('when event is full', () => {
@@ -65,9 +66,9 @@ describe('when event is full', () => {
     });
 
   it('should show full label instead of remaining capacity', () => {
-    const { queryByText } = getFullEventWrapper();
+    getFullEventWrapper();
 
-    expect(queryByText('TÄYNNÄ')).not.toEqual(null);
+    expect(screen.queryAllByText('TÄYNNÄ')[0]).not.toEqual(null);
   });
 
   describe('and child has not subscribed to notifications', () => {
@@ -77,24 +78,26 @@ describe('when event is full', () => {
       const render = getFullEventWrapper(null);
 
       await waitFor(() => {
-        fireEvent.click(selectHdsButtonByText(render, 'Tilaa ilmoitus'), {});
+        fireEvent.click(selectAllHdsButtonByText(render, 'Tilaa ilmoitus'), {});
       });
 
       await waitFor(() => {
         // This button is hooked up to Apollo and mocks are not
         // provided, but this test still works.
-        expect(render.getAllByText('Tilaa ilmoitus')[0]).toBeDefined();
+        expect(screen.getAllByText('Tilaa ilmoitus')[0]).toBeDefined();
       });
     });
   });
 
   describe('and child has subscribed to notifications', () => {
     it('user should be able to unsubscribe', () => {
-      const { queryByText } = getFullEventWrapper({
+      getFullEventWrapper({
         childHasFreeSpotNotificationSubscription: true,
       });
 
-      expect(queryByText('Peru ilmoituksen tilaus')).not.toEqual(null);
+      expect(screen.queryAllByText('Peru ilmoituksen tilaus')[0]).not.toEqual(
+        null
+      );
     });
   });
 });

--- a/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
@@ -7,9 +7,7 @@ exports[`renders snapshot correctly 1`] = `
       <tr
         class="occurrence isMobile"
       >
-        <td
-          class="occurrenceVenue"
-        >
+        <td>
           Musiikkitalo
            
           <time
@@ -48,19 +46,13 @@ exports[`renders snapshot correctly 1`] = `
       <tr
         class="occurrence"
       >
-        <td
-          class="occurrenceDate"
-        >
+        <td>
           su 8.3.2020
         </td>
-        <td
-          class="occurrenceTime"
-        >
+        <td>
           04:00
         </td>
-        <td
-          class="occurrenceVenue"
-        >
+        <td>
           Musiikkitalo
         </td>
         <td

--- a/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
@@ -5,6 +5,47 @@ exports[`renders snapshot correctly 1`] = `
   <table>
     <tbody>
       <tr
+        class="occurrence isMobile"
+      >
+        <td
+          class="occurrenceVenue"
+        >
+          Musiikkitalo
+           
+          <time
+            datetime="2020-03-08 04:00:00.000"
+          >
+            su 8.3.2020
+             
+            04:00
+          </time>
+        </td>
+        <td
+          class="remainingCapacity"
+        >
+          99
+        </td>
+        <td
+          class="occurrenceSubmit"
+        >
+          <a
+            class="linkButton"
+            href="/zzaaz/occurrence/T2NjdXJyZW5jZU5vZGU6Mg==/enrol"
+          >
+            <button
+              class="Button-module_button__1msFE button_hds-button__2A0je Button-module_primary__2LfKB button_hds-button--primary__2NVvO submitButton"
+              type="submit"
+            >
+              <span
+                class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+              >
+                Valitse
+              </span>
+            </button>
+          </a>
+        </td>
+      </tr>
+      <tr
         class="occurrence"
       >
         <td

--- a/src/domain/event/eventOccurrence.module.scss
+++ b/src/domain/event/eventOccurrence.module.scss
@@ -50,40 +50,14 @@ tr {
       min-width: 17rem;
     }
     &.remainingCapacity {
-      text-align: center;
+      text-align: right;
     }
   }
 }
 @include respond-below(md) {
   tr {
-    // display: grid;
-    // grid-template-rows: auto;
-    // grid-template-columns: auto 1fr 1fr auto;
-    // grid-row-gap: $basePadding;
     padding: 1rem 0;
   }
-
-  // td.remainingCapacity {
-  //   grid-column: 4;
-  //   grid-row: 1 / span 2;
-  //   justify-self: end;
-  //   align-self: center;
-  // }
-  // td.occurrenceVenue {
-  //   grid-row: 1;
-  //   grid-column: 1 / span 3;
-  // }
-  // td.occurrenceDate {
-  //   grid-row: 2;
-  //   grid-column: 1;
-  // }
-  // td.occurrenceTime {
-  //   grid-row: 2;
-  //   grid-column: 2;
-  // }
-  // td.occurrenceSubmit {
-  //   grid-column: 1 / span 4;
-  // }
 }
 
 .remainingCapacity {

--- a/src/domain/event/eventOccurrence.module.scss
+++ b/src/domain/event/eventOccurrence.module.scss
@@ -13,6 +13,30 @@ tr {
   border-bottom: 2px solid var(--color-black-5);
 }
 
+.occurrence {
+  display: none;
+
+  & {
+    @include respond-above(md) {
+      display: table-row;
+    }
+  }
+
+  &.isMobile {
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+    grid-template-rows: 1fr 1fr;
+
+    & .occurrenceSubmit {
+      grid-column: 1 / -1;
+    }
+
+    @include respond-above(md) {
+      display: none;
+    }
+  }
+}
+
 @include respond-above(md) {
   table {
     border-collapse: collapse;
@@ -32,31 +56,36 @@ tr {
 }
 @include respond-below(md) {
   tr {
-    display: grid;
-    grid-template-rows: auto;
-    grid-template-columns: auto 1fr 1fr auto;
-    grid-row-gap: $basePadding;
+    // display: grid;
+    // grid-template-rows: auto;
+    // grid-template-columns: auto 1fr 1fr auto;
+    // grid-row-gap: $basePadding;
     padding: 1rem 0;
   }
-  td.remainingCapacity {
-    grid-column: 4;
-    grid-row: 1 / span 2;
-    justify-self: end;
-    align-self: center;
-  }
-  td.occurrenceVenue {
-    grid-row: 1;
-    grid-column: 1 / span 3;
-  }
-  td.occurrenceDate {
-    grid-row: 2;
-    grid-column: 1;
-  }
-  td.occurrenceTime {
-    grid-row: 2;
-    grid-column: 2;
-  }
-  td.occurrenceSubmit {
-    grid-column: 1 / span 4;
-  }
+
+  // td.remainingCapacity {
+  //   grid-column: 4;
+  //   grid-row: 1 / span 2;
+  //   justify-self: end;
+  //   align-self: center;
+  // }
+  // td.occurrenceVenue {
+  //   grid-row: 1;
+  //   grid-column: 1 / span 3;
+  // }
+  // td.occurrenceDate {
+  //   grid-row: 2;
+  //   grid-column: 1;
+  // }
+  // td.occurrenceTime {
+  //   grid-row: 2;
+  //   grid-column: 2;
+  // }
+  // td.occurrenceSubmit {
+  //   grid-column: 1 / span 4;
+  // }
+}
+
+.remainingCapacity {
+  text-align: right;
 }


### PR DESCRIPTION
## Description

Fixes incorrect tab order in occurrence list when using a mobile sized screen.

Implements a custom view for mobile so that table headers and rows match.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-684](https://helsinkisolutionoffice.atlassian.net/browse/KK-684)

## How Has This Been Tested?

I've used VoiceOver and Safari to test this.

One thing worth noting is that the technical implementation uses table, but override's its display values in which case the screen reader is not able to see a table.

The layout on mobile looks like it could be difficult to reproduce using tables do I haven't attempted to fix the semantics here.