### PR TITLE
KK-698  | Fix low contrast in checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Accessibility] Announce title on page changes
 - [Accessibility] Incorrect tab order in occurrence list table
 - Missing Finnish translation
+- [Accessibility] Add contrast to checkbox input tick icon
 
 # 1.6.1
 

--- a/src/common/components/form/fields/terms/TermsField.tsx
+++ b/src/common/components/form/fields/terms/TermsField.tsx
@@ -15,6 +15,7 @@ const kukkuuCheckboxStyles = {
   '--border-color-selected-hover': 'var(--color-summer-dark)',
   '--border-color-selected-focus': 'var(--color-summer-dark)',
   '--border-color-selected-hover-focus': 'var(--color-summer-dark)',
+  '--icon-color-selected': 'var(--color-black)',
 } as React.CSSProperties;
 
 type Props = {


### PR DESCRIPTION
## Description

Fix low contract in checkbox tickmark.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-698](https://helsinkisolutionoffice.atlassian.net/browse/KK-698)

## Screenshots

<img width="350" alt="Screenshot 2021-02-23 at 10 25 45" src="https://user-images.githubusercontent.com/9090689/108818083-8971b300-75c1-11eb-92bc-ab6781969418.png">
<img width="350" alt="Screenshot 2021-02-23 at 10 24 21" src="https://user-images.githubusercontent.com/9090689/108818085-8a0a4980-75c1-11eb-9ac9-cc1b8c0dff35.png">

