### PR TITLE
Capture network errors into Sentry when authenticating

### DIFF
--- a/src/domain/auth/authenticate.ts
+++ b/src/domain/auth/authenticate.ts
@@ -27,8 +27,8 @@ export const loginTunnistamo = (path?: string) => {
         toast.error(i18n.t('authentication.networkError.message'));
       } else {
         toast.error(i18n.t('authentication.errorMessage'));
-        Sentry.captureException(error);
       }
+      Sentry.captureException(error);
       // eslint-disable-next-line no-console
       console.error(error);
     });


### PR DESCRIPTION
## Description

Users are receiving unexpected network errors when registering. We suspect that the error fails to be passed into Sentry at this point in code.