### PR TITLE
Document release 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # [Unreleased]
 
+# 1.6.4
+
+### Fixed
+
+- [#370](https://github.com/City-of-Helsinki/kukkuu-ui/pull/370) Fix broken authentication: Users accessing the www prefixed address of the production version of the service will now be redirected to the service address without the www prefix
+
 # 1.6.3
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kukkuu-ui",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "MIT",
   "contributors": [
     "Bernt Andreas Drange",


### PR DESCRIPTION
## Description

Adds documentation for release 1.6.4

--------------

# 1.6.4

### Fix

- [#370](https://github.com/City-of-Helsinki/kukkuu-ui/pull/370) Fix broken authentication: Users accessing the www prefixed address of the production version of the service will now be redirected to the service address without the www prefix
