### PR TITLE
KK-773 | Prevent users from accessing event group enrolment userpath after having been enrolled into an event

### DIFF
--- a/src/domain/api/generatedTypes/eventOccurrenceQuery.ts
+++ b/src/domain/api/generatedTypes/eventOccurrenceQuery.ts
@@ -63,5 +63,5 @@ export interface eventOccurrenceQuery {
 
 export interface eventOccurrenceQueryVariables {
   id: string;
-  childId?: string | null;
+  childId: string;
 }

--- a/src/domain/api/generatedTypes/eventQuery.ts
+++ b/src/domain/api/generatedTypes/eventQuery.ts
@@ -153,7 +153,7 @@ export interface eventQuery_event {
    * In minutes
    */
   duration: number | null;
-  capacityPerOccurrence: number;
+  capacityPerOccurrence: number | null;
   occurrences: eventQuery_event_occurrences;
   allOccurrences: eventQuery_event_allOccurrences;
   ticketSystem: eventQuery_event_ticketSystem | null;
@@ -170,5 +170,5 @@ export interface eventQueryVariables {
   id: string;
   date?: any | null;
   time?: any | null;
-  childId?: string | null;
+  childId: string;
 }

--- a/src/domain/api/generatedTypes/occurrenceQuery.ts
+++ b/src/domain/api/generatedTypes/occurrenceQuery.ts
@@ -9,6 +9,13 @@ import { EventParticipantsPerInvite } from "./globalTypes";
 // GraphQL query operation: occurrenceQuery
 // ====================================================
 
+export interface occurrenceQuery_occurrence_event_eventGroup {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+}
+
 export interface occurrenceQuery_occurrence_event {
   /**
    * The ID of the object.
@@ -24,6 +31,7 @@ export interface occurrenceQuery_occurrence_event {
    */
   duration: number | null;
   participantsPerInvite: EventParticipantsPerInvite;
+  eventGroup: occurrenceQuery_occurrence_event_eventGroup | null;
 }
 
 export interface occurrenceQuery_occurrence_venue {

--- a/src/domain/event/EventIsEnrolled.tsx
+++ b/src/domain/event/EventIsEnrolled.tsx
@@ -69,6 +69,7 @@ const EventIsEnrolled = () => {
           setIsOpen={setIsOpen}
           childId={params.childId}
           occurrenceId={data.occurrence.id}
+          eventGroupId={data?.occurrence?.event?.eventGroup?.id}
         />
       )}
     </EventPage>

--- a/src/domain/event/enrol/EnrolPage.tsx
+++ b/src/domain/event/enrol/EnrolPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../api/generatedTypes/enrolOccurrenceMutation';
 import profileQuery from '../../profile/queries/ProfileQuery';
 import { childByIdQuery } from '../../child/queries/ChildQueries';
+import eventGroupQuery from '../../eventGroup/queries/eventGroupQuery';
 import { saveChildEvents, justEnrolled } from '../state/EventActions';
 import ErrorMessage from '../../../common/components/error/Error';
 import { GQLErrors } from './EnrolConstants';
@@ -84,6 +85,13 @@ const EnrolPage = () => {
         query: childByIdQuery,
         variables: {
           id: params.childId,
+        },
+      },
+      {
+        query: eventGroupQuery,
+        variables: {
+          id: data?.occurrence?.event?.eventGroup?.id,
+          childId: params.childId,
         },
       },
     ],

--- a/src/domain/event/modal/UnenrolModal.tsx
+++ b/src/domain/event/modal/UnenrolModal.tsx
@@ -16,12 +16,14 @@ import {
 import ConfirmModal from '../../../common/components/confirm/ConfirmModal';
 import { saveChildEvents } from '../state/EventActions';
 import { childByIdQuery } from '../../child/queries/ChildQueries';
+import eventGroupQuery from '../../eventGroup/queries/eventGroupQuery';
 
 interface UnenrolModalProps {
   isOpen: boolean;
   setIsOpen: (value: boolean) => void;
   childId: string;
   occurrenceId: string;
+  eventGroupId?: string;
 }
 
 const UnenrolModal = ({
@@ -29,6 +31,7 @@ const UnenrolModal = ({
   setIsOpen,
   childId,
   occurrenceId,
+  eventGroupId,
 }: UnenrolModalProps) => {
   const history = useHistory();
   const { t } = useTranslation();
@@ -46,6 +49,13 @@ const UnenrolModal = ({
         },
       },
       { query: profileQuery },
+      {
+        query: eventGroupQuery,
+        variables: {
+          id: eventGroupId,
+          childId: childId,
+        },
+      },
     ],
     onCompleted: (data) => {
       if (data.unenrolOccurrence?.child?.occurrences.edges) {

--- a/src/domain/event/queries/occurrenceQuery.ts
+++ b/src/domain/event/queries/occurrenceQuery.ts
@@ -15,6 +15,9 @@ const occurrenceQuery = gql`
         name
         duration
         participantsPerInvite
+        eventGroup {
+          id
+        }
       }
       venue {
         id

--- a/src/domain/eventGroup/EventGroupPage.tsx
+++ b/src/domain/eventGroup/EventGroupPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useQuery } from '@apollo/client';
-import { useParams } from 'react-router';
+import { useHistory, useParams } from 'react-router';
 
 import eventGroupQuery from './queries/eventGroupQuery';
 import EventGroup from './EventGroup';
@@ -12,10 +12,20 @@ type Params = {
 
 const EventGroupPage = () => {
   const { childId, eventGroupId } = useParams<Params>();
+  const history = useHistory();
   const query = useQuery(eventGroupQuery, {
     variables: {
       id: eventGroupId,
       childId,
+    },
+    onCompleted: (data) => {
+      const events = data?.eventGroup?.events?.edges ?? [];
+
+      // If there are no events the child can enrol into, assume that they have
+      // already enrolled and redirect them into their profile.
+      if (events.length === 0) {
+        history.replace('/profile');
+      }
     },
   });
 


### PR DESCRIPTION
## Description

Introduces a check which redirects users into the profile page when there are no events to enrol into on the event group page. We assume that when there are no events, something is either wrong or the user has already enrolled.

Adds a query refetching mechanism that refetches the event group page query so that the amount of available event is correctly updated when a user enrols into an event.
