### PR TITLE
KK-775 | Fix profile refetching after unenrol mutation

### DIFF
--- a/src/domain/event/modal/UnenrolModal.tsx
+++ b/src/domain/event/modal/UnenrolModal.tsx
@@ -57,6 +57,7 @@ const UnenrolModal = ({
         },
       },
     ],
+    awaitRefetchQueries: true,
     onCompleted: (data) => {
       if (data.unenrolOccurrence?.child?.occurrences.edges) {
         dispatch(


### PR DESCRIPTION
The profile query is refetched after executing the unenrol mutation to update the child's enrolments. However, the unenrol mutation's refetch queries weren't awaited for, which resulted in a situation where the refetched profile query was still not completed when there was already a redirection to the profile page where the child's enrolments were then updated to the Redux store with old data.

In practice this meant a user could not go back to an event page after unenrolling at least when the event was in an event group.

As a side note, I really think we should try to get rid of Redux.