### PR TITLE
KK-804 | Fix occurrence refetching for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # [Unreleased]
 
+### Fixed
+
+- Occurrence refetching failing when occurrence did not have an event group
+
 # 1.6.9
 
 ### Fixed

--- a/src/domain/event/enrol/EnrolPage.tsx
+++ b/src/domain/event/enrol/EnrolPage.tsx
@@ -18,11 +18,9 @@ import {
   enrolOccurrenceMutation as EnrolOccurrenceMutationData,
   enrolOccurrenceMutationVariables as EnrolOccurrenceMutationVariables,
 } from '../../api/generatedTypes/enrolOccurrenceMutation';
-import profileQuery from '../../profile/queries/ProfileQuery';
-import { childByIdQuery } from '../../child/queries/ChildQueries';
-import eventGroupQuery from '../../eventGroup/queries/eventGroupQuery';
 import { saveChildEvents, justEnrolled } from '../state/EventActions';
 import ErrorMessage from '../../../common/components/error/Error';
+import getEventOrEventGroupOccurrenceRefetchQueries from '../getEventOrEventGroupOccurrenceRefetchQueries';
 import { GQLErrors } from './EnrolConstants';
 import Enrol from './Enrol';
 
@@ -79,22 +77,10 @@ const EnrolPage = () => {
     EnrolOccurrenceMutationData,
     EnrolOccurrenceMutationVariables
   >(enrolOccurrenceMutation, {
-    refetchQueries: [
-      { query: profileQuery },
-      {
-        query: childByIdQuery,
-        variables: {
-          id: params.childId,
-        },
-      },
-      {
-        query: eventGroupQuery,
-        variables: {
-          id: data?.occurrence?.event?.eventGroup?.id,
-          childId: params.childId,
-        },
-      },
-    ],
+    refetchQueries: getEventOrEventGroupOccurrenceRefetchQueries({
+      childId: params.childId,
+      eventGroupId: data?.occurrence?.event?.eventGroup?.id,
+    }),
     onCompleted: (data) => {
       if (data?.enrolOccurrence?.enrolment?.child?.occurrences?.edges) {
         dispatch(

--- a/src/domain/event/getEventOrEventGroupOccurrenceRefetchQueries.ts
+++ b/src/domain/event/getEventOrEventGroupOccurrenceRefetchQueries.ts
@@ -1,0 +1,38 @@
+import profileQuery from '../profile/queries/ProfileQuery';
+import { childByIdQuery } from '../child/queries/ChildQueries';
+import eventGroupQuery from '../eventGroup/queries/eventGroupQuery';
+
+type Config = {
+  childId: string;
+  eventGroupId?: string;
+};
+
+export default function getEventOrEventGroupOccurrenceRefetchQueries({
+  childId,
+  eventGroupId,
+}: Config) {
+  const sharedQueries = [
+    { query: profileQuery },
+    {
+      query: childByIdQuery,
+      variables: {
+        id: childId,
+      },
+    },
+  ];
+
+  if (!eventGroupId) {
+    return sharedQueries;
+  }
+
+  return [
+    ...sharedQueries,
+    {
+      query: eventGroupQuery,
+      variables: {
+        id: eventGroupId,
+        childId: childId,
+      },
+    },
+  ];
+}

--- a/src/domain/event/modal/UnenrolModal.tsx
+++ b/src/domain/event/modal/UnenrolModal.tsx
@@ -8,15 +8,13 @@ import { toast } from 'react-toastify';
 import { useDispatch } from 'react-redux';
 
 import unenrolOccurrenceMutation from '../mutations/unenrolOccurrenceMutation';
-import profileQuery from '../../profile/queries/ProfileQuery';
 import {
   unenrolOccurrenceMutation as UnenrolOccurrenceMutation,
   unenrolOccurrenceMutationVariables as UnenrolOccurrenceMutationVariables,
 } from '../../api/generatedTypes/unenrolOccurrenceMutation';
 import ConfirmModal from '../../../common/components/confirm/ConfirmModal';
 import { saveChildEvents } from '../state/EventActions';
-import { childByIdQuery } from '../../child/queries/ChildQueries';
-import eventGroupQuery from '../../eventGroup/queries/eventGroupQuery';
+import getEventOrEventGroupOccurrenceRefetchQueries from '../getEventOrEventGroupOccurrenceRefetchQueries';
 
 interface UnenrolModalProps {
   isOpen: boolean;
@@ -41,22 +39,10 @@ const UnenrolModal = ({
     UnenrolOccurrenceMutation,
     UnenrolOccurrenceMutationVariables
   >(unenrolOccurrenceMutation, {
-    refetchQueries: [
-      {
-        query: childByIdQuery,
-        variables: {
-          id: childId,
-        },
-      },
-      { query: profileQuery },
-      {
-        query: eventGroupQuery,
-        variables: {
-          id: eventGroupId,
-          childId: childId,
-        },
-      },
-    ],
+    refetchQueries: getEventOrEventGroupOccurrenceRefetchQueries({
+      childId,
+      eventGroupId,
+    }),
     awaitRefetchQueries: true,
     onCompleted: (data) => {
       if (data.unenrolOccurrence?.child?.occurrences.edges) {


### PR DESCRIPTION
## Description

Fixes refetching when user enrols or unenrols to an occurrence that's only related to an event and not at all related to an event group.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-804](https://helsinkisolutionoffice.atlassian.net/browse/KK-804)
