### PR TITLE
KK-904 | Scroll modal when it overflows viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Support for defining menu and pages in the CMS
 
+### Fixed
+
+- Inaccessible modal content when it overflowed container
+
 # 1.8.0
 
 ### Changed

--- a/src/common/components/modal/modal.module.scss
+++ b/src/common/components/modal/modal.module.scss
@@ -6,8 +6,11 @@ $modalPadding: 2rem;
 $modalWidthLg: 800px;
 
 .modal {
-  background-color: var(--color-white);
   position: relative;
+
+  background-color: var(--color-white);
+  margin: auto;
+
   &:focus {
     outline: none;
   }
@@ -31,12 +34,11 @@ $modalWidthLg: 800px;
   left: 0;
   right: 0;
   bottom: 0;
+
   // Cannot use var(--color-black-30) here because browsers don't support rgba-ing it.
   background-color: rgba(#b2b2b2, 0.75);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   z-index: 10;
+  overflow: auto;
 }
 
 .closeButtonWrapper {


### PR DESCRIPTION
## Description

Fix inaccessible modal content.

Modals did not scroll, which caused content on some larger modals to become inaccessible.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-904](https://helsinkisolutionoffice.atlassian.net/browse/KK-904)
