### PR TITLE
KK-912 | Use new upcomingWithOngoing filter

### DIFF
--- a/src/domain/child/queries/ChildQueries.ts
+++ b/src/domain/child/queries/ChildQueries.ts
@@ -13,7 +13,7 @@ export const childByIdQuery = gql`
         name
         year
       }
-      occurrences(upcomingWithLeeway: true) {
+      occurrences(upcomingWithOngoing: true) {
         edges {
           node {
             id

--- a/src/domain/event/mutations/unenrolOccurrenceMutation.ts
+++ b/src/domain/event/mutations/unenrolOccurrenceMutation.ts
@@ -19,7 +19,7 @@ const unenrolOccurrenceMutation = gql`
             }
           }
         }
-        occurrences(upcomingWithLeeway: true) {
+        occurrences(upcomingWithOngoing: true) {
           edges {
             node {
               id


### PR DESCRIPTION
[Backend added](https://github.com/City-of-Helsinki/kukkuu/pull/275) a new `upcomingWithOngoing` filter, which can be used instead of `upcomingWihtLeeway`. By using the new filter enrolled events should stay visible in the child profile for duration of the event + leeway time.