### PR TITLE
Fix login when using some other language than Finnish

### DIFF
--- a/src/common/route/useSyncLanguageBetweenI18nAndReactRouter.ts
+++ b/src/common/route/useSyncLanguageBetweenI18nAndReactRouter.ts
@@ -6,7 +6,7 @@ import { SUPPORT_LANGUAGES } from '../../common/translation/TranslationConstants
 import { localeParam } from '../../domain/app/appRoutes';
 
 function persistLanguageChoice(language: string) {
-  document.cookie = `i18next=${language}; SameSite=Strict`;
+  document.cookie = `i18next=${language}; SameSite=Strict; path=/`;
 }
 
 export default function useSyncLanguageBetweenI18nAndReactRouter() {

--- a/src/common/route/utils/__tests__/getPathname.test.ts
+++ b/src/common/route/utils/__tests__/getPathname.test.ts
@@ -1,0 +1,24 @@
+import { SUPPORT_LANGUAGES } from '../../../translation/TranslationConstants';
+import getPathname from '../getPathname';
+
+const languages = Object.values(SUPPORT_LANGUAGES);
+const testCases = (language: string) => [
+  ['/', language, `/${language === SUPPORT_LANGUAGES.FI ? '' : language}`],
+  [
+    '/profile',
+    language,
+    `${language === SUPPORT_LANGUAGES.FI ? '' : '/' + language}/profile`,
+  ],
+  [
+    'profile',
+    language,
+    `${language === SUPPORT_LANGUAGES.FI ? '' : '/' + language}/profile`,
+  ],
+];
+
+test.each(languages.flatMap((language) => testCases(language)))(
+  'when pathname is %p and language is %p, yields %p',
+  (pathname, language, result) => {
+    expect(getPathname(pathname, language)).toEqual(result);
+  }
+);

--- a/src/common/route/utils/getPathname.ts
+++ b/src/common/route/utils/getPathname.ts
@@ -1,9 +1,12 @@
 import { SUPPORT_LANGUAGES } from '../../translation/TranslationConstants';
 
 export default function getPathname(pathname: string, locale: string) {
+  const needsSlash = pathname.length > 0 && !pathname.startsWith('/');
+  const basePathname = `${needsSlash ? '/' : ''}${pathname}`;
+
   if (locale === SUPPORT_LANGUAGES.FI) {
-    return pathname;
+    return basePathname;
   }
 
-  return `/${locale}${pathname}`;
+  return `/${locale}${basePathname === '/' ? '' : basePathname}`;
 }

--- a/src/common/translation/i18n/i18nInit.ts
+++ b/src/common/translation/i18n/i18nInit.ts
@@ -25,11 +25,15 @@ export function initI18next(history: History) {
   // language when language is changed by using i18n.changeLanguage
   i18n.on('languageChanged', (nextLanguage) => {
     // If necessary, change language in pathname
-    const { pathname } = window.location;
+    const { pathname, ...rest } = window.location;
+
     const nextPathname = replaceLocaleInPathname(nextLanguage, pathname);
 
     if (nextPathname) {
-      history.replace(nextPathname);
+      history.replace({
+        ...rest,
+        pathname: nextPathname,
+      });
     }
   });
 


### PR DESCRIPTION
## Description

Previously logging in would fail when users used some other language than Finnish.

When the user logged in while using English:

1) They get redirected from Tunnistamo to `/callback#...`
2) i18next detects that user locale is `en` from a cookie
3) i18next language is changed
4) `languageChanged` hook is fired in `src/common/translation/i18n/i18nInit.ts`
5) User is redirected into `/callback` (missing hash)
