### PR TITLE
KK-899 | Add enrolled Ticketmaster event page

### DIFF
--- a/src/common/commonUtils.tsx
+++ b/src/common/commonUtils.tsx
@@ -1,3 +1,11 @@
 export const nlToParagraph = (text: string) => {
   return (text || '').split(/\r?\n/g).map((item, i) => <p key={i}>{item}</p>);
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+export const getNodeText = (node: any): string => {
+  if (['string', 'number'].includes(typeof node)) return node;
+  if (node instanceof Array) return node.map(getNodeText).join('');
+  if (typeof node === 'object' && node) return getNodeText(node.props.children);
+  return node;
+};

--- a/src/common/components/button/LinkButtonBase.tsx
+++ b/src/common/components/button/LinkButtonBase.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { ButtonProps } from 'hds-react';
+import { ButtonProps, IconLinkExternal } from 'hds-react';
+import { useTranslation } from 'react-i18next';
 
+import { getNodeText } from '../../commonUtils';
 import styles from './buttonOverrides.module.scss';
 
 const variantClassNameMap = {
@@ -15,6 +17,7 @@ const variantClassNameMap = {
 
 export type LinkButtonBaseProps = {
   variant?: ButtonProps['variant'];
+  openInNewTab?: boolean;
 };
 
 type Props = LinkButtonBaseProps & {
@@ -26,14 +29,26 @@ type Props = LinkButtonBaseProps & {
 
 const LinkButtonBase = ({
   as = 'a',
+  openInNewTab = false,
   children,
   className,
   ...delegated
 }: Props) => {
+  const { t } = useTranslation();
   const variant = delegated.variant;
+  const externalLinkIcon = openInNewTab ? (
+    <div className={classNames(styles.externalLinkIcon)} aria-hidden="true">
+      <IconLinkExternal />
+    </div>
+  ) : null;
   return React.createElement(
     as,
     {
+      ...(openInNewTab && {
+        target: '_blank',
+        'aria-label':
+          getNodeText(children) + '. ' + t('common.openInNewTabAriaLabel'),
+      }),
       ...delegated,
       className: classNames(
         className,
@@ -42,7 +57,10 @@ const LinkButtonBase = ({
         variant ? variantClassNameMap[variant] : variant
       ),
     },
-    <span className="hds-button__label">{children}</span>
+    <>
+      <span className="hds-button__label">{children}</span>
+      {externalLinkIcon}
+    </>
   );
 };
 

--- a/src/common/components/button/buttonOverrides.module.scss
+++ b/src/common/components/button/buttonOverrides.module.scss
@@ -47,3 +47,7 @@
     --border-color-focus: var(--color-black-40);
   }
 }
+
+.externalLinkIcon {
+  margin: 0 var(--spacing-s) 0 0;
+}

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -344,6 +344,12 @@
     },
     "ticketmasterNotice": "Registration for the event takes place in the Ticketmaster ticket service. To reserve tickets you will need a user account which you can create during the reservation process if you do not already have one. The up to date status for placing can be found from Ticketmaster."
   },
+  "ticketmasterEvent": {
+    "description": "",
+    "passwordLabel": "",
+    "continueButton": "",
+    "participantsPerInviteText": ""
+  },
   "eventOccurrenceRedirectPage": {
     "back": "Back",
     "continue": "Continue to Ticketmaster",

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -344,6 +344,12 @@
     },
     "ticketmasterNotice": "Ilmoittautuminen tapahtumaan tapahtuu Ticketmaster-lippupalvelussa. Lippuja varten tarvitset ilmaisen käyttäjätilin jonka voit luoda varauksen yhteydessä, ellei sellainen löydy entuudestaan. Tapahtumien ajantasaiset paikkatilanteet näet Ticketmasterista."
   },
+  "ticketmasterEvent": {
+    "description": "Huomaathan että sinun tulee varata liput tähän tapahtumaan Ticketmasterissa, jos et ole sitä jo tehnyt.",
+    "passwordLabel": "Henkilökohtainen salasanasi lippujen varaamista varten:",
+    "continueButton": "Jatka Ticketmasterin palveluun",
+    "participantsPerInviteText": "Lippujen määrä per salasana: {{ participantsPerInvite }}."
+  },
   "eventOccurrenceRedirectPage": {
     "back": "Takaisin",
     "continue": "Jatka Ticketmasteriin",

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -344,6 +344,12 @@
     },
     "ticketmasterNotice": "Anmälningen till evenemanget sker via Ticketmasters-biljettjänst. Du behöver ett gratis användarkonto för biljetterna. Du kan skapa kontot då du bokar, ifall du inte har ett från tidigare. Information om lediga platser för evenemanget hittar du på Ticketmaster."
   },
+  "ticketmasterEvent": {
+    "description": "",
+    "passwordLabel": "",
+    "continueButton": "",
+    "participantsPerInviteText": ""
+  },
   "eventOccurrenceRedirectPage": {
     "back": "Tillbaka",
     "continue": "Fortsätt till Ticketmaster",

--- a/src/domain/api/generatedTypes/ticketmasterEventQuery.ts
+++ b/src/domain/api/generatedTypes/ticketmasterEventQuery.ts
@@ -1,0 +1,73 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { EventParticipantsPerInvite, TicketSystem } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: ticketmasterEventQuery
+// ====================================================
+
+export interface ticketmasterEventQuery_event_occurrences_edges_node_ticketSystem_InternalOccurrenceTicketSystem {
+  type: TicketSystem;
+}
+
+export interface ticketmasterEventQuery_event_occurrences_edges_node_ticketSystem_TicketmasterOccurrenceTicketSystem {
+  type: TicketSystem;
+  url: string;
+}
+
+export type ticketmasterEventQuery_event_occurrences_edges_node_ticketSystem = ticketmasterEventQuery_event_occurrences_edges_node_ticketSystem_InternalOccurrenceTicketSystem | ticketmasterEventQuery_event_occurrences_edges_node_ticketSystem_TicketmasterOccurrenceTicketSystem;
+
+export interface ticketmasterEventQuery_event_occurrences_edges_node {
+  ticketSystem: ticketmasterEventQuery_event_occurrences_edges_node_ticketSystem | null;
+}
+
+export interface ticketmasterEventQuery_event_occurrences_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: ticketmasterEventQuery_event_occurrences_edges_node | null;
+}
+
+export interface ticketmasterEventQuery_event_occurrences {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (ticketmasterEventQuery_event_occurrences_edges | null)[];
+}
+
+export interface ticketmasterEventQuery_event_ticketSystem_InternalEventTicketSystem {
+  type: TicketSystem;
+}
+
+export interface ticketmasterEventQuery_event_ticketSystem_TicketmasterEventTicketSystem {
+  type: TicketSystem;
+  childPassword: string;
+}
+
+export type ticketmasterEventQuery_event_ticketSystem = ticketmasterEventQuery_event_ticketSystem_InternalEventTicketSystem | ticketmasterEventQuery_event_ticketSystem_TicketmasterEventTicketSystem;
+
+export interface ticketmasterEventQuery_event {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+  description: string | null;
+  image: string;
+  imageAltText: string | null;
+  participantsPerInvite: EventParticipantsPerInvite;
+  occurrences: ticketmasterEventQuery_event_occurrences;
+  ticketSystem: ticketmasterEventQuery_event_ticketSystem | null;
+}
+
+export interface ticketmasterEventQuery {
+  event: ticketmasterEventQuery_event | null;
+}
+
+export interface ticketmasterEventQueryVariables {
+  eventId: string;
+  childId: string;
+}

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -100,7 +100,7 @@ const EventOccurrence = ({
       )}
       {submitType === SubmitTypes.ticketmaster && (
         <LinkButton to={`${occurrenceUrl}/redirect`}>
-          {t('event.register.occurrenceTableHeader.buttonContinueText')}
+          {t('event.register.occurrenceTableHeader.buttonText')}
         </LinkButton>
       )}
     </>

--- a/src/domain/event/EventOccurrenceRedirect.tsx
+++ b/src/domain/event/EventOccurrenceRedirect.tsx
@@ -1,7 +1,4 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import copy from 'copy-to-clipboard';
-import { IconCheck } from 'hds-react';
 import { useParams } from 'react-router';
 import { useQuery } from '@apollo/client';
 
@@ -15,16 +12,8 @@ import styles from './eventOccurrenceRedirect.module.scss';
 import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
 import InfoPageLayout from '../app/layout/InfoPageLayout';
 import useEventOccurrence from './queries/useEventOccurrence';
-import useAriaLive from '../../common/AriaLive/useAriaLive';
 import useGetPathname from '../../common/route/utils/useGetPathname';
-
-const CopyStates = {
-  initial: 'INITIAL',
-  success: 'SUCCESS',
-  error: 'ERROR',
-} as const;
-
-type CopyState = typeof CopyStates[keyof typeof CopyStates];
+import TicketmasterPassword from './TicketmasterPassword';
 
 type Params = {
   eventId: string;
@@ -48,8 +37,6 @@ const EventOccurrenceRedirect = () => {
     params.occurrenceId,
     params.childId
   );
-  const [copyStatus, setCopyStatus] = useState<CopyState>(CopyStates.initial);
-  const { sendMessage } = useAriaLive();
 
   const ticketSystem = data?.event?.ticketSystem;
   const ticketmasterPassword =
@@ -62,20 +49,6 @@ const EventOccurrenceRedirect = () => {
     occurrenceTicketSystem && 'url' in occurrenceTicketSystem
       ? occurrenceTicketSystem.url
       : null;
-
-  const handlePasswordCopy = () => {
-    if (ticketmasterPassword) {
-      const success = copy(ticketmasterPassword);
-
-      // If copying was successful, true is returned. Otherwise the
-      // copy-to-clipboard package will render a modal which advises the user
-      // to copy by other means.
-      if (success) {
-        sendMessage(t('eventOccurrenceRedirectPage.passwordCopySuccess'));
-        setCopyStatus(CopyStates.success);
-      }
-    }
-  };
 
   if (loading) {
     return <LoadingSpinner isLoading={true} />;
@@ -107,17 +80,7 @@ const EventOccurrenceRedirect = () => {
           {t('eventOccurrenceRedirectPage.passwordLabel')}
         </Text>
         <div className={styles.row}>
-          <div className={styles.password}>{ticketmasterPassword}</div>
-          <button
-            type="button"
-            onClick={handlePasswordCopy}
-            className={styles.copyButton}
-          >
-            {t('eventOccurrenceRedirectPage.copyPassword')}
-          </button>
-          {copyStatus === CopyStates.success && (
-            <IconCheck className={styles.successCheckMark} />
-          )}
+          <TicketmasterPassword password={ticketmasterPassword} />
         </div>
         <div className={styles.row}>
           <LinkButton

--- a/src/domain/event/EventPage.tsx
+++ b/src/domain/event/EventPage.tsx
@@ -8,9 +8,11 @@ import PageWrapper from '../app/layout/PageWrapper';
 import backIcon from '../../assets/icons/svg/arrowLeft.svg';
 import { eventQuery_event as EventQueryType } from '../api/generatedTypes/eventQuery';
 import { occurrenceQuery_occurrence_event as OccurrenceQueryType } from '../api/generatedTypes/occurrenceQuery';
+// eslint-disable-next-line max-len
+import { ticketmasterEventQuery_event as TicketmasterEventQueryType } from '../api/generatedTypes/ticketmasterEventQuery';
 
 type EventProps = {
-  event: EventQueryType | OccurrenceQueryType;
+  event: EventQueryType | OccurrenceQueryType | TicketmasterEventQueryType;
   children?: ReactElement | Array<ReactElement | false>;
   success?: ReactElement;
   backTo?: string;

--- a/src/domain/event/TicketmasterEventIsEnrolled.tsx
+++ b/src/domain/event/TicketmasterEventIsEnrolled.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+
+import styles from './ticketmasterEventIsEnrolled.module.scss';
+import { ticketmasterEventQuery } from './queries/ticketmasterEventQuery';
+import {
+  ticketmasterEventQuery as TicketmasterEventQueryType,
+  // eslint-disable-next-line max-len
+  ticketmasterEventQuery_event_ticketSystem_TicketmasterEventTicketSystem as EventTicketSystem,
+  // eslint-disable-next-line max-len
+  ticketmasterEventQuery_event_occurrences_edges_node_ticketSystem_TicketmasterOccurrenceTicketSystem as OccurrenceTicketSystem,
+} from '../api/generatedTypes/ticketmasterEventQuery';
+import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
+import Paragraph from '../../common/components/paragraph/Paragraph';
+import EventPage from './EventPage';
+import ErrorMessage from '../../common/components/error/Error';
+import { useChildRouteGoBackTo } from '../profile/route/ProfileRoute';
+import AnchorButton from '../../common/components/button/AnchorButton';
+import TicketmasterPassword from './TicketmasterPassword';
+import Text from '../../common/components/text/Text';
+
+const TicketmasterEventIsEnrolled = () => {
+  const { t } = useTranslation();
+  const goBackTo = useChildRouteGoBackTo();
+  const params = useParams<{ childId: string; eventId: string }>();
+  const { loading, error, data } = useQuery<TicketmasterEventQueryType>(
+    ticketmasterEventQuery,
+    {
+      variables: {
+        eventId: params.eventId,
+        childId: params.childId,
+      },
+    }
+  );
+
+  if (loading) return <LoadingSpinner isLoading={true} />;
+
+  const errorMessage = <ErrorMessage message={t('api.errorMessage')} />;
+  if (error || !data?.event) return errorMessage;
+
+  const eventTicketSystem = data?.event.ticketSystem as EventTicketSystem;
+  /* TODO Currently we don't have Ticketmaster URLs for whole events, so as a workaround
+      the URL of the first occurrence is used for now.
+   */
+  const ticketmasterUrl = (
+    data?.event?.occurrences?.edges[0]?.node
+      ?.ticketSystem as OccurrenceTicketSystem
+  ).url;
+
+  return (
+    <EventPage event={data.event} backTo={goBackTo}>
+      <div className={styles.description}>
+        <Paragraph text={data.event.description || ''} />
+      </div>
+      <Text>{t('ticketmasterEvent.description')}</Text>
+      <Text>{t('ticketmasterEvent.passwordLabel')}</Text>
+      <div className={styles.passwordRow}>
+        <TicketmasterPassword password={eventTicketSystem?.childPassword} />
+        <AnchorButton href={ticketmasterUrl} openInNewTab>
+          {t('ticketmasterEvent.continueButton')}
+        </AnchorButton>
+      </div>
+      <Text>
+        {t('ticketmasterEvent.participantsPerInviteText', {
+          participantsPerInvite: t(
+            `event.participantsPerInviteEnum.${data.event.participantsPerInvite}`
+          ),
+        })}
+      </Text>
+    </EventPage>
+  );
+};
+
+export default TicketmasterEventIsEnrolled;

--- a/src/domain/event/TicketmasterPassword.tsx
+++ b/src/domain/event/TicketmasterPassword.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import copy from 'copy-to-clipboard';
+import { IconCheck } from 'hds-react';
+
+import styles from './ticketmasterPassword.module.scss';
+import useAriaLive from '../../common/AriaLive/useAriaLive';
+
+const CopyStates = {
+  initial: 'INITIAL',
+  success: 'SUCCESS',
+  error: 'ERROR',
+} as const;
+
+type CopyState = typeof CopyStates[keyof typeof CopyStates];
+
+type Props = {
+  password: string | null;
+};
+
+const TicketmasterPassword = ({ password }: Props) => {
+  const { t } = useTranslation();
+  const [copyStatus, setCopyStatus] = useState<CopyState>(CopyStates.initial);
+  const { sendMessage } = useAriaLive();
+
+  const handlePasswordCopy = () => {
+    if (password) {
+      const success = copy(password);
+      // If copying was successful, true is returned. Otherwise the
+      // copy-to-clipboard package will render a modal which advises the user
+      // to copy by other means.
+      if (success) {
+        sendMessage(t('eventOccurrenceRedirectPage.passwordCopySuccess'));
+        setCopyStatus(CopyStates.success);
+      }
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.password}>{password}</div>
+      <div className={styles.copyButtonWrapper}>
+        <button
+          type="button"
+          onClick={handlePasswordCopy}
+          className={styles.copyButton}
+        >
+          {t('eventOccurrenceRedirectPage.copyPassword')}
+        </button>
+        {copyStatus === CopyStates.success && (
+          <div className={styles.successWrapper}>
+            <IconCheck className={styles.successCheckMark} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TicketmasterPassword;

--- a/src/domain/event/eventOccurrenceRedirect.module.scss
+++ b/src/domain/event/eventOccurrenceRedirect.module.scss
@@ -43,36 +43,6 @@
       }
     }
   }
-
-  .password {
-    padding: $spacing-s;
-    width: min-content;
-
-    font-size: $fontsize-body-xl;
-    text-transform: uppercase;
-    letter-spacing: 6px;
-
-    background-color: $color-black-5;
-  }
-
-  .copyButton {
-    padding: 0;
-
-    text-decoration: underline;
-    color: $color-black-90;
-
-    background: none;
-    border: none;
-    cursor: pointer;
-  }
-
-  .successCheckMark {
-    color: $color-success;
-
-    @include respond-above(sm) {
-      margin-left: $spacing-2-xs;
-    }
-  }
 }
 
 .lessMargin {

--- a/src/domain/event/partial/__tests__/package.json
+++ b/src/domain/event/partial/__tests__/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "__tests__",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/src/domain/event/queries/ticketmasterEventQuery.ts
+++ b/src/domain/event/queries/ticketmasterEventQuery.ts
@@ -1,0 +1,32 @@
+import { gql } from '@apollo/client';
+
+export const ticketmasterEventQuery = gql`
+  query ticketmasterEventQuery($eventId: ID!, $childId: ID!) {
+    event(id: $eventId) {
+      id
+      name
+      description
+      image
+      imageAltText
+      participantsPerInvite
+      occurrences: occurrences(upcoming: true, first: 1) {
+        edges {
+          node {
+            ticketSystem {
+              type
+              ... on TicketmasterOccurrenceTicketSystem {
+                url
+              }
+            }
+          }
+        }
+      }
+      ticketSystem {
+        type
+        ... on TicketmasterEventTicketSystem {
+          childPassword(childId: $childId)
+        }
+      }
+    }
+  }
+`;

--- a/src/domain/event/ticketmasterEventIsEnrolled.module.scss
+++ b/src/domain/event/ticketmasterEventIsEnrolled.module.scss
@@ -1,0 +1,36 @@
+@import 'styles/variables';
+@import 'styles/fonts';
+@import 'styles/layout';
+
+.passwordRow {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  margin-top: $spacing-l;
+  margin-bottom: $spacing-l;
+
+  & > *:not(:last-child) {
+    margin-bottom: $spacing-s;
+  }
+
+  & > *:last-child {
+    margin-top: $spacing-m;
+    width: 100%;
+  }
+
+  @include respond-above(sm) {
+    flex-direction: row;
+    flex-wrap: wrap;
+    row-gap: $spacing-m;
+
+    & > *:not(:last-child) {
+      margin-right: $spacing-s;
+      margin-bottom: 0;
+    }
+
+    & > *:last-child {
+      width: initial;
+      margin-top: 0;
+    }
+  }
+}

--- a/src/domain/event/ticketmasterPassword.module.scss
+++ b/src/domain/event/ticketmasterPassword.module.scss
@@ -1,0 +1,49 @@
+@import 'styles/variables';
+@import 'styles/layout';
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-xs;
+
+  @include respond-above(sm) {
+    flex-direction: row;
+  }
+
+  .password {
+    padding: $spacing-s;
+    width: min-content;
+
+    font-size: $fontsize-body-xl;
+    text-transform: uppercase;
+    letter-spacing: 6px;
+
+    background-color: $color-black-5;
+  }
+
+  .copyButton {
+    padding: 0;
+
+    text-decoration: underline;
+    color: $color-black-90;
+
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .copyButtonWrapper {
+    position: relative;
+    @include respond-above(sm) {
+      margin-right: 42px;
+    }
+  }
+
+  .successCheckMark {
+    color: $color-success;
+    position: absolute;
+    bottom: -2px;
+    right: -32px;
+  }
+}

--- a/src/domain/profile/events/ProfileEventsList.tsx
+++ b/src/domain/profile/events/ProfileEventsList.tsx
@@ -106,6 +106,14 @@ const ProfileEventsList = ({
     );
   };
 
+  const gotoExternalEnrolmentEventPage = (eventId: string) => {
+    history.push(
+      getPathname(
+        `/profile/child/${childId}/event/${eventId}/external-enrolment`
+      )
+    );
+  };
+
   const upcomingEventsAndEventGroups = upcomingEventsAndEventGroupsList(
     upcomingEventsAndEventGroupsData
   ).items;
@@ -157,7 +165,9 @@ const ProfileEventsList = ({
               <EventCard
                 key={internalOrTicketSystemEnrolment.id}
                 event={ticketmasterEnrolment.event}
-                action={() => gotoEventPage(ticketmasterEnrolment.event.id)}
+                action={() =>
+                  gotoExternalEnrolmentEventPage(ticketmasterEnrolment.event.id)
+                }
                 actionText={t('enrollment.showEventInfo.buttonText')}
                 primaryAction="hidden"
                 focalContent={TicketMasterInfo()}

--- a/src/domain/profile/route/ProfileChildRoutes.tsx
+++ b/src/domain/profile/route/ProfileChildRoutes.tsx
@@ -8,6 +8,7 @@ import EventIsEnrolled from '../../event/EventIsEnrolled';
 import EventOccurrenceRedirect from '../../event/EventOccurrenceRedirect';
 import EventGroupPage from '../../eventGroup/EventGroupPage';
 import ProfileChildDetail from '../children/child/ProfileChildDetail';
+import TicketmasterEventIsEnrolled from '../../event/TicketmasterEventIsEnrolled';
 
 const ProfileChildRoute = ({ match: { path } }: RouteComponentProps) => {
   const { t } = useTranslation();
@@ -43,6 +44,12 @@ const ProfileChildRoute = ({ match: { path } }: RouteComponentProps) => {
         exact
         component={EventIsEnrolled}
         path={`${path}/occurrence/:occurrenceId`}
+      />
+      <AppRoute
+        noTitle
+        exact
+        component={TicketmasterEventIsEnrolled}
+        path={`${path}/event/:eventId/external-enrolment`}
       />
       <AppRoute
         title={t('enrolPage.enrol')}


### PR DESCRIPTION
Added a new event page for Ticketmaster events that users have "enrolled" (obtained a password) in. One will end up on this new page when clicking the event in the upcoming events section of a child's profile page.

The new page contains the same kind of Ticketmaster password showing functionality as exists already on a different page, so the password thing was refactored into its own separate component.

<img width="1373" alt="Screenshot 2022-09-23 at 15 45 10" src="https://user-images.githubusercontent.com/1314604/191963331-2149b838-0d5d-4c61-95f2-1981b57c0ccc.png">
