### PR TITLE
KK-962 | Use event related external ticket system URL

### DIFF
--- a/src/domain/api/generatedTypes/eventQuery.ts
+++ b/src/domain/api/generatedTypes/eventQuery.ts
@@ -140,7 +140,8 @@ export interface eventQuery_event_ticketSystem_InternalEventTicketSystem {
 
 export interface eventQuery_event_ticketSystem_TicketmasterEventTicketSystem {
   type: TicketSystem;
-  childPassword: string;
+  childPassword: string | null;
+  url: string;
 }
 
 export type eventQuery_event_ticketSystem = eventQuery_event_ticketSystem_InternalEventTicketSystem | eventQuery_event_ticketSystem_TicketmasterEventTicketSystem;

--- a/src/domain/api/generatedTypes/eventTicketmasterPasswordQuery.ts
+++ b/src/domain/api/generatedTypes/eventTicketmasterPasswordQuery.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { EventParticipantsPerInvite } from "./globalTypes";
+
 // ====================================================
 // GraphQL query operation: eventTicketmasterPasswordQuery
 // ====================================================
@@ -10,12 +12,14 @@
 export interface eventTicketmasterPasswordQuery_event_ticketSystem_InternalEventTicketSystem {}
 
 export interface eventTicketmasterPasswordQuery_event_ticketSystem_TicketmasterEventTicketSystem {
-  childPassword: string;
+  childPassword: string | null;
+  url: string;
 }
 
 export type eventTicketmasterPasswordQuery_event_ticketSystem = eventTicketmasterPasswordQuery_event_ticketSystem_InternalEventTicketSystem | eventTicketmasterPasswordQuery_event_ticketSystem_TicketmasterEventTicketSystem;
 
 export interface eventTicketmasterPasswordQuery_event {
+  participantsPerInvite: EventParticipantsPerInvite;
   ticketSystem: eventTicketmasterPasswordQuery_event_ticketSystem | null;
 }
 

--- a/src/domain/api/generatedTypes/ticketmasterEventQuery.ts
+++ b/src/domain/api/generatedTypes/ticketmasterEventQuery.ts
@@ -44,7 +44,8 @@ export interface ticketmasterEventQuery_event_ticketSystem_InternalEventTicketSy
 
 export interface ticketmasterEventQuery_event_ticketSystem_TicketmasterEventTicketSystem {
   type: TicketSystem;
-  childPassword: string;
+  childPassword: string | null;
+  url: string;
 }
 
 export type ticketmasterEventQuery_event_ticketSystem = ticketmasterEventQuery_event_ticketSystem_InternalEventTicketSystem | ticketmasterEventQuery_event_ticketSystem_TicketmasterEventTicketSystem;

--- a/src/domain/event/EventRedirect.tsx
+++ b/src/domain/event/EventRedirect.tsx
@@ -81,6 +81,9 @@ const EventRedirect = () => {
       ? ticketSystem.childPassword
       : null) || mutationData?.assignTicketSystemPassword?.password;
 
+  const ticketSystemUrl =
+    ticketSystem && 'url' in ticketSystem ? ticketSystem.url : undefined;
+
   if (queryLoading) {
     return <LoadingSpinner isLoading={true} />;
   }
@@ -144,10 +147,9 @@ const EventRedirect = () => {
             <Text variant="body-l">
               {t('eventRedirectPage.passwordCopyDescription')}
             </Text>
-            {/* TODO replace this with the event's TM URL once available */}
             <AnchorButton
               className={styles.continueButton}
-              href={'https://www.example.com'}
+              href={ticketSystemUrl}
               openInNewTab
             >
               {t('ticketmasterEvent.continueButton')}

--- a/src/domain/event/TicketmasterEventIsEnrolled.tsx
+++ b/src/domain/event/TicketmasterEventIsEnrolled.tsx
@@ -8,8 +8,6 @@ import {
   ticketmasterEventQuery as TicketmasterEventQueryType,
   // eslint-disable-next-line max-len
   ticketmasterEventQuery_event_ticketSystem_TicketmasterEventTicketSystem as EventTicketSystem,
-  // eslint-disable-next-line max-len
-  ticketmasterEventQuery_event_occurrences_edges_node_ticketSystem_TicketmasterOccurrenceTicketSystem as OccurrenceTicketSystem,
 } from '../api/generatedTypes/ticketmasterEventQuery';
 import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
 import Paragraph from '../../common/components/paragraph/Paragraph';
@@ -40,13 +38,6 @@ const TicketmasterEventIsEnrolled = () => {
   if (error || !data?.event) return errorMessage;
 
   const eventTicketSystem = data?.event.ticketSystem as EventTicketSystem;
-  /* TODO Currently we don't have Ticketmaster URLs for whole events, so as a workaround
-      the URL of the first occurrence is used for now.
-   */
-  const ticketmasterUrl = (
-    data?.event?.occurrences?.edges[0]?.node
-      ?.ticketSystem as OccurrenceTicketSystem
-  ).url;
 
   return (
     <EventPage event={data.event} backTo={goBackTo}>
@@ -57,7 +48,7 @@ const TicketmasterEventIsEnrolled = () => {
       <Text>{t('ticketmasterEvent.passwordLabel')}</Text>
       <div className={styles.passwordRow}>
         <TicketmasterPassword password={eventTicketSystem?.childPassword} />
-        <AnchorButton href={ticketmasterUrl} openInNewTab>
+        <AnchorButton href={eventTicketSystem?.url} openInNewTab>
           {t('ticketmasterEvent.continueButton')}
         </AnchorButton>
       </div>

--- a/src/domain/event/queries/eventQuery.ts
+++ b/src/domain/event/queries/eventQuery.ts
@@ -59,6 +59,7 @@ const eventQuery = gql`
         type
         ... on TicketmasterEventTicketSystem {
           childPassword(childId: $childId)
+          url
         }
       }
     }
@@ -84,6 +85,7 @@ export const eventTicketmasterPasswordQuery = gql`
       ticketSystem {
         ... on TicketmasterEventTicketSystem {
           childPassword(childId: $childId)
+          url
         }
       }
     }

--- a/src/domain/event/queries/ticketmasterEventQuery.ts
+++ b/src/domain/event/queries/ticketmasterEventQuery.ts
@@ -25,6 +25,7 @@ export const ticketmasterEventQuery = gql`
         type
         ... on TicketmasterEventTicketSystem {
           childPassword(childId: $childId)
+          url
         }
       }
     }


### PR DESCRIPTION
## Description

Changed external ticket system (=Ticketmaster ATM) links to use the URL field related to an event instead of the one related to an occurrence.

## Context

[KK-962](https://helsinkisolutionoffice.atlassian.net/browse/KK-962)
