### PR TITLE
Remove occurrences from unenrolled Ticketmaster event page

### DIFF
--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -342,7 +342,11 @@
       },
       "participants": "Participants"
     },
-    "ticketmasterNotice": "Registration for the event takes place in the Ticketmaster ticket service. To reserve tickets you will need a user account which you can create during the reservation process if you do not already have one. The up to date status for placing can be found from Ticketmaster."
+    "ticketmasterNotice": "Registration for the event takes place in the Ticketmaster ticket service. To reserve tickets you will need a user account which you can create during the reservation process if you do not already have one. The up to date status for placing can be found from Ticketmaster.",
+    "ticketmasterButtons": {
+      "continue": "Continue to register",
+      "back": "Back"
+    }
   },
   "ticketmasterEvent": {
     "description": "",

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -342,7 +342,11 @@
       },
       "participants": "Osallistujat"
     },
-    "ticketmasterNotice": "Ilmoittautuminen tapahtumaan tapahtuu Ticketmaster-lippupalvelussa. Lippuja varten tarvitset ilmaisen käyttäjätilin jonka voit luoda varauksen yhteydessä, ellei sellainen löydy entuudestaan. Tapahtumien ajantasaiset paikkatilanteet näet Ticketmasterista."
+    "ticketmasterNotice": "Ilmoittautuminen tapahtumaan tapahtuu Ticketmaster-lippupalvelussa. Lippuja varten tarvitset ilmaisen käyttäjätilin jonka voit luoda varauksen yhteydessä, ellei sellainen löydy entuudestaan. Tapahtumien ajantasaiset paikkatilanteet näet Ticketmasterista.",
+    "ticketmasterButtons": {
+      "continue": "Jatka ilmoittautumaan",
+      "back": "Takaisin"
+    }
   },
   "ticketmasterEvent": {
     "description": "Huomaathan että sinun tulee varata liput tähän tapahtumaan Ticketmasterissa, jos et ole sitä jo tehnyt.",

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -342,7 +342,11 @@
       },
       "participants": "Deltagare"
     },
-    "ticketmasterNotice": "Anmälningen till evenemanget sker via Ticketmasters-biljettjänst. Du behöver ett gratis användarkonto för biljetterna. Du kan skapa kontot då du bokar, ifall du inte har ett från tidigare. Information om lediga platser för evenemanget hittar du på Ticketmaster."
+    "ticketmasterNotice": "Anmälningen till evenemanget sker via Ticketmasters-biljettjänst. Du behöver ett gratis användarkonto för biljetterna. Du kan skapa kontot då du bokar, ifall du inte har ett från tidigare. Information om lediga platser för evenemanget hittar du på Ticketmaster.",
+    "ticketmasterButtons": {
+      "continue": "Fortsätt till anmälan",
+      "back": "Tillbaka"
+    }
   },
   "ticketmasterEvent": {
     "description": "",

--- a/src/domain/event/event.module.scss
+++ b/src/domain/event/event.module.scss
@@ -154,3 +154,35 @@
     justify-content: normal;
   }
 }
+
+.divider {
+  margin-top: $spacing-m;
+  margin-bottom: $spacing-l;
+}
+
+.ticketmasterButtons {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+
+  & > * {
+    width: 100%;
+  }
+
+  & > *:not(:last-child) {
+    margin-bottom: $spacing-s;
+  }
+
+  @include respond-above(sm) {
+    flex-direction: row;
+
+    & > * {
+      width: initial;
+    }
+
+    & > *:not(:last-child) {
+      margin-bottom: 0;
+      margin-right: $spacing-s;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Removed the whole enrollment part containing the occurrences list and some filters for those from the unenrolled event view when the event is Ticketmaster based, because Ticketmaster events won't be having any occurrences. Instead a button which leads to the Ticketmaster enrollment process is shown.
 
## Context

[KK-959](https://helsinkisolutionoffice.atlassian.net/browse/KK-959)

## Screenshots

<img width="1237" alt="Screenshot 2022-10-10 at 9 45 34" src="https://user-images.githubusercontent.com/1314604/194811812-8661082f-111a-4a83-8a5c-4f6b73112137.png">

