### PR TITLE
Fix the URL locale handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# 1.10.2
+
+### FIXED
+
+- [#460](https://github.com/City-of-Helsinki/kukkuu-ui/pull/460) Fix the URL locale handling
+
 # 1.10.1
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kukkuu-ui",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "license": "MIT",
   "contributors": [
     "Bernt Andreas Drange",

--- a/src/common/route/utils/replaceLocaleInPathname.ts
+++ b/src/common/route/utils/replaceLocaleInPathname.ts
@@ -7,7 +7,7 @@ export default function replaceLocaleInPathname(
   const supportedLanguages = Object.values(SUPPORT_LANGUAGES);
 
   const currentLanguage = supportedLanguages.find((language) =>
-    pathname.includes(`/${language}`)
+    pathname.startsWith(`/${language}`)
   );
 
   // If next language is Finnish and the path does not have a language, do
@@ -19,7 +19,7 @@ export default function replaceLocaleInPathname(
   // If next language is Finnish and the path does have a language, remove the
   // existing language
   if (currentLanguage && nextLanguage === SUPPORT_LANGUAGES.FI) {
-    return pathname.replace(`/${currentLanguage}`, '');
+    return pathname.replace(new RegExp(`^/${currentLanguage}`), '');
   }
 
   // If no current language, but not Finnish, add language
@@ -27,5 +27,8 @@ export default function replaceLocaleInPathname(
     return `/${nextLanguage}${pathname}`;
   }
 
-  return pathname.replace(`/${currentLanguage}`, `/${nextLanguage}`);
+  return pathname.replace(
+    new RegExp(`^/${currentLanguage}`),
+    `/${nextLanguage}`
+  );
 }

--- a/src/domain/app/layout/utilityComponents/PageMeta.tsx
+++ b/src/domain/app/layout/utilityComponents/PageMeta.tsx
@@ -34,7 +34,7 @@ const PageMeta = ({
       ? t(description)
       : t('homePage.hero.descriptionText');
 
-  const path = window.location.pathname.replace(`/${lang}/`, '');
+  const path = window.location.pathname.replace(new RegExp(`^/${lang}/`), '');
 
   useEffect(() => {
     if (translatedTitle) {


### PR DESCRIPTION
KK-995.

The locale was replaced from anywhere from the URL pathname,
when it should have been replaced only from the beginning.
This led to a situation where e.g `/enrol` part of the pathname
was replaced with `rol`.