### PR TITLE
KK-1000 | feat: show localized language name in parentheses in MoreInfoLinkList

### DIFF
--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -405,21 +405,21 @@
         "text": "Lisätietoa palvelusta eri kielillä"
       },
       "links": {
-        "ar": "Arabia",
-        "ckb": "Kurdi",
-        "en": "Englanti",
-        "es": "Espanja",
-        "et": "Viro",
-        "fas": "Persia",
-        "fi": "Suomi",
-        "fr": "Ranska",
-        "npi": "Nepali",
-        "ru": "Venäjä",
-        "som": "Somali",
-        "sv": "Ruotsi",
-        "tur": "Turkki",
-        "vi": "Vietnam",
-        "zh": "Kiina"
+        "ar": "arabia",
+        "ckb": "kurdi",
+        "en": "englanti",
+        "es": "espanja",
+        "et": "viro",
+        "fas": "persia",
+        "fi": "suomi",
+        "fr": "ranska",
+        "npi": "nepali",
+        "ru": "venäjä",
+        "som": "somali",
+        "sv": "ruotsi",
+        "tur": "turkki",
+        "vi": "vietnam",
+        "zh": "kiina"
       }
     },
     "partners": {

--- a/src/domain/home/moreInfo/MoreInfoLinkList.tsx
+++ b/src/domain/home/moreInfo/MoreInfoLinkList.tsx
@@ -2,25 +2,26 @@ import { useTranslation } from 'react-i18next';
 
 import styles from './moreInfoLinkList.module.scss';
 import { MoreInfoLink } from './types/moreInfo';
+import { getCurrentLanguage } from '../../../common/translation/TranslationUtils';
 
 type MoreInfoLinkListProps = {
   links: MoreInfoLink[];
 };
 
 const MoreInfoLinkList = ({ links }: MoreInfoLinkListProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const currentLanguage = getCurrentLanguage(i18n);
   return (
     <div className={styles.link}>
       {links.map((link, index: number) => {
         const languageName = t(`home.moreInfo.links.${link.langCode}`);
         return (
-          <a
-            href={link.url}
-            lang={link.langCode}
-            key={index}
-            title={languageName}
-          >
-            {link.langName}
+          <a href={link.url} key={index}>
+            <span lang={link.langCode}>{link.langName}</span>
+            <span>&thinsp;</span>
+            <span lang={currentLanguage} className={styles.localizedLanguage}>
+              ({languageName})
+            </span>
           </a>
         );
       })}

--- a/src/domain/home/moreInfo/__tests__/__snapshots__/MoreInfoLinkList.test.tsx.snap
+++ b/src/domain/home/moreInfo/__tests__/__snapshots__/MoreInfoLinkList.test.tsx.snap
@@ -7,122 +7,317 @@ exports[`renders snapshot correctly 1`] = `
   <a
     href="/brochures/fr.pdf"
     key="0"
-    lang="fr"
-    title="Ranska"
   >
-    Français
+    <span
+      lang="fr"
+    >
+      Français
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      ranska
+      )
+    </span>
   </a>
   <a
     href="/brochures/ru.pdf"
     key="1"
-    lang="ru"
-    title="Venäjä"
   >
-    Русский
+    <span
+      lang="ru"
+    >
+      Русский
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      venäjä
+      )
+    </span>
   </a>
   <a
     href="/brochures/es.pdf"
     key="2"
-    lang="es"
-    title="Espanja"
   >
-    Español
+    <span
+      lang="es"
+    >
+      Español
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      espanja
+      )
+    </span>
   </a>
   <a
     href="/brochures/zh.pdf"
     key="3"
-    lang="zh"
-    title="Kiina"
   >
-    中文
+    <span
+      lang="zh"
+    >
+      中文
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      kiina
+      )
+    </span>
   </a>
   <a
     href="/brochures/npi.pdf"
     key="4"
-    lang="npi"
-    title="Nepali"
   >
-    नेपाली गण
+    <span
+      lang="npi"
+    >
+      नेपाली गण
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      nepali
+      )
+    </span>
   </a>
   <a
     href="/brochures/som.pdf"
     key="5"
-    lang="som"
-    title="Somali"
   >
-    Somali
+    <span
+      lang="som"
+    >
+      Somali
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      somali
+      )
+    </span>
   </a>
   <a
     href="/brochures/fas.pdf"
     key="6"
-    lang="fas"
-    title="Persia"
   >
-    زبان فارسی
+    <span
+      lang="fas"
+    >
+      زبان فارسی
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      persia
+      )
+    </span>
   </a>
   <a
     href="/brochures/et.pdf"
     key="7"
-    lang="et"
-    title="Viro"
   >
-    Eesti
+    <span
+      lang="et"
+    >
+      Eesti
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      viro
+      )
+    </span>
   </a>
   <a
     href="/brochures/tur.pdf"
     key="8"
-    lang="tur"
-    title="Turkki"
   >
-    Türkçe
+    <span
+      lang="tur"
+    >
+      Türkçe
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      turkki
+      )
+    </span>
   </a>
   <a
     href="/brochures/ara.pdf"
     key="9"
-    lang="ar"
-    title="Arabia"
   >
-    اَلْعَرَبِيَّةُ
+    <span
+      lang="ar"
+    >
+      اَلْعَرَبِيَّةُ
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      arabia
+      )
+    </span>
   </a>
   <a
     href="/brochures/ckb.pdf"
     key="10"
-    lang="ckb"
-    title="Kurdi"
   >
-    کوردی
+    <span
+      lang="ckb"
+    >
+      کوردی
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      kurdi
+      )
+    </span>
   </a>
   <a
     href="/brochures/vi.pdf"
     key="11"
-    lang="vi"
-    title="Vietnam"
   >
-    Tiếng Việt
+    <span
+      lang="vi"
+    >
+      Tiếng Việt
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      vietnam
+      )
+    </span>
   </a>
   <a
     href="/brochures/en.pdf"
     key="12"
-    lang="en"
-    title="Englanti"
   >
-    English
+    <span
+      lang="en"
+    >
+      English
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      englanti
+      )
+    </span>
   </a>
   <a
     href="/brochures/sv.pdf"
     key="13"
-    lang="sv"
-    title="Ruotsi"
   >
-    Svenska
+    <span
+      lang="sv"
+    >
+      Svenska
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      ruotsi
+      )
+    </span>
   </a>
   <a
     href="/brochures/fi.pdf"
     key="14"
-    lang="fi"
-    title="Suomi"
   >
-    Suomi
+    <span
+      lang="fi"
+    >
+      Suomi
+    </span>
+    <span>
+       
+    </span>
+    <span
+      className="localizedLanguage"
+      lang="fi"
+    >
+      (
+      suomi
+      )
+    </span>
   </a>
 </div>
 `;

--- a/src/domain/home/moreInfo/moreInfoLinkList.module.scss
+++ b/src/domain/home/moreInfo/moreInfoLinkList.module.scss
@@ -12,5 +12,12 @@
     margin: $baseMargin;
     text-decoration: none;
     font-weight: 500;
+    &:hover {
+      text-decoration: underline;
+    }
+    .localizedLanguage {
+      font-weight: 400;
+      font-size: 90%;
+    }
   }
 }


### PR DESCRIPTION
## Description

### feat: show localized language name in parentheses in MoreInfoLinkList 

also:
 - remove title from link in MoreInfoLinkList
 - stylize the localized language name in parentheses to be less
   prominent as the native language name
 - update test snapshots

Example:
 - Finnish: "Français (ranska)"
 - Swedish: "Français (Franska)"
 - English: "Français (French)"

refs KK-1000

## Context

[KK-1000](https://helsinkisolutionoffice.atlassian.net/browse/KK-1000)

## How Has This Been Tested?

## Manual Testing Instructions for Reviewers

## Screenshots

### Finnish
![suomi](https://user-images.githubusercontent.com/77663720/228520856-9aa07306-8714-4566-a4ef-9583ed819457.png)

### English
![english](https://user-images.githubusercontent.com/77663720/228520815-e3a23117-5f82-48a6-a2ef-a9252e34edf6.png)

### Swedish
![svenska](https://user-images.githubusercontent.com/77663720/228520838-cc6224c1-efb4-440b-b888-cb7049ff2c0c.png)

### Mobile view
![mobile](https://user-images.githubusercontent.com/77663720/228520890-39eeffc5-bc8a-48f5-9e3a-69c96a5f158f.png)


[KK-1000]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ