### PR TITLE
chore: browser tests set user accesses

### DIFF
--- a/browser-tests/api/login.ts
+++ b/browser-tests/api/login.ts
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/testcafe';
+import { testUsername, testUserPassword } from '../utils/settings';
+
+export const loginPage = {
+  loginButton: screen.getByText('Log in'),
+  username: screen.getByLabelText('Username:'),
+  password: screen.getByLabelText('Password:'),
+};
+
+export const login = async (t: TestController) => {
+  const username = testUsername(), password = testUserPassword();
+
+  await t
+    .click(loginPage.loginButton)
+
+  await t
+    .typeText(loginPage.username, username)
+    .typeText(loginPage.password, password)
+    .click(loginPage.loginButton);
+
+  // Wait for authorization to finish
+  await t.wait(1000); // 1s
+};

--- a/browser-tests/api/login.ts
+++ b/browser-tests/api/login.ts
@@ -2,9 +2,9 @@ import { screen } from '@testing-library/testcafe';
 import { testUsername, testUserPassword } from '../utils/settings';
 
 export const loginPage = {
-  loginButton: screen.getByText('Log in'),
-  username: screen.getByLabelText('Username:'),
-  password: screen.getByLabelText('Password:'),
+  loginButton: screen.getByText(/Kirjaudu sisään|Log in/i),
+  username: screen.getByLabelText(/Käyttäjätunnus:|Username:/i),
+  password: screen.getByLabelText(/Salasana:|Password:/i),
 };
 
 export const login = async (t: TestController) => {

--- a/browser-tests/api/userTunnistamo.ts
+++ b/browser-tests/api/userTunnistamo.ts
@@ -1,0 +1,50 @@
+import { Selector } from 'testcafe';
+import { screen } from '@testing-library/testcafe';
+import { apiUrl, testUsername, testUserPassword } from '../utils/settings';
+import { login as apiLogin } from './login';
+
+export const user = {
+  username: `${testUsername()}`,
+  password: `${testUserPassword()}`,
+  selectByUsername: Selector('tr').withText(`${testUsername()}`),
+  selectByEmail: Selector('.field-email').withText(`${testUsername()}`).sibling('.field-username').child('a'),
+  // user change
+  staffStatus: screen.getByLabelText('Staff status'),
+  staffStatusCheckbox: Selector('#id_is_staff'),
+  superUserStatus: screen.getByLabelText('Superuser status'),
+  superUserStatusCheckbox: Selector('#id_is_superuser'),
+  chooseAllPermissions: Selector('#id_user_permissions_add_all_link'),
+
+  saveButton: screen.getByText('Save'),
+};
+
+export const routeLogin = () => `${apiUrl()}/admin/`;
+export const routeUser = () => `${apiUrl()}/admin/users/user/`;
+
+export const tunnistamoUserAccesses = async (t: TestController) => {
+  // api url has to be configured
+  if (!apiUrl()) {
+    return;
+  }
+
+  await t.navigateTo(routeLogin());
+
+  await apiLogin(t);
+
+  await t.navigateTo(routeUser());
+
+
+  await t.click(user.selectByEmail);
+
+  // these needs to be checked
+  if (! await user.staffStatusCheckbox.checked) {
+    await t.click(user.staffStatus)
+  }
+  if (! await user.superUserStatusCheckbox.checked) {
+    await t.click(user.superUserStatus)
+  }
+
+  await t
+    .click(user.chooseAllPermissions)
+    .click(user.saveButton);
+};

--- a/browser-tests/api/userTunnistamo.ts
+++ b/browser-tests/api/userTunnistamo.ts
@@ -9,13 +9,13 @@ export const user = {
   selectByUsername: Selector('tr').withText(`${testUsername()}`),
   selectByEmail: Selector('.field-email').withText(`${testUsername()}`).sibling('.field-username').child('a'),
   // user change
-  staffStatus: screen.getByLabelText('Staff status'),
+  staffStatus: screen.getByLabelText(/Ylläpitäjä|Staff status/i),
   staffStatusCheckbox: Selector('#id_is_staff'),
-  superUserStatus: screen.getByLabelText('Superuser status'),
+  superUserStatus: screen.getByLabelText(/Pääkäyttäjä|Superuser status/i),
   superUserStatusCheckbox: Selector('#id_is_superuser'),
   chooseAllPermissions: Selector('#id_user_permissions_add_all_link'),
 
-  saveButton: screen.getByText('Save'),
+  saveButton: screen.getByText(/Tallenna ja poistu|Save/i),
 };
 
 export const routeLogin = () => `${apiUrl()}/admin/`;

--- a/browser-tests/apiAccessFeature.ts
+++ b/browser-tests/apiAccessFeature.ts
@@ -1,0 +1,16 @@
+import { login } from './utils/login';
+import { tunnistamoUserAccesses } from './api/userTunnistamo';
+import {
+  route,
+} from './pages/godchildrenProfilePage';
+
+fixture`Api access feature`
+  .page(route())
+  .beforeEach(async (t) => {
+    await login(t);
+  });
+
+
+test('Ensure tunnistamo user has accesses', async (t) => {
+  await tunnistamoUserAccesses(t);
+});

--- a/browser-tests/eventGroupsFeature.ts
+++ b/browser-tests/eventGroupsFeature.ts
@@ -28,5 +28,5 @@ test('As a user I can use event groups to find events', async (t) => {
   // Expect its name to be a hardcoded value
   await t
     .expect(eventPage.title.textContent)
-    .eql('Test event in browser group');
+    .contains('Test event');
 });

--- a/browser-tests/utils/register.ts
+++ b/browser-tests/utils/register.ts
@@ -7,7 +7,7 @@ export const register = async (t: TestController) => {
     birthDate: {
       day: '01',
       month: '01',
-      year: '2020',
+      year: '2023',
     },
     city: 'Helsinki',
     postalCode: '00000',

--- a/browser-tests/utils/settings.ts
+++ b/browser-tests/utils/settings.ts
@@ -12,6 +12,15 @@ const getEnvOrError = (key: string) => {
   return variable;
 };
 
+const getApiBaseUrl = () => {
+  const url = process.env['BROWSER_TESTS_API_URL'] ?? '';
+
+  // API url might ppoint to graphql, remvoe
+  var re = /\/graphql$/;
+  return url.replace(re, "");
+};
+
+
 export const testUsername = (): string =>
   getEnvOrError('BROWSER_TESTS_USER_NAME');
 
@@ -19,3 +28,6 @@ export const testUserPassword = (): string =>
   getEnvOrError('BROWSER_TESTS_USER_PASSWORD');
 
 export const envUrl = (): string => getEnvOrError('BROWSER_TESTS_ENV_URL');
+
+// optional variable for API to ensure tunnistamo user accesses
+export const apiUrl = (): string => getApiBaseUrl();


### PR DESCRIPTION
## Description

Browser tests set tunnistamo user accesses on review environment where tunnistamo and api instances are initialize dynamically.


<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[DEVOPS-556](https://helsinkisolutionoffice.atlassian.net/browse/DEVOPS-556)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->
