### PR TITLE
KK-1034 | fix: use https instead of http in partner links, fix security warning

### DIFF
--- a/src/domain/home/__tests__/__snapshots__/Home.test.jsx.snap
+++ b/src/domain/home/__tests__/__snapshots__/Home.test.jsx.snap
@@ -952,7 +952,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </a>
                 <a
                   class="_container_46f5db"
-                  href="http://www.q-teatteri.fi/"
+                  href="https://www.q-teatteri.fi/"
                 >
                   <div
                     class="_imgWrapper_73ff55 _icon_46f5db"

--- a/src/domain/home/partners/__tests__/__snapshots__/HomePartners.test.tsx.snap
+++ b/src/domain/home/partners/__tests__/__snapshots__/HomePartners.test.tsx.snap
@@ -309,7 +309,7 @@ exports[`renders snapshot correctly 1`] = `
           </a>
           <a
             class="_container_46f5db"
-            href="http://www.q-teatteri.fi/"
+            href="https://www.q-teatteri.fi/"
           >
             <div
               class="_imgWrapper_73ff55 _icon_46f5db"

--- a/src/domain/home/partners/__tests__/__snapshots__/PartnersLogoList.test.tsx.snap
+++ b/src/domain/home/partners/__tests__/__snapshots__/PartnersLogoList.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`renders snapshot correctly 2`] = `
     </a>
     <a
       class="_container_46f5db"
-      href="http://www.q-teatteri.fi/"
+      href="https://www.q-teatteri.fi/"
     >
       <div
         class="_imgWrapper_73ff55 _icon_46f5db"

--- a/src/domain/home/partners/constants/PartnersConstants.tsx
+++ b/src/domain/home/partners/constants/PartnersConstants.tsx
@@ -238,8 +238,8 @@ export const partnerList: Partner[] = [
     name: 'qteatteri',
     icon: qteatteriIcon,
     url: {
-      fi: 'http://www.q-teatteri.fi/',
-      en: 'http://www.q-teatteri.fi/q-in-english/',
+      fi: 'https://www.q-teatteri.fi/',
+      en: 'https://www.q-teatteri.fi/q-in-english/',
     },
   },
   {


### PR DESCRIPTION
## Description

### fix: use https instead of http in partner links, fix security warning

refs KK-1034

## Context

[KK-1034](https://helsinkisolutionoffice.atlassian.net/browse/KK-1034)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1034]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ