### PR TITLE
refactor: migrate reducers since the creation method is deprecated

### DIFF
--- a/src/domain/app/state/ui/UIReducers.ts
+++ b/src/domain/app/state/ui/UIReducers.ts
@@ -1,24 +1,45 @@
-import { createReducer } from '@reduxjs/toolkit';
+import { createAction, createReducer } from '@reduxjs/toolkit';
 import { SILENT_RENEW_ERROR } from 'redux-oidc';
 
-import { UI_ACTIONS } from './UIActionsConstants';
 import { UIData } from '../../types/ui/UITypes';
+import {
+  closeExpiredSessionPrompt,
+  resetUIState,
+  showExpiredSessionPrompt,
+} from './UIActions';
 
 export const defaultUIState: UIData = {
   sessionExpiredPrompt: {
     isOpen: false,
   },
 };
-
-export default createReducer(defaultUIState, {
-  [SILENT_RENEW_ERROR]: (state) => {
-    state.sessionExpiredPrompt.isOpen = true;
-  },
-  [UI_ACTIONS.SESSION_EXPIRED_PROMPT.SHOW]: (state) => {
-    state.sessionExpiredPrompt.isOpen = true;
-  },
-  [UI_ACTIONS.SESSION_EXPIRED_PROMPT.CLOSE]: (state, action) => {
-    state.sessionExpiredPrompt.isOpen = false;
-  },
-  [UI_ACTIONS.RESET_UI_STATE]: (state) => (state = defaultUIState),
+const silentRenewError = createAction(SILENT_RENEW_ERROR);
+const reducer = createReducer(defaultUIState, (builder) => {
+  builder
+    .addCase(silentRenewError, (state) => ({
+      ...state,
+      sessionExpiredPrompt: {
+        ...state.sessionExpiredPrompt,
+        isOpen: true,
+      },
+    }))
+    .addCase(showExpiredSessionPrompt, (state) => ({
+      ...state,
+      sessionExpiredPrompt: {
+        ...state.sessionExpiredPrompt,
+        isOpen: true,
+      },
+    }))
+    .addCase(closeExpiredSessionPrompt, (state) => ({
+      ...state,
+      sessionExpiredPrompt: {
+        ...state.sessionExpiredPrompt,
+        isOpen: false,
+      },
+    }))
+    .addCase(resetUIState, () => ({
+      ...defaultUIState,
+    }));
 });
+
+export default reducer;

--- a/src/domain/event/state/EnrolledReducers.tsx
+++ b/src/domain/event/state/EnrolledReducers.tsx
@@ -1,7 +1,9 @@
 import { createReducer } from '@reduxjs/toolkit';
 
-import { EVENT_ACTIONS } from '../constants/EventActionConstants';
+import { justEnrolled } from './EventActions';
 
-export default createReducer(false, {
-  [EVENT_ACTIONS.JUST_ENROLLED]: (state) => !state,
+const reducer = createReducer(false, (builder) => {
+  builder.addCase(justEnrolled, (state) => !state);
 });
+
+export default reducer;

--- a/src/domain/event/state/EventReducers.tsx
+++ b/src/domain/event/state/EventReducers.tsx
@@ -1,44 +1,46 @@
 import { createReducer } from '@reduxjs/toolkit';
 
-import { EVENT_ACTIONS } from '../constants/EventActionConstants';
 import { ChildEvents } from '../type/EventChildTypes';
-import { profileQuery_myProfile_children_edges as edges } from '../../api/generatedTypes/profileQuery';
-// eslint-disable-next-line max-len
-import { enrolOccurrenceMutation_enrolOccurrence_enrolment_child_occurrences_edges as EnrolmentNodeEdge } from '../../api/generatedTypes/enrolOccurrenceMutation';
-// eslint-disable-next-line max-len
-import { unenrolOccurrenceMutation_unenrolOccurrence_child_occurrences_edges as UnEnrolmentNodeEdge } from '../../api/generatedTypes/unenrolOccurrenceMutation';
+import {
+  clearEvent,
+  saveChildEvents,
+  saveChildrenEvents,
+} from './EventActions';
 
 export const defaultChildEventData: ChildEvents[] = [];
 
-export default createReducer(defaultChildEventData, {
-  [EVENT_ACTIONS.CLEAR_EVENT]: (state) => (state = defaultChildEventData),
-  [EVENT_ACTIONS.SAVE_CHILDREN_EVENTS]: (state, action) => {
-    const childrenEvents: ChildEvents[] = [];
-    action.payload?.edges?.forEach((childEdge: edges) => {
-      const events: string[] = [];
-      childEdge?.node?.occurrences?.edges?.forEach((occurrenceEdge) => {
-        if (childEdge?.node?.id && occurrenceEdge?.node?.event.id) {
-          events.push(occurrenceEdge.node.event.id);
-        }
+const reducer = createReducer(defaultChildEventData, (builder) => {
+  builder
+    .addCase(clearEvent, (state) => ({ ...defaultChildEventData }))
+    .addCase(saveChildrenEvents, (state, action) => {
+      const childrenEvents: ChildEvents[] = [];
+      action.payload?.edges?.forEach((childEdge) => {
+        const events: string[] = [];
+        childEdge?.node?.occurrences?.edges?.forEach((occurrenceEdge) => {
+          if (childEdge?.node?.id && occurrenceEdge?.node?.event.id) {
+            events.push(occurrenceEdge.node.event.id);
+          }
+        });
+        const childEvents: ChildEvents = {
+          childId: childEdge?.node?.id || 'a',
+          eventIds: events,
+        };
+        childrenEvents.push(childEvents);
       });
-      const childEvents: ChildEvents = {
-        childId: childEdge.node?.id || 'a',
-        eventIds: events,
-      };
-      childrenEvents.push(childEvents);
+      return childrenEvents;
+    })
+    .addCase(saveChildEvents, (state, action) => {
+      const events: string[] =
+        action.payload?.occurrences?.edges
+          ?.map((enrolEdge) => {
+            return enrolEdge?.node?.event.id ?? '';
+          })
+          .filter((eventId) => !!eventId) ?? [];
+      return state.map((child) =>
+        child.childId === action.payload.childId
+          ? { ...child, eventIds: events }
+          : child
+      );
     });
-    return childrenEvents;
-  },
-  [EVENT_ACTIONS.SAVE_CHILD_EVENTS]: (state, action) => {
-    const events: string[] = action.payload.occurrences.edges.map(
-      (enrolEdge: EnrolmentNodeEdge | UnEnrolmentNodeEdge) => {
-        return enrolEdge.node?.event.id;
-      }
-    );
-    return state.map((child) =>
-      child.childId === action.payload.childId
-        ? { ...child, eventIds: events }
-        : child
-    );
-  },
 });
+export default reducer;

--- a/src/domain/profile/state/ProfileReducers.tsx
+++ b/src/domain/profile/state/ProfileReducers.tsx
@@ -1,8 +1,8 @@
 import { createReducer } from '@reduxjs/toolkit';
 
-import { PROFILE_ACTIONS } from '../constants/ProfileActionConstants';
 import { ProfileType } from '../type/ProfileTypes';
 import { Language } from '../../api/generatedTypes/globalTypes';
+import { clearProfile, saveProfile } from './ProfileActions';
 
 export const defaultProfileData: ProfileType = {
   id: '',
@@ -19,7 +19,10 @@ export const defaultProfileData: ProfileType = {
   },
 };
 
-export default createReducer(defaultProfileData, {
-  [PROFILE_ACTIONS.SAVE_PROFILE]: (state, action) => (state = action.payload),
-  [PROFILE_ACTIONS.CLEAR_PROFILE]: (state) => (state = defaultProfileData),
+const reducer = createReducer(defaultProfileData, (builder) => {
+  builder
+    .addCase(saveProfile, (_state, action: any) => ({ ...action.payload }))
+    .addCase(clearProfile, () => ({ ...defaultProfileData }));
 });
+
+export default reducer;

--- a/src/domain/registration/state/RegistrationReducers.tsx
+++ b/src/domain/registration/state/RegistrationReducers.tsx
@@ -1,7 +1,11 @@
 import { createReducer } from '@reduxjs/toolkit';
 
-import { REGISTRATION_ACTIONS } from '../constants/RegistrationActionConstants';
 import { RegistrationData } from '../types/RegistrationTypes';
+import {
+  resetFormValues,
+  setFormValues,
+  setHomeFormValues,
+} from './RegistrationActions';
 
 export const defaultRegistrationData: RegistrationData = {
   formValues: {
@@ -28,16 +32,31 @@ export const defaultRegistrationData: RegistrationData = {
   },
 };
 
-export default createReducer(defaultRegistrationData, {
-  [REGISTRATION_ACTIONS.SET_FORM_VALUES]: (state, action) => {
-    state.formValues = action.payload;
-  },
-  [REGISTRATION_ACTIONS.RESET_FORM_VALUES]: (state) => {
-    state.formValues = defaultRegistrationData.formValues;
-  },
-  [REGISTRATION_ACTIONS.SET_HOME_FORM_VALUES]: (state, action) => {
-    state.formValues.children[0].birthdate = action.payload.child.birthdate;
-    state.formValues.children[0].homeCity = action.payload.child.homeCity;
-    state.formValues.verifyInformation = action.payload.verifyInformation;
-  },
+const reducer = createReducer(defaultRegistrationData, (builder) => {
+  builder
+    .addCase(setFormValues, (state, action) => ({
+      ...state,
+      formValues: action.payload,
+    }))
+    .addCase(resetFormValues, (state) => ({
+      ...state,
+      formValues: defaultRegistrationData.formValues,
+    }))
+    .addCase(setHomeFormValues, (state, action) => ({
+      ...state,
+      formValues: {
+        ...state.formValues,
+        children: [
+          {
+            ...state.formValues.children[0],
+            birthdate: action.payload.child.birthdate,
+            homeCity: action.payload.child.homeCity,
+          },
+          ...state.formValues.children.slice(1),
+        ],
+        verifyInformation: action.payload.verifyInformation,
+      },
+    }));
 });
+
+export default reducer;


### PR DESCRIPTION
KK-1017. Usage with the "Builder Callback" Notation, since the old  "map object" notation is now deprecated. 
