### PR TITLE
fix: formik dropdown component in mobile view mode

### DIFF
--- a/src/common/components/formikWrappers/FormikDropdown.tsx
+++ b/src/common/components/formikWrappers/FormikDropdown.tsx
@@ -53,7 +53,7 @@ function FormikDropdown({
     <Select<Option>
       {...field}
       className={styles.formField}
-      value={valueAsOption || emptyValue}
+      defaultValue={valueAsOption || emptyValue}
       options={options}
       onChange={handleChange}
       invalid={meta.touched && Boolean(meta.error)}


### PR DESCRIPTION
KK-1044.
Critical fix to Select-components that did not work
in mobile view mode without crashing browser.
