### PR TITLE
fix: front page info links to brochure PDFs

### DIFF
--- a/src/domain/home/__tests__/__snapshots__/Home.test.jsx.snap
+++ b/src/domain/home/__tests__/__snapshots__/Home.test.jsx.snap
@@ -80,7 +80,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
               class="_link_0c660e"
             >
               <a
-                href="undefined/brochures/fr.pdf"
+                href="/brochures/fr.pdf"
               >
                 <span
                   lang="fr"
@@ -100,7 +100,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/ru.pdf"
+                href="/brochures/ru.pdf"
               >
                 <span
                   lang="ru"
@@ -120,7 +120,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/es.pdf"
+                href="/brochures/es.pdf"
               >
                 <span
                   lang="es"
@@ -140,7 +140,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/zh.pdf"
+                href="/brochures/zh.pdf"
               >
                 <span
                   lang="zh"
@@ -160,7 +160,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/npi.pdf"
+                href="/brochures/npi.pdf"
               >
                 <span
                   lang="npi"
@@ -180,7 +180,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/som.pdf"
+                href="/brochures/som.pdf"
               >
                 <span
                   lang="som"
@@ -200,7 +200,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/fas.pdf"
+                href="/brochures/fas.pdf"
               >
                 <span
                   lang="fas"
@@ -220,7 +220,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/et.pdf"
+                href="/brochures/et.pdf"
               >
                 <span
                   lang="et"
@@ -240,7 +240,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/tur.pdf"
+                href="/brochures/tur.pdf"
               >
                 <span
                   lang="tur"
@@ -260,7 +260,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/ara.pdf"
+                href="/brochures/ara.pdf"
               >
                 <span
                   lang="ar"
@@ -280,7 +280,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/ckb.pdf"
+                href="/brochures/ckb.pdf"
               >
                 <span
                   lang="ckb"
@@ -300,7 +300,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/vi.pdf"
+                href="/brochures/vi.pdf"
               >
                 <span
                   lang="vi"
@@ -320,7 +320,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/en.pdf"
+                href="/brochures/en.pdf"
               >
                 <span
                   lang="en"
@@ -340,7 +340,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/sv.pdf"
+                href="/brochures/sv.pdf"
               >
                 <span
                   lang="sv"
@@ -360,7 +360,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </span>
               </a>
               <a
-                href="undefined/brochures/fi.pdf"
+                href="/brochures/fi.pdf"
               >
                 <span
                   lang="fi"

--- a/src/domain/home/moreInfo/MoreInfoLinkList.tsx
+++ b/src/domain/home/moreInfo/MoreInfoLinkList.tsx
@@ -11,6 +11,7 @@ type MoreInfoLinkListProps = {
 const MoreInfoLinkList = ({ links }: MoreInfoLinkListProps) => {
   const { t, i18n } = useTranslation();
   const currentLanguage = getCurrentLanguage(i18n);
+  console.log({ currentLanguage });
   return (
     <div className={styles.link}>
       {links.map((link, index: number) => {

--- a/src/domain/home/moreInfo/__tests__/__snapshots__/HomeMoreInfo.test.tsx.snap
+++ b/src/domain/home/moreInfo/__tests__/__snapshots__/HomeMoreInfo.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`renders snapshot correctly 1`] = `
         class="_link_0c660e"
       >
         <a
-          href="undefined/brochures/fr.pdf"
+          href="/brochures/fr.pdf"
         >
           <span
             lang="fr"
@@ -38,7 +38,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/ru.pdf"
+          href="/brochures/ru.pdf"
         >
           <span
             lang="ru"
@@ -58,7 +58,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/es.pdf"
+          href="/brochures/es.pdf"
         >
           <span
             lang="es"
@@ -78,7 +78,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/zh.pdf"
+          href="/brochures/zh.pdf"
         >
           <span
             lang="zh"
@@ -98,7 +98,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/npi.pdf"
+          href="/brochures/npi.pdf"
         >
           <span
             lang="npi"
@@ -118,7 +118,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/som.pdf"
+          href="/brochures/som.pdf"
         >
           <span
             lang="som"
@@ -138,7 +138,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/fas.pdf"
+          href="/brochures/fas.pdf"
         >
           <span
             lang="fas"
@@ -158,7 +158,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/et.pdf"
+          href="/brochures/et.pdf"
         >
           <span
             lang="et"
@@ -178,7 +178,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/tur.pdf"
+          href="/brochures/tur.pdf"
         >
           <span
             lang="tur"
@@ -198,7 +198,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/ara.pdf"
+          href="/brochures/ara.pdf"
         >
           <span
             lang="ar"
@@ -218,7 +218,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/ckb.pdf"
+          href="/brochures/ckb.pdf"
         >
           <span
             lang="ckb"
@@ -238,7 +238,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/vi.pdf"
+          href="/brochures/vi.pdf"
         >
           <span
             lang="vi"
@@ -258,7 +258,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/en.pdf"
+          href="/brochures/en.pdf"
         >
           <span
             lang="en"
@@ -278,7 +278,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/sv.pdf"
+          href="/brochures/sv.pdf"
         >
           <span
             lang="sv"
@@ -298,7 +298,7 @@ exports[`renders snapshot correctly 1`] = `
           </span>
         </a>
         <a
-          href="undefined/brochures/fi.pdf"
+          href="/brochures/fi.pdf"
         >
           <span
             lang="fi"

--- a/src/domain/home/moreInfo/__tests__/__snapshots__/MoreInfoLinkList.test.tsx.snap
+++ b/src/domain/home/moreInfo/__tests__/__snapshots__/MoreInfoLinkList.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders snapshot correctly 1`] = `
     class="_link_0c660e"
   >
     <a
-      href="undefined/brochures/fr.pdf"
+      href="/brochures/fr.pdf"
     >
       <span
         lang="fr"
@@ -26,7 +26,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/ru.pdf"
+      href="/brochures/ru.pdf"
     >
       <span
         lang="ru"
@@ -46,7 +46,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/es.pdf"
+      href="/brochures/es.pdf"
     >
       <span
         lang="es"
@@ -66,7 +66,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/zh.pdf"
+      href="/brochures/zh.pdf"
     >
       <span
         lang="zh"
@@ -86,7 +86,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/npi.pdf"
+      href="/brochures/npi.pdf"
     >
       <span
         lang="npi"
@@ -106,7 +106,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/som.pdf"
+      href="/brochures/som.pdf"
     >
       <span
         lang="som"
@@ -126,7 +126,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/fas.pdf"
+      href="/brochures/fas.pdf"
     >
       <span
         lang="fas"
@@ -146,7 +146,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/et.pdf"
+      href="/brochures/et.pdf"
     >
       <span
         lang="et"
@@ -166,7 +166,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/tur.pdf"
+      href="/brochures/tur.pdf"
     >
       <span
         lang="tur"
@@ -186,7 +186,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/ara.pdf"
+      href="/brochures/ara.pdf"
     >
       <span
         lang="ar"
@@ -206,7 +206,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/ckb.pdf"
+      href="/brochures/ckb.pdf"
     >
       <span
         lang="ckb"
@@ -226,7 +226,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/vi.pdf"
+      href="/brochures/vi.pdf"
     >
       <span
         lang="vi"
@@ -246,7 +246,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/en.pdf"
+      href="/brochures/en.pdf"
     >
       <span
         lang="en"
@@ -266,7 +266,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/sv.pdf"
+      href="/brochures/sv.pdf"
     >
       <span
         lang="sv"
@@ -286,7 +286,7 @@ exports[`renders snapshot correctly 1`] = `
       </span>
     </a>
     <a
-      href="undefined/brochures/fi.pdf"
+      href="/brochures/fi.pdf"
     >
       <span
         lang="fi"

--- a/src/domain/home/moreInfo/constants/MoreInfoConstants.tsx
+++ b/src/domain/home/moreInfo/constants/MoreInfoConstants.tsx
@@ -4,80 +4,80 @@ export const moreInfoLinks: MoreInfoLink[] = [
   {
     langName: 'Français',
     langCode: 'fr',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/fr.pdf`,
+    url: '/brochures/fr.pdf',
   },
   {
     langName: 'Русский',
     langCode: 'ru',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/ru.pdf`,
+    url: '/brochures/ru.pdf',
   },
   {
     langName: 'Español',
     langCode: 'es',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/es.pdf`,
+    url: '/brochures/es.pdf',
   },
 
   {
     langName: '中文',
     langCode: 'zh',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/zh.pdf`,
+    url: '/brochures/zh.pdf',
   },
   {
     langName: 'नेपाली गण',
     langCode: 'npi',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/npi.pdf`,
+    url: '/brochures/npi.pdf',
   },
   {
     langName: 'Somali',
     langCode: 'som',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/som.pdf`,
+    url: '/brochures/som.pdf',
   },
 
   {
     langName: 'زبان فارسی',
     langCode: 'fas',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/fas.pdf`,
+    url: '/brochures/fas.pdf',
   },
   {
     langName: 'Eesti',
     langCode: 'et',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/et.pdf`,
+    url: '/brochures/et.pdf',
   },
   {
     langName: 'Türkçe',
     langCode: 'tur',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/tur.pdf`,
+    url: '/brochures/tur.pdf',
   },
 
   {
     langName: 'اَلْعَرَبِيَّةُ',
     langCode: 'ar',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/ara.pdf`,
+    url: '/brochures/ara.pdf',
   },
   {
     langName: 'کوردی',
     langCode: 'ckb',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/ckb.pdf`,
+    url: '/brochures/ckb.pdf',
   },
   {
     langName: 'Tiếng Việt',
     langCode: 'vi',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/vi.pdf`,
+    url: '/brochures/vi.pdf',
   },
 
   {
     langName: 'English',
     langCode: 'en',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/en.pdf`,
+    url: '/brochures/en.pdf',
   },
   {
     langName: 'Svenska',
     langCode: 'sv',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/sv.pdf`,
+    url: '/brochures/sv.pdf',
   },
   {
     langName: 'Suomi',
     langCode: 'fi',
-    url: `${import.meta.env.PUBLIC_URL}/brochures/fi.pdf`,
+    url: '/brochures/fi.pdf',
   },
 ];


### PR DESCRIPTION
KK-1060.

The URLs were broken, because they had a needless parameter there (after the huge dependency upgrade that was done recently).

<img width="1176" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-ui/assets/389204/2e3a1b7f-a184-43c4-ad33-2838dd5b646d">
