### PR TITLE
KK-738 | fix: set correct background color behind hero image's lower grey part

### DIFF
--- a/src/domain/home/hero/hero.module.scss
+++ b/src/domain/home/hero/hero.module.scss
@@ -12,7 +12,9 @@
   grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
   display: grid;
   @include respond-above(lg) {
-    background-image: url('../../../assets/images/Culture_kids_background@2x.png');
+    background-image:
+      linear-gradient(to bottom, var(--color-summer) 276px, var(--color-black-5) 0),
+      url('../../../assets/images/Culture_kids_background@2x.png');
     background-repeat: repeat-x;
     background-position: center bottom -2px;
     background-size: 100% 321px;


### PR DESCRIPTION
## Description

NOTE:
 - Zooming may make the background color position change a tiny bit which shows up as a discrepancy between the change from the yellow color and the grey color, like a one pixel offset or sometimes not

### fix: set correct background color behind hero image's lower grey part

The background color was more white, now it is var(--color-black-5)
which is #f2f2f2 which is almost the same as #f1f1f1 which would be
the value from the hero image's lower part. Chose to use --color-black-5
because it was provided by HDS and was almost the same color.

refs KK-738

## Context

[KK-738](https://helsinkisolutionoffice.atlassian.net/browse/KK-738)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

![image](https://github.com/City-of-Helsinki/kukkuu-ui/assets/77663720/105703c3-5533-4c38-a27b-203279470b55)
![image](https://github.com/City-of-Helsinki/kukkuu-ui/assets/77663720/07378578-f41c-462a-89ef-96029e5c99ba)
![image](https://github.com/City-of-Helsinki/kukkuu-ui/assets/77663720/317715fb-08e3-4eeb-b86f-faca5579ba16)

<!-- Add screenshots if appropriate -->


[KK-738]: https://helsinkisolutionoffice.atlassian.net/browse/KK-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ