### PR TITLE
KK-1065 | refactor: generate most subtypes with graphql-codegen using fragments

### DIFF
--- a/src/domain/api/generatedTypes/graphql.tsx
+++ b/src/domain/api/generatedTypes/graphql.tsx
@@ -1800,6 +1800,11 @@ export type AddNewChildMutation = {
   } | null;
 };
 
+export type DeleteChildMutationPayloadFieldsFragment = {
+  __typename?: 'DeleteChildMutationPayload';
+  clientMutationId: string | null;
+};
+
 export type DeleteChildMutationVariables = Exact<{
   input: DeleteChildMutationInput;
 }>;
@@ -1809,6 +1814,35 @@ export type DeleteChildMutation = {
   deleteChild: {
     __typename?: 'DeleteChildMutationPayload';
     clientMutationId: string | null;
+  } | null;
+};
+
+export type UpdateChildMutationPayloadFieldsFragment = {
+  __typename?: 'UpdateChildMutationPayload';
+  child: {
+    __typename?: 'ChildNode';
+    id: string;
+    firstName: string;
+    lastName: string;
+    birthdate: any;
+    postalCode: string;
+    project: {
+      __typename?: 'ProjectNode';
+      id: string;
+      name: string | null;
+      year: number;
+    };
+    relationships: {
+      __typename?: 'RelationshipNodeConnection';
+      edges: Array<{
+        __typename?: 'RelationshipNodeEdge';
+        node: {
+          __typename?: 'RelationshipNode';
+          id: string;
+          type: RelationshipTypeEnum | null;
+        } | null;
+      } | null>;
+    };
   } | null;
 };
 
@@ -1902,6 +1936,424 @@ export type EnrolmentEventFieldsFragment = {
   image: string;
   imageAltText: string | null;
   participantsPerInvite: EventParticipantsPerInvite;
+};
+
+export type PastEventOccurrenceFieldsFragment = {
+  __typename?: 'OccurrenceNode';
+  id: string;
+  time: any;
+};
+
+export type PastEventOccurrencesFieldsFragment = {
+  __typename?: 'OccurrenceNodeConnection';
+  edges: Array<{
+    __typename?: 'OccurrenceNodeEdge';
+    node: { __typename?: 'OccurrenceNode'; id: string; time: any } | null;
+  } | null>;
+};
+
+export type PastEventFieldsFragment = {
+  __typename?: 'EventNode';
+  id: string;
+  name: string | null;
+  shortDescription: string | null;
+  image: string;
+  imageAltText: string | null;
+  participantsPerInvite: EventParticipantsPerInvite;
+  occurrences: {
+    __typename?: 'OccurrenceNodeConnection';
+    edges: Array<{
+      __typename?: 'OccurrenceNodeEdge';
+      node: { __typename?: 'OccurrenceNode'; id: string; time: any } | null;
+    } | null>;
+  };
+};
+
+export type PastEventsFieldsFragment = {
+  __typename?: 'EventConnection';
+  edges: Array<{
+    __typename?: 'EventEdge';
+    node: {
+      __typename?: 'EventNode';
+      id: string;
+      name: string | null;
+      shortDescription: string | null;
+      image: string;
+      imageAltText: string | null;
+      participantsPerInvite: EventParticipantsPerInvite;
+      occurrences: {
+        __typename?: 'OccurrenceNodeConnection';
+        edges: Array<{
+          __typename?: 'OccurrenceNodeEdge';
+          node: { __typename?: 'OccurrenceNode'; id: string; time: any } | null;
+        } | null>;
+      };
+    } | null;
+  } | null>;
+};
+
+export type EnrolmentVenueFieldsFragment = {
+  __typename?: 'VenueNode';
+  id: string;
+  name: string | null;
+  address: string | null;
+};
+
+export type EnrolmentOccurrenceFieldsFragment = {
+  __typename?: 'OccurrenceNode';
+  id: string;
+  time: any;
+  venue: {
+    __typename?: 'VenueNode';
+    id: string;
+    name: string | null;
+    address: string | null;
+  };
+  event: {
+    __typename?: 'EventNode';
+    id: string;
+    name: string | null;
+    shortDescription: string | null;
+    duration: number | null;
+    image: string;
+    imageAltText: string | null;
+    participantsPerInvite: EventParticipantsPerInvite;
+  };
+};
+
+export type ActiveInternalEnrolmentFieldsFragment = {
+  __typename: 'EnrolmentNode';
+  id: string;
+  referenceId: string | null;
+  occurrence: {
+    __typename?: 'OccurrenceNode';
+    id: string;
+    time: any;
+    venue: {
+      __typename?: 'VenueNode';
+      id: string;
+      name: string | null;
+      address: string | null;
+    };
+    event: {
+      __typename?: 'EventNode';
+      id: string;
+      name: string | null;
+      shortDescription: string | null;
+      duration: number | null;
+      image: string;
+      imageAltText: string | null;
+      participantsPerInvite: EventParticipantsPerInvite;
+    };
+  };
+};
+
+export type ActiveTicketmasterEnrolmentFieldsFragment = {
+  __typename: 'TicketmasterEnrolmentNode';
+  id: string;
+  event: {
+    __typename?: 'EventNode';
+    id: string;
+    name: string | null;
+    shortDescription: string | null;
+    duration: number | null;
+    image: string;
+    imageAltText: string | null;
+    participantsPerInvite: EventParticipantsPerInvite;
+  };
+};
+
+export type ActiveLippupisteEnrolmentFieldsFragment = {
+  __typename: 'LippupisteEnrolmentNode';
+  id: string;
+  event: {
+    __typename?: 'EventNode';
+    id: string;
+    name: string | null;
+    shortDescription: string | null;
+    duration: number | null;
+    image: string;
+    imageAltText: string | null;
+    participantsPerInvite: EventParticipantsPerInvite;
+  };
+};
+
+export type ActiveInternalAndTicketSystemEnrolmentsFieldsFragment = {
+  __typename?: 'InternalOrTicketSystemEnrolmentConnection';
+  edges: Array<{
+    __typename?: 'InternalOrTicketSystemEnrolmentEdge';
+    node:
+      | {
+          __typename: 'EnrolmentNode';
+          id: string;
+          referenceId: string | null;
+          occurrence: {
+            __typename?: 'OccurrenceNode';
+            id: string;
+            time: any;
+            venue: {
+              __typename?: 'VenueNode';
+              id: string;
+              name: string | null;
+              address: string | null;
+            };
+            event: {
+              __typename?: 'EventNode';
+              id: string;
+              name: string | null;
+              shortDescription: string | null;
+              duration: number | null;
+              image: string;
+              imageAltText: string | null;
+              participantsPerInvite: EventParticipantsPerInvite;
+            };
+          };
+        }
+      | {
+          __typename: 'LippupisteEnrolmentNode';
+          id: string;
+          event: {
+            __typename?: 'EventNode';
+            id: string;
+            name: string | null;
+            shortDescription: string | null;
+            duration: number | null;
+            image: string;
+            imageAltText: string | null;
+            participantsPerInvite: EventParticipantsPerInvite;
+          };
+        }
+      | {
+          __typename: 'TicketmasterEnrolmentNode';
+          id: string;
+          event: {
+            __typename?: 'EventNode';
+            id: string;
+            name: string | null;
+            shortDescription: string | null;
+            duration: number | null;
+            image: string;
+            imageAltText: string | null;
+            participantsPerInvite: EventParticipantsPerInvite;
+          };
+        }
+      | null;
+  } | null>;
+};
+
+export type UpcomingEventFieldsFragment = {
+  __typename: 'EventNode';
+  id: string;
+  name: string | null;
+  shortDescription: string | null;
+  image: string;
+  imageAltText: string | null;
+  participantsPerInvite: EventParticipantsPerInvite;
+  canChildEnroll: boolean | null;
+};
+
+export type UpcomingEventGroupFieldsFragment = {
+  __typename: 'EventGroupNode';
+  id: string;
+  name: string | null;
+  shortDescription: string | null;
+  image: string;
+  imageAltText: string | null;
+  canChildEnroll: boolean | null;
+};
+
+export type UpcomingEventsAndEventGroupsFieldsFragment = {
+  __typename?: 'EventOrEventGroupConnection';
+  edges: Array<{
+    __typename?: 'EventOrEventGroupEdge';
+    node:
+      | {
+          __typename: 'EventGroupNode';
+          id: string;
+          name: string | null;
+          shortDescription: string | null;
+          image: string;
+          imageAltText: string | null;
+          canChildEnroll: boolean | null;
+        }
+      | {
+          __typename: 'EventNode';
+          id: string;
+          name: string | null;
+          shortDescription: string | null;
+          image: string;
+          imageAltText: string | null;
+          participantsPerInvite: EventParticipantsPerInvite;
+          canChildEnroll: boolean | null;
+        }
+      | null;
+  } | null>;
+};
+
+export type RelationshipFieldsFragment = {
+  __typename?: 'RelationshipNode';
+  id: string;
+  type: RelationshipTypeEnum | null;
+};
+
+export type RelationshipsFieldsFragment = {
+  __typename?: 'RelationshipNodeConnection';
+  edges: Array<{
+    __typename?: 'RelationshipNodeEdge';
+    node: {
+      __typename?: 'RelationshipNode';
+      id: string;
+      type: RelationshipTypeEnum | null;
+    } | null;
+  } | null>;
+};
+
+export type ChildByIdQueryProjectFieldsFragment = {
+  __typename?: 'ProjectNode';
+  id: string;
+  name: string | null;
+  year: number;
+};
+
+export type ChildByIdQueryFieldsFragment = {
+  __typename?: 'ChildNode';
+  id: string;
+  firstName: string;
+  lastName: string;
+  birthdate: any;
+  postalCode: string;
+  project: {
+    __typename?: 'ProjectNode';
+    id: string;
+    name: string | null;
+    year: number;
+  };
+  activeInternalAndTicketSystemEnrolments: {
+    __typename?: 'InternalOrTicketSystemEnrolmentConnection';
+    edges: Array<{
+      __typename?: 'InternalOrTicketSystemEnrolmentEdge';
+      node:
+        | {
+            __typename: 'EnrolmentNode';
+            id: string;
+            referenceId: string | null;
+            occurrence: {
+              __typename?: 'OccurrenceNode';
+              id: string;
+              time: any;
+              venue: {
+                __typename?: 'VenueNode';
+                id: string;
+                name: string | null;
+                address: string | null;
+              };
+              event: {
+                __typename?: 'EventNode';
+                id: string;
+                name: string | null;
+                shortDescription: string | null;
+                duration: number | null;
+                image: string;
+                imageAltText: string | null;
+                participantsPerInvite: EventParticipantsPerInvite;
+              };
+            };
+          }
+        | {
+            __typename: 'LippupisteEnrolmentNode';
+            id: string;
+            event: {
+              __typename?: 'EventNode';
+              id: string;
+              name: string | null;
+              shortDescription: string | null;
+              duration: number | null;
+              image: string;
+              imageAltText: string | null;
+              participantsPerInvite: EventParticipantsPerInvite;
+            };
+          }
+        | {
+            __typename: 'TicketmasterEnrolmentNode';
+            id: string;
+            event: {
+              __typename?: 'EventNode';
+              id: string;
+              name: string | null;
+              shortDescription: string | null;
+              duration: number | null;
+              image: string;
+              imageAltText: string | null;
+              participantsPerInvite: EventParticipantsPerInvite;
+            };
+          }
+        | null;
+    } | null>;
+  } | null;
+  upcomingEventsAndEventGroups: {
+    __typename?: 'EventOrEventGroupConnection';
+    edges: Array<{
+      __typename?: 'EventOrEventGroupEdge';
+      node:
+        | {
+            __typename: 'EventGroupNode';
+            id: string;
+            name: string | null;
+            shortDescription: string | null;
+            image: string;
+            imageAltText: string | null;
+            canChildEnroll: boolean | null;
+          }
+        | {
+            __typename: 'EventNode';
+            id: string;
+            name: string | null;
+            shortDescription: string | null;
+            image: string;
+            imageAltText: string | null;
+            participantsPerInvite: EventParticipantsPerInvite;
+            canChildEnroll: boolean | null;
+          }
+        | null;
+    } | null>;
+  } | null;
+  pastEvents: {
+    __typename?: 'EventConnection';
+    edges: Array<{
+      __typename?: 'EventEdge';
+      node: {
+        __typename?: 'EventNode';
+        id: string;
+        name: string | null;
+        shortDescription: string | null;
+        image: string;
+        imageAltText: string | null;
+        participantsPerInvite: EventParticipantsPerInvite;
+        occurrences: {
+          __typename?: 'OccurrenceNodeConnection';
+          edges: Array<{
+            __typename?: 'OccurrenceNodeEdge';
+            node: {
+              __typename?: 'OccurrenceNode';
+              id: string;
+              time: any;
+            } | null;
+          } | null>;
+        };
+      } | null;
+    } | null>;
+  } | null;
+  relationships: {
+    __typename?: 'RelationshipNodeConnection';
+    edges: Array<{
+      __typename?: 'RelationshipNodeEdge';
+      node: {
+        __typename?: 'RelationshipNode';
+        id: string;
+        type: RelationshipTypeEnum | null;
+      } | null;
+    } | null>;
+  };
 };
 
 export type ChildByIdQueryVariables = Exact<{
@@ -2064,6 +2516,106 @@ export type AssignTicketSystemPasswordMutation = {
   } | null;
 };
 
+export type EnrolOccurrencesFieldsFragment = {
+  __typename?: 'OccurrenceNodeConnection';
+  edges: Array<{
+    __typename?: 'OccurrenceNodeEdge';
+    node: {
+      __typename?: 'OccurrenceNode';
+      id: string;
+      time: any;
+      event: {
+        __typename?: 'EventNode';
+        id: string;
+        image: string;
+        imageAltText: string | null;
+        description: string | null;
+        shortDescription: string | null;
+        name: string | null;
+        duration: number | null;
+        participantsPerInvite: EventParticipantsPerInvite;
+      };
+      venue: {
+        __typename?: 'VenueNode';
+        id: string;
+        name: string | null;
+        address: string | null;
+        accessibilityInfo: string | null;
+        arrivalInstructions: string | null;
+        additionalInfo: string | null;
+        wwwUrl: string | null;
+        wcAndFacilities: string | null;
+      };
+    } | null;
+  } | null>;
+};
+
+export type EnrolOccurrenceMutationPayloadFieldsFragment = {
+  __typename?: 'EnrolOccurrenceMutationPayload';
+  clientMutationId: string | null;
+  enrolment: {
+    __typename?: 'EnrolmentNode';
+    id: string;
+    occurrence: {
+      __typename?: 'OccurrenceNode';
+      id: string;
+      event: { __typename?: 'EventNode'; id: string };
+      venue: { __typename?: 'VenueNode'; id: string };
+    };
+    child: {
+      __typename?: 'ChildNode';
+      id: string;
+      occurrences: {
+        __typename?: 'OccurrenceNodeConnection';
+        edges: Array<{
+          __typename?: 'OccurrenceNodeEdge';
+          node: {
+            __typename?: 'OccurrenceNode';
+            id: string;
+            time: any;
+            event: {
+              __typename?: 'EventNode';
+              id: string;
+              image: string;
+              imageAltText: string | null;
+              description: string | null;
+              shortDescription: string | null;
+              name: string | null;
+              duration: number | null;
+              participantsPerInvite: EventParticipantsPerInvite;
+            };
+            venue: {
+              __typename?: 'VenueNode';
+              id: string;
+              name: string | null;
+              address: string | null;
+              accessibilityInfo: string | null;
+              arrivalInstructions: string | null;
+              additionalInfo: string | null;
+              wwwUrl: string | null;
+              wcAndFacilities: string | null;
+            };
+          } | null;
+        } | null>;
+      };
+      pastEvents: {
+        __typename?: 'EventConnection';
+        edges: Array<{
+          __typename?: 'EventEdge';
+          node: { __typename?: 'EventNode'; id: string } | null;
+        } | null>;
+      } | null;
+      availableEvents: {
+        __typename?: 'EventConnection';
+        edges: Array<{
+          __typename?: 'EventEdge';
+          node: { __typename?: 'EventNode'; id: string } | null;
+        } | null>;
+      } | null;
+    } | null;
+  } | null;
+};
+
 export type EnrolOccurrenceMutationVariables = Exact<{
   input: EnrolOccurrenceMutationInput;
 }>;
@@ -2146,6 +2698,101 @@ export type SubscribeToFreeSpotNotificationMutation = {
   subscribeToFreeSpotNotification: {
     __typename?: 'SubscribeToFreeSpotNotificationMutationPayload';
     clientMutationId: string | null;
+  } | null;
+};
+
+export type UnenrolOccurrencesFieldsFragment = {
+  __typename?: 'OccurrenceNodeConnection';
+  edges: Array<{
+    __typename?: 'OccurrenceNodeEdge';
+    node: {
+      __typename?: 'OccurrenceNode';
+      id: string;
+      time: any;
+      event: {
+        __typename?: 'EventNode';
+        id: string;
+        image: string;
+        imageAltText: string | null;
+        description: string | null;
+        shortDescription: string | null;
+        name: string | null;
+        duration: number | null;
+        participantsPerInvite: EventParticipantsPerInvite;
+      };
+      venue: {
+        __typename?: 'VenueNode';
+        id: string;
+        name: string | null;
+        address: string | null;
+        accessibilityInfo: string | null;
+        arrivalInstructions: string | null;
+        additionalInfo: string | null;
+        wwwUrl: string | null;
+        wcAndFacilities: string | null;
+      };
+    } | null;
+  } | null>;
+};
+
+export type UnenrolOccurrenceMutationPayloadFieldsFragment = {
+  __typename?: 'UnenrolOccurrenceMutationPayload';
+  clientMutationId: string | null;
+  occurrence: {
+    __typename?: 'OccurrenceNode';
+    id: string;
+    event: { __typename?: 'EventNode'; id: string };
+  } | null;
+  child: {
+    __typename?: 'ChildNode';
+    id: string;
+    availableEvents: {
+      __typename?: 'EventConnection';
+      edges: Array<{
+        __typename?: 'EventEdge';
+        node: { __typename?: 'EventNode'; id: string } | null;
+      } | null>;
+    } | null;
+    occurrences: {
+      __typename?: 'OccurrenceNodeConnection';
+      edges: Array<{
+        __typename?: 'OccurrenceNodeEdge';
+        node: {
+          __typename?: 'OccurrenceNode';
+          id: string;
+          time: any;
+          event: {
+            __typename?: 'EventNode';
+            id: string;
+            image: string;
+            imageAltText: string | null;
+            description: string | null;
+            shortDescription: string | null;
+            name: string | null;
+            duration: number | null;
+            participantsPerInvite: EventParticipantsPerInvite;
+          };
+          venue: {
+            __typename?: 'VenueNode';
+            id: string;
+            name: string | null;
+            address: string | null;
+            accessibilityInfo: string | null;
+            arrivalInstructions: string | null;
+            additionalInfo: string | null;
+            wwwUrl: string | null;
+            wcAndFacilities: string | null;
+          };
+        } | null;
+      } | null>;
+    };
+    pastEvents: {
+      __typename?: 'EventConnection';
+      edges: Array<{
+        __typename?: 'EventEdge';
+        node: { __typename?: 'EventNode'; id: string } | null;
+      } | null>;
+    } | null;
   } | null;
 };
 
@@ -2253,7 +2900,7 @@ export type EventExternalTicketSystemPasswordCountQuery = {
   } | null;
 };
 
-export type OccurrenceFragment = {
+export type EventOccurrenceFieldsFragment = {
   __typename?: 'OccurrenceNode';
   id: string;
   time: any;
@@ -2284,6 +2931,45 @@ export type OccurrenceFragment = {
         type: TicketSystem;
       }
     | null;
+};
+
+export type EventOccurrencesFieldsFragment = {
+  __typename?: 'OccurrenceNodeConnection';
+  edges: Array<{
+    __typename?: 'OccurrenceNodeEdge';
+    node: {
+      __typename?: 'OccurrenceNode';
+      id: string;
+      time: any;
+      remainingCapacity: number | null;
+      childHasFreeSpotNotificationSubscription: boolean | null;
+      event: {
+        __typename?: 'EventNode';
+        id: string;
+        name: string | null;
+        duration: number | null;
+      };
+      venue: {
+        __typename?: 'VenueNode';
+        id: string;
+        name: string | null;
+        address: string | null;
+      };
+      ticketSystem:
+        | { __typename?: 'InternalOccurrenceTicketSystem'; type: TicketSystem }
+        | {
+            __typename?: 'LippupisteOccurrenceTicketSystem';
+            url: string;
+            type: TicketSystem;
+          }
+        | {
+            __typename?: 'TicketmasterOccurrenceTicketSystem';
+            url: string;
+            type: TicketSystem;
+          }
+        | null;
+    } | null;
+  } | null>;
 };
 
 export type EventQueryVariables = Exact<{
@@ -2475,6 +3161,68 @@ export type EventExternalTicketSystemPasswordQuery = {
   } | null;
 };
 
+export type TicketmasterEventFieldsFragment = {
+  __typename?: 'TicketmasterEventTicketSystem';
+  childPassword: string | null;
+  url: string;
+};
+
+export type LippupisteEventFieldsFragment = {
+  __typename?: 'LippupisteEventTicketSystem';
+  childPassword: string | null;
+  url: string;
+};
+
+export type ExternalTicketSystemEventFieldsFragment = {
+  __typename?: 'EventNode';
+  id: string;
+  name: string | null;
+  description: string | null;
+  image: string;
+  imageAltText: string | null;
+  participantsPerInvite: EventParticipantsPerInvite;
+  occurrences: {
+    __typename?: 'OccurrenceNodeConnection';
+    edges: Array<{
+      __typename?: 'OccurrenceNodeEdge';
+      node: {
+        __typename?: 'OccurrenceNode';
+        ticketSystem:
+          | {
+              __typename?: 'InternalOccurrenceTicketSystem';
+              type: TicketSystem;
+            }
+          | {
+              __typename?: 'LippupisteOccurrenceTicketSystem';
+              url: string;
+              type: TicketSystem;
+            }
+          | {
+              __typename?: 'TicketmasterOccurrenceTicketSystem';
+              url: string;
+              type: TicketSystem;
+            }
+          | null;
+      } | null;
+    } | null>;
+  };
+  ticketSystem:
+    | { __typename?: 'InternalEventTicketSystem'; type: TicketSystem }
+    | {
+        __typename?: 'LippupisteEventTicketSystem';
+        type: TicketSystem;
+        childPassword: string | null;
+        url: string;
+      }
+    | {
+        __typename?: 'TicketmasterEventTicketSystem';
+        type: TicketSystem;
+        childPassword: string | null;
+        url: string;
+      }
+    | null;
+};
+
 export type ExternalTicketSystemEventQueryVariables = Exact<{
   eventId: Scalars['ID']['input'];
   childId: Scalars['ID']['input'];
@@ -2519,18 +3267,74 @@ export type ExternalTicketSystemEventQuery = {
       | { __typename?: 'InternalEventTicketSystem'; type: TicketSystem }
       | {
           __typename?: 'LippupisteEventTicketSystem';
+          type: TicketSystem;
           childPassword: string | null;
           url: string;
-          type: TicketSystem;
         }
       | {
           __typename?: 'TicketmasterEventTicketSystem';
+          type: TicketSystem;
           childPassword: string | null;
           url: string;
-          type: TicketSystem;
         }
       | null;
   } | null;
+};
+
+export type OccurrenceEventFieldsFragment = {
+  __typename?: 'EventNode';
+  id: string;
+  image: string;
+  imageAltText: string | null;
+  description: string | null;
+  shortDescription: string | null;
+  name: string | null;
+  duration: number | null;
+  participantsPerInvite: EventParticipantsPerInvite;
+  eventGroup: { __typename?: 'EventGroupNode'; id: string } | null;
+};
+
+export type OccurrenceVenueFieldsFragment = {
+  __typename?: 'VenueNode';
+  id: string;
+  name: string | null;
+  address: string | null;
+  accessibilityInfo: string | null;
+  arrivalInstructions: string | null;
+  additionalInfo: string | null;
+  wwwUrl: string | null;
+  wcAndFacilities: string | null;
+};
+
+export type OccurrenceFieldsFragment = {
+  __typename?: 'OccurrenceNode';
+  id: string;
+  time: any;
+  remainingCapacity: number | null;
+  childHasFreeSpotNotificationSubscription: boolean | null;
+  event: {
+    __typename?: 'EventNode';
+    id: string;
+    image: string;
+    imageAltText: string | null;
+    description: string | null;
+    shortDescription: string | null;
+    name: string | null;
+    duration: number | null;
+    participantsPerInvite: EventParticipantsPerInvite;
+    eventGroup: { __typename?: 'EventGroupNode'; id: string } | null;
+  };
+  venue: {
+    __typename?: 'VenueNode';
+    id: string;
+    name: string | null;
+    address: string | null;
+    accessibilityInfo: string | null;
+    arrivalInstructions: string | null;
+    additionalInfo: string | null;
+    wwwUrl: string | null;
+    wcAndFacilities: string | null;
+  };
 };
 
 export type OccurrenceQueryVariables = Exact<{
@@ -2570,6 +3374,55 @@ export type OccurrenceQuery = {
       wcAndFacilities: string | null;
     };
   } | null;
+};
+
+export type EventGroupEventFieldsFragment = {
+  __typename?: 'EventNode';
+  id: string;
+  name: string | null;
+  shortDescription: string | null;
+  image: string;
+  imageAltText: string | null;
+  canChildEnroll: boolean | null;
+};
+
+export type EventGroupEventsFieldsFragment = {
+  __typename?: 'EventNodeConnection';
+  edges: Array<{
+    __typename?: 'EventNodeEdge';
+    node: {
+      __typename?: 'EventNode';
+      id: string;
+      name: string | null;
+      shortDescription: string | null;
+      image: string;
+      imageAltText: string | null;
+      canChildEnroll: boolean | null;
+    } | null;
+  } | null>;
+};
+
+export type EventGroupFieldsFragment = {
+  __typename?: 'EventGroupNode';
+  id: string;
+  name: string | null;
+  shortDescription: string | null;
+  description: string | null;
+  events: {
+    __typename?: 'EventNodeConnection';
+    edges: Array<{
+      __typename?: 'EventNodeEdge';
+      node: {
+        __typename?: 'EventNode';
+        id: string;
+        name: string | null;
+        shortDescription: string | null;
+        image: string;
+        imageAltText: string | null;
+        canChildEnroll: boolean | null;
+      } | null;
+    } | null>;
+  };
 };
 
 export type EventGroupQueryVariables = Exact<{
@@ -2640,6 +3493,24 @@ export type GuardiansQuery = {
   } | null;
 };
 
+export type LanguageFieldsFragment = {
+  __typename?: 'LanguageNode';
+  id: string;
+  name: string | null;
+};
+
+export type LanguagesFieldsFragment = {
+  __typename?: 'LanguageNodeConnection';
+  edges: Array<{
+    __typename?: 'LanguageNodeEdge';
+    node: {
+      __typename?: 'LanguageNode';
+      id: string;
+      name: string | null;
+    } | null;
+  } | null>;
+};
+
 export type LanguageQueryVariables = Exact<{ [key: string]: never }>;
 
 export type LanguageQuery = {
@@ -2691,6 +3562,346 @@ export type ProfileChildrenQuery = {
       } | null>;
     };
   } | null;
+};
+
+export type MyProfileEnrolmentFieldsFragment = {
+  __typename?: 'EnrolmentNode';
+  id: string;
+  occurrence: {
+    __typename?: 'OccurrenceNode';
+    id: string;
+    time: any;
+    venue: { __typename?: 'VenueNode'; id: string; name: string | null };
+    event: {
+      __typename?: 'EventNode';
+      id: string;
+      name: string | null;
+      duration: number | null;
+    };
+  };
+};
+
+export type MyProfileEnrolmentsFieldsFragment = {
+  __typename?: 'EnrolmentNodeConnection';
+  edges: Array<{
+    __typename?: 'EnrolmentNodeEdge';
+    node: {
+      __typename?: 'EnrolmentNode';
+      id: string;
+      occurrence: {
+        __typename?: 'OccurrenceNode';
+        id: string;
+        time: any;
+        venue: { __typename?: 'VenueNode'; id: string; name: string | null };
+        event: {
+          __typename?: 'EventNode';
+          id: string;
+          name: string | null;
+          duration: number | null;
+        };
+      };
+    } | null;
+  } | null>;
+};
+
+export type MyProfileChildProjectFieldsFragment = {
+  __typename?: 'ProjectNode';
+  id: string;
+  name: string | null;
+  year: number;
+};
+
+export type MyProfileChildFieldsFragment = {
+  __typename?: 'ChildNode';
+  id: string;
+  firstName: string;
+  lastName: string;
+  birthdate: any;
+  postalCode: string;
+  project: {
+    __typename?: 'ProjectNode';
+    id: string;
+    name: string | null;
+    year: number;
+  };
+  relationships: {
+    __typename?: 'RelationshipNodeConnection';
+    edges: Array<{
+      __typename?: 'RelationshipNodeEdge';
+      node: {
+        __typename?: 'RelationshipNode';
+        id: string;
+        type: RelationshipTypeEnum | null;
+      } | null;
+    } | null>;
+  };
+  upcomingEventsAndEventGroups: {
+    __typename?: 'EventOrEventGroupConnection';
+    edges: Array<{
+      __typename?: 'EventOrEventGroupEdge';
+      node:
+        | { __typename?: 'EventGroupNode'; id: string; name: string | null }
+        | {
+            __typename?: 'EventNode';
+            id: string;
+            name: string | null;
+            duration: number | null;
+            participantsPerInvite: EventParticipantsPerInvite;
+          }
+        | null;
+    } | null>;
+  } | null;
+  occurrences: {
+    __typename?: 'OccurrenceNodeConnection';
+    edges: Array<{
+      __typename?: 'OccurrenceNodeEdge';
+      node: {
+        __typename?: 'OccurrenceNode';
+        id: string;
+        event: {
+          __typename?: 'EventNode';
+          id: string;
+          name: string | null;
+          shortDescription: string | null;
+        };
+      } | null;
+    } | null>;
+  };
+  enrolments: {
+    __typename?: 'EnrolmentNodeConnection';
+    edges: Array<{
+      __typename?: 'EnrolmentNodeEdge';
+      node: {
+        __typename?: 'EnrolmentNode';
+        id: string;
+        occurrence: {
+          __typename?: 'OccurrenceNode';
+          id: string;
+          time: any;
+          venue: { __typename?: 'VenueNode'; id: string; name: string | null };
+          event: {
+            __typename?: 'EventNode';
+            id: string;
+            name: string | null;
+            duration: number | null;
+          };
+        };
+      } | null;
+    } | null>;
+  };
+};
+
+export type MyProfileChildrenFieldsFragment = {
+  __typename?: 'ChildNodeConnection';
+  edges: Array<{
+    __typename?: 'ChildNodeEdge';
+    node: {
+      __typename?: 'ChildNode';
+      id: string;
+      firstName: string;
+      lastName: string;
+      birthdate: any;
+      postalCode: string;
+      project: {
+        __typename?: 'ProjectNode';
+        id: string;
+        name: string | null;
+        year: number;
+      };
+      relationships: {
+        __typename?: 'RelationshipNodeConnection';
+        edges: Array<{
+          __typename?: 'RelationshipNodeEdge';
+          node: {
+            __typename?: 'RelationshipNode';
+            id: string;
+            type: RelationshipTypeEnum | null;
+          } | null;
+        } | null>;
+      };
+      upcomingEventsAndEventGroups: {
+        __typename?: 'EventOrEventGroupConnection';
+        edges: Array<{
+          __typename?: 'EventOrEventGroupEdge';
+          node:
+            | { __typename?: 'EventGroupNode'; id: string; name: string | null }
+            | {
+                __typename?: 'EventNode';
+                id: string;
+                name: string | null;
+                duration: number | null;
+                participantsPerInvite: EventParticipantsPerInvite;
+              }
+            | null;
+        } | null>;
+      } | null;
+      occurrences: {
+        __typename?: 'OccurrenceNodeConnection';
+        edges: Array<{
+          __typename?: 'OccurrenceNodeEdge';
+          node: {
+            __typename?: 'OccurrenceNode';
+            id: string;
+            event: {
+              __typename?: 'EventNode';
+              id: string;
+              name: string | null;
+              shortDescription: string | null;
+            };
+          } | null;
+        } | null>;
+      };
+      enrolments: {
+        __typename?: 'EnrolmentNodeConnection';
+        edges: Array<{
+          __typename?: 'EnrolmentNodeEdge';
+          node: {
+            __typename?: 'EnrolmentNode';
+            id: string;
+            occurrence: {
+              __typename?: 'OccurrenceNode';
+              id: string;
+              time: any;
+              venue: {
+                __typename?: 'VenueNode';
+                id: string;
+                name: string | null;
+              };
+              event: {
+                __typename?: 'EventNode';
+                id: string;
+                name: string | null;
+                duration: number | null;
+              };
+            };
+          } | null;
+        } | null>;
+      };
+    } | null;
+  } | null>;
+};
+
+export type LanguageSpokenAtHomeFieldsFragment = {
+  __typename?: 'LanguageNode';
+  id: string;
+};
+
+export type LanguagesSpokenAtHomeFieldsFragment = {
+  __typename?: 'LanguageNodeConnection';
+  edges: Array<{
+    __typename?: 'LanguageNodeEdge';
+    node: { __typename?: 'LanguageNode'; id: string } | null;
+  } | null>;
+};
+
+export type MyProfileFieldsFragment = {
+  __typename?: 'GuardianNode';
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+  language: Language;
+  children: {
+    __typename?: 'ChildNodeConnection';
+    edges: Array<{
+      __typename?: 'ChildNodeEdge';
+      node: {
+        __typename?: 'ChildNode';
+        id: string;
+        firstName: string;
+        lastName: string;
+        birthdate: any;
+        postalCode: string;
+        project: {
+          __typename?: 'ProjectNode';
+          id: string;
+          name: string | null;
+          year: number;
+        };
+        relationships: {
+          __typename?: 'RelationshipNodeConnection';
+          edges: Array<{
+            __typename?: 'RelationshipNodeEdge';
+            node: {
+              __typename?: 'RelationshipNode';
+              id: string;
+              type: RelationshipTypeEnum | null;
+            } | null;
+          } | null>;
+        };
+        upcomingEventsAndEventGroups: {
+          __typename?: 'EventOrEventGroupConnection';
+          edges: Array<{
+            __typename?: 'EventOrEventGroupEdge';
+            node:
+              | {
+                  __typename?: 'EventGroupNode';
+                  id: string;
+                  name: string | null;
+                }
+              | {
+                  __typename?: 'EventNode';
+                  id: string;
+                  name: string | null;
+                  duration: number | null;
+                  participantsPerInvite: EventParticipantsPerInvite;
+                }
+              | null;
+          } | null>;
+        } | null;
+        occurrences: {
+          __typename?: 'OccurrenceNodeConnection';
+          edges: Array<{
+            __typename?: 'OccurrenceNodeEdge';
+            node: {
+              __typename?: 'OccurrenceNode';
+              id: string;
+              event: {
+                __typename?: 'EventNode';
+                id: string;
+                name: string | null;
+                shortDescription: string | null;
+              };
+            } | null;
+          } | null>;
+        };
+        enrolments: {
+          __typename?: 'EnrolmentNodeConnection';
+          edges: Array<{
+            __typename?: 'EnrolmentNodeEdge';
+            node: {
+              __typename?: 'EnrolmentNode';
+              id: string;
+              occurrence: {
+                __typename?: 'OccurrenceNode';
+                id: string;
+                time: any;
+                venue: {
+                  __typename?: 'VenueNode';
+                  id: string;
+                  name: string | null;
+                };
+                event: {
+                  __typename?: 'EventNode';
+                  id: string;
+                  name: string | null;
+                  duration: number | null;
+                };
+              };
+            } | null;
+          } | null>;
+        };
+      } | null;
+    } | null>;
+  };
+  languagesSpokenAtHome: {
+    __typename?: 'LanguageNodeConnection';
+    edges: Array<{
+      __typename?: 'LanguageNodeEdge';
+      node: { __typename?: 'LanguageNode'; id: string } | null;
+    } | null>;
+  };
 };
 
 export type ProfileQueryVariables = Exact<{ [key: string]: never }>;
@@ -2803,6 +4014,91 @@ export type ProfileQuery = {
       edges: Array<{
         __typename?: 'LanguageNodeEdge';
         node: { __typename?: 'LanguageNode'; id: string } | null;
+      } | null>;
+    };
+  } | null;
+};
+
+export type SubmitGuardianFieldsFragment = {
+  __typename?: 'GuardianNode';
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+  language: Language;
+  children: {
+    __typename?: 'ChildNodeConnection';
+    edges: Array<{
+      __typename?: 'ChildNodeEdge';
+      node: {
+        __typename?: 'ChildNode';
+        id: string;
+        firstName: string;
+        lastName: string;
+        birthdate: any;
+        postalCode: string;
+        project: {
+          __typename?: 'ProjectNode';
+          id: string;
+          name: string | null;
+          year: number;
+        };
+        relationships: {
+          __typename?: 'RelationshipNodeConnection';
+          edges: Array<{
+            __typename?: 'RelationshipNodeEdge';
+            node: {
+              __typename?: 'RelationshipNode';
+              id: string;
+              type: RelationshipTypeEnum | null;
+            } | null;
+          } | null>;
+        };
+      } | null;
+    } | null>;
+  };
+};
+
+export type SubmitChildrenAndGuardianMutationPayloadFieldsFragment = {
+  __typename?: 'SubmitChildrenAndGuardianMutationPayload';
+  guardian: {
+    __typename?: 'GuardianNode';
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    phoneNumber: string;
+    language: Language;
+    children: {
+      __typename?: 'ChildNodeConnection';
+      edges: Array<{
+        __typename?: 'ChildNodeEdge';
+        node: {
+          __typename?: 'ChildNode';
+          id: string;
+          firstName: string;
+          lastName: string;
+          birthdate: any;
+          postalCode: string;
+          project: {
+            __typename?: 'ProjectNode';
+            id: string;
+            name: string | null;
+            year: number;
+          };
+          relationships: {
+            __typename?: 'RelationshipNodeConnection';
+            edges: Array<{
+              __typename?: 'RelationshipNodeEdge';
+              node: {
+                __typename?: 'RelationshipNode';
+                id: string;
+                type: RelationshipTypeEnum | null;
+              } | null;
+            } | null>;
+          };
+        } | null;
       } | null>;
     };
   } | null;

--- a/src/domain/child/mutation/ChildMutation.ts
+++ b/src/domain/child/mutation/ChildMutation.ts
@@ -20,36 +20,44 @@ export const addChildMutation = gql`
 `;
 
 export const deleteChildMutation = gql`
+  fragment DeleteChildMutationPayloadFields on DeleteChildMutationPayload {
+    clientMutationId
+  }
+
   mutation deleteChild($input: DeleteChildMutationInput!) {
     deleteChild(input: $input) {
-      clientMutationId
+      ...DeleteChildMutationPayloadFields
     }
   }
 `;
 
 export const editChildMutation = gql`
-  mutation updateChild($input: UpdateChildMutationInput!) {
-    updateChild(input: $input) {
-      child {
+  fragment UpdateChildMutationPayloadFields on UpdateChildMutationPayload {
+    child {
+      id
+      firstName
+      lastName
+      birthdate
+      postalCode
+      project {
         id
-        firstName
-        lastName
-        birthdate
-        postalCode
-        project {
-          id
-          name
-          year
-        }
-        relationships {
-          edges {
-            node {
-              id
-              type
-            }
+        name
+        year
+      }
+      relationships {
+        edges {
+          node {
+            id
+            type
           }
         }
       }
+    }
+  }
+
+  mutation updateChild($input: UpdateChildMutationInput!) {
+    updateChild(input: $input) {
+      ...UpdateChildMutationPayloadFields
     }
   }
 `;

--- a/src/domain/child/queries/ChildQueries.ts
+++ b/src/domain/child/queries/ChildQueries.ts
@@ -10,108 +10,177 @@ export const childByIdQuery = gql`
     imageAltText
     participantsPerInvite
   }
+
+  fragment PastEventOccurrenceFields on OccurrenceNode {
+    id
+    time
+  }
+
+  fragment PastEventOccurrencesFields on OccurrenceNodeConnection {
+    edges {
+      node {
+        ...PastEventOccurrenceFields
+      }
+    }
+  }
+
+  fragment PastEventFields on EventNode {
+    id
+    name
+    shortDescription
+    image
+    imageAltText
+    participantsPerInvite
+    occurrences {
+      ...PastEventOccurrencesFields
+    }
+  }
+
+  fragment PastEventsFields on EventConnection {
+    edges {
+      node {
+        ...PastEventFields
+      }
+    }
+  }
+
+  fragment EnrolmentVenueFields on VenueNode {
+    id
+    name
+    address
+  }
+
+  fragment EnrolmentOccurrenceFields on OccurrenceNode {
+    id
+    time
+    venue {
+      ...EnrolmentVenueFields
+    }
+    event {
+      ...EnrolmentEventFields
+    }
+  }
+
+  fragment ActiveInternalEnrolmentFields on EnrolmentNode {
+    id
+    referenceId
+    occurrence {
+      ...EnrolmentOccurrenceFields
+    }
+    __typename
+  }
+
+  fragment ActiveTicketmasterEnrolmentFields on TicketmasterEnrolmentNode {
+    id
+    event {
+      ...EnrolmentEventFields
+    }
+    __typename
+  }
+
+  fragment ActiveLippupisteEnrolmentFields on LippupisteEnrolmentNode {
+    id
+    event {
+      ...EnrolmentEventFields
+    }
+    __typename
+  }
+
+  fragment ActiveInternalAndTicketSystemEnrolmentsFields on InternalOrTicketSystemEnrolmentConnection {
+    edges {
+      node {
+        ... on EnrolmentNode {
+          ...ActiveInternalEnrolmentFields
+        }
+        ... on TicketmasterEnrolmentNode {
+          ...ActiveTicketmasterEnrolmentFields
+        }
+        ... on LippupisteEnrolmentNode {
+          ...ActiveLippupisteEnrolmentFields
+        }
+      }
+    }
+  }
+
+  fragment UpcomingEventFields on EventNode {
+    id
+    name
+    shortDescription
+    image
+    imageAltText
+    participantsPerInvite
+    canChildEnroll(childId: $id)
+    __typename
+  }
+
+  fragment UpcomingEventGroupFields on EventGroupNode {
+    id
+    name
+    shortDescription
+    image
+    imageAltText
+    canChildEnroll(childId: $id)
+    __typename
+  }
+
+  fragment UpcomingEventsAndEventGroupsFields on EventOrEventGroupConnection {
+    edges {
+      node {
+        ... on EventNode {
+          ...UpcomingEventFields
+        }
+        ... on EventGroupNode {
+          ...UpcomingEventGroupFields
+        }
+      }
+    }
+  }
+
+  fragment RelationshipFields on RelationshipNode {
+    id
+    type
+  }
+
+  fragment RelationshipsFields on RelationshipNodeConnection {
+    edges {
+      node {
+        ...RelationshipFields
+      }
+    }
+  }
+
+  fragment ChildByIdQueryProjectFields on ProjectNode {
+    id
+    name
+    year
+  }
+
+  fragment ChildByIdQueryFields on ChildNode {
+    id
+    firstName
+    lastName
+    birthdate
+    postalCode
+    project {
+      ...ChildByIdQueryProjectFields
+    }
+    activeInternalAndTicketSystemEnrolments {
+      ...ActiveInternalAndTicketSystemEnrolmentsFields
+    }
+    upcomingEventsAndEventGroups {
+      ...UpcomingEventsAndEventGroupsFields
+    }
+    pastEvents {
+      ...PastEventsFields
+    }
+    relationships {
+      ...RelationshipsFields
+    }
+  }
+
   query childByIdQuery($id: ID!) {
     child(id: $id) {
-      id
-      firstName
-      lastName
-      birthdate
-      postalCode
-      project {
-        id
-        name
-        year
-      }
-      activeInternalAndTicketSystemEnrolments {
-        edges {
-          node {
-            ... on EnrolmentNode {
-              id
-              referenceId
-              occurrence {
-                id
-                time
-                venue {
-                  id
-                  name
-                  address
-                }
-                event {
-                  ...EnrolmentEventFields
-                }
-              }
-              __typename
-            }
-            ... on TicketmasterEnrolmentNode {
-              id
-              event {
-                ...EnrolmentEventFields
-              }
-              __typename
-            }
-            ... on LippupisteEnrolmentNode {
-              id
-              event {
-                ...EnrolmentEventFields
-              }
-              __typename
-            }
-          }
-        }
-      }
-      upcomingEventsAndEventGroups {
-        edges {
-          node {
-            ... on EventNode {
-              id
-              name
-              shortDescription
-              image
-              imageAltText
-              participantsPerInvite
-              canChildEnroll(childId: $id)
-              __typename
-            }
-            ... on EventGroupNode {
-              id
-              name
-              shortDescription
-              image
-              imageAltText
-              canChildEnroll(childId: $id)
-              __typename
-            }
-          }
-        }
-      }
-      pastEvents {
-        edges {
-          node {
-            id
-            name
-            shortDescription
-            image
-            imageAltText
-            participantsPerInvite
-            occurrences {
-              edges {
-                node {
-                  id
-                  time
-                }
-              }
-            }
-          }
-        }
-      }
-      relationships {
-        edges {
-          node {
-            id
-            type
-          }
-        }
-      }
+      ...ChildByIdQueryFields
     }
   }
 `;

--- a/src/domain/child/types/ChildByIdQueryTypes.ts
+++ b/src/domain/child/types/ChildByIdQueryTypes.ts
@@ -1,56 +1,46 @@
-import { ChildByIdQuery } from '../../api/generatedTypes/graphql';
+import {
+  ChildByIdQueryFieldsFragment,
+  PastEventsFieldsFragment,
+  PastEventFieldsFragment,
+  ActiveInternalAndTicketSystemEnrolmentsFieldsFragment,
+  ActiveInternalEnrolmentFieldsFragment,
+  ActiveTicketmasterEnrolmentFieldsFragment,
+  ActiveLippupisteEnrolmentFieldsFragment,
+  EnrolmentOccurrenceFieldsFragment,
+  UpcomingEventsAndEventGroupsFieldsFragment,
+  UpcomingEventFieldsFragment,
+  UpcomingEventGroupFieldsFragment,
+} from '../../api/generatedTypes/graphql';
 
-export type ChildByIdResponse = NonNullable<ChildByIdQuery['child']>;
+export type ChildByIdResponse = ChildByIdQueryFieldsFragment;
 
-export type PastEvents = ChildByIdResponse['pastEvents'];
+export type PastEvents = PastEventsFieldsFragment;
 
-export type PastEvent = NonNullable<
-  NonNullable<PastEvents>['edges'][number]
->['node'];
+export type PastEvent = PastEventFieldsFragment;
 
 export type InternalAndTicketSystemEnrolments =
-  ChildByIdResponse['activeInternalAndTicketSystemEnrolments'];
+  ActiveInternalAndTicketSystemEnrolmentsFieldsFragment;
 
-export type InternalOrTicketSystemEnrolment = NonNullable<
-  NonNullable<
-    NonNullable<InternalAndTicketSystemEnrolments>['edges'][number]
-  >['node']
->;
+export type InternalEnrolment = ActiveInternalEnrolmentFieldsFragment;
 
-export type InternalEnrolment = Extract<
-  InternalOrTicketSystemEnrolment,
-  { __typename: 'EnrolmentNode' }
->;
+export type TicketmasterEnrolment = ActiveTicketmasterEnrolmentFieldsFragment;
 
-export type TicketmasterEnrolment = Extract<
-  InternalOrTicketSystemEnrolment,
-  { __typename: 'TicketmasterEnrolmentNode' }
->;
+export type LippupisteEnrolment = ActiveLippupisteEnrolmentFieldsFragment;
 
-export type LippupisteEnrolment = Extract<
-  InternalOrTicketSystemEnrolment,
-  { __typename: 'LippupisteEnrolmentNode' }
->;
+export type InternalOrTicketSystemEnrolment =
+  | ActiveInternalEnrolmentFieldsFragment
+  | ActiveTicketmasterEnrolmentFieldsFragment
+  | ActiveLippupisteEnrolmentFieldsFragment;
 
-export type InternalEnrolmentOccurrence = NonNullable<
-  InternalEnrolment['occurrence']
->;
+export type InternalEnrolmentOccurrence = EnrolmentOccurrenceFieldsFragment;
 
 export type UpcomingEventsAndEventGroups =
-  ChildByIdResponse['upcomingEventsAndEventGroups'];
+  UpcomingEventsAndEventGroupsFieldsFragment;
 
-export type UpcomingEventOrEventGroup = NonNullable<
-  NonNullable<
-    NonNullable<UpcomingEventsAndEventGroups>['edges'][number]
-  >['node']
->;
+export type UpcomingEvent = UpcomingEventFieldsFragment;
 
-export type UpcomingEvent = Extract<
-  UpcomingEventOrEventGroup,
-  { __typename: 'EventNode' }
->;
+export type UpcomingEventGroup = UpcomingEventGroupFieldsFragment;
 
-export type UpcomingEventGroup = Extract<
-  UpcomingEventOrEventGroup,
-  { __typename: 'EventGroupNode' }
->;
+export type UpcomingEventOrEventGroup =
+  | UpcomingEventFieldsFragment
+  | UpcomingEventGroupFieldsFragment;

--- a/src/domain/child/types/DeleteChildMutationTypes.ts
+++ b/src/domain/child/types/DeleteChildMutationTypes.ts
@@ -1,5 +1,0 @@
-import { DeleteChildMutation } from '../../api/generatedTypes/graphql';
-
-export type DeleteChildPayload = NonNullable<
-  DeleteChildMutation['deleteChild']
->;

--- a/src/domain/child/types/UpdateChildMutationTypes.ts
+++ b/src/domain/child/types/UpdateChildMutationTypes.ts
@@ -1,3 +1,0 @@
-import { UpdateChildMutation } from '../../api/generatedTypes/graphql';
-
-export type EditChildPayload = NonNullable<UpdateChildMutation['updateChild']>;

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -1,40 +1,37 @@
-import {
-  OccurrenceQuery,
-  EventParticipantsPerInvite,
-} from '../../api/generatedTypes/graphql';
+import { EventParticipantsPerInvite } from '../../api/generatedTypes/graphql';
 import EventPage from '../EventPage';
 import { render } from '../../../common/test/testingLibraryUtils';
+import { OccurrenceFields } from '../types/OccurrenceQueryTypes';
 
-export const mockedOccurrenceNode: NonNullable<OccurrenceQuery['occurrence']> =
-  {
-    id: 'T2NjdXJyZW5jZU5vZGU6Mg==',
-    time: '2020-03-08T04:00:00+00:00',
-    remainingCapacity: 99,
-    event: {
-      id: 'zzaaz',
-      name: 'event name',
-      image: 'a',
-      imageAltText: 'b',
-      description: 'c',
-      shortDescription: 'd',
-      duration: 12,
-      participantsPerInvite: EventParticipantsPerInvite.Family,
-      eventGroup: {
-        id: 'e1',
-      },
+export const mockedOccurrenceNode: OccurrenceFields = {
+  id: 'T2NjdXJyZW5jZU5vZGU6Mg==',
+  time: '2020-03-08T04:00:00+00:00',
+  remainingCapacity: 99,
+  event: {
+    id: 'zzaaz',
+    name: 'event name',
+    image: 'a',
+    imageAltText: 'b',
+    description: 'c',
+    shortDescription: 'd',
+    duration: 12,
+    participantsPerInvite: EventParticipantsPerInvite.Family,
+    eventGroup: {
+      id: 'e1',
     },
-    venue: {
-      id: 'auppss',
-      name: 'Musiikkitalo',
-      address: '',
-      accessibilityInfo: 'z',
-      arrivalInstructions: 'y',
-      additionalInfo: 'x',
-      wwwUrl: 'https://example.com/z',
-      wcAndFacilities: 'uio',
-    },
-    childHasFreeSpotNotificationSubscription: null,
-  };
+  },
+  venue: {
+    id: 'auppss',
+    name: 'Musiikkitalo',
+    address: '',
+    accessibilityInfo: 'z',
+    arrivalInstructions: 'y',
+    additionalInfo: 'x',
+    wwwUrl: 'https://example.com/z',
+    wcAndFacilities: 'uio',
+  },
+  childHasFreeSpotNotificationSubscription: null,
+};
 
 it('renders snapshot correctly', () => {
   const { container } = render(

--- a/src/domain/event/enrol/Enrol.tsx
+++ b/src/domain/event/enrol/Enrol.tsx
@@ -2,14 +2,14 @@ import { useTranslation } from 'react-i18next';
 import joinClassNames from 'classnames';
 
 import styles from './enrol.module.scss';
-import { OccurrenceQuery } from '../../api/generatedTypes/graphql';
 import OccurrenceInfo from '../partial/OccurrenceInfo';
 import Button from '../../../common/components/button/Button';
 import EventOccurrenceNotificationControlButton from '../EventOccurrenceNotificationControlButton';
+import { OccurrenceFields } from '../types/OccurrenceQueryTypes';
 
 type Props = {
   childId: string;
-  occurrence: NonNullable<OccurrenceQuery['occurrence']>;
+  occurrence: OccurrenceFields;
   onCancel: () => void;
   onEnrol: () => void;
   onUnsubscribed?: () => void;

--- a/src/domain/event/mutations/enrolOccurrenceMutation.ts
+++ b/src/domain/event/mutations/enrolOccurrenceMutation.ts
@@ -1,66 +1,74 @@
 import { gql } from '@apollo/client';
 
 const enrolOccurrenceMutation = gql`
-  mutation enrolOccurrenceMutation($input: EnrolOccurrenceMutationInput!) {
-    enrolOccurrence(input: $input) {
-      clientMutationId
-      enrolment {
+  fragment EnrolOccurrencesFields on OccurrenceNodeConnection {
+    edges {
+      node {
         id
-        occurrence {
+        time
+        event {
           id
-          event {
-            id
-          }
-          venue {
-            id
+          image
+          imageAltText
+          description
+          shortDescription
+          name
+          duration
+          participantsPerInvite
+        }
+        venue {
+          id
+          name
+          address
+          accessibilityInfo
+          arrivalInstructions
+          additionalInfo
+          wwwUrl
+          wcAndFacilities
+        }
+      }
+    }
+  }
+
+  fragment EnrolOccurrenceMutationPayloadFields on EnrolOccurrenceMutationPayload {
+    clientMutationId
+    enrolment {
+      id
+      occurrence {
+        id
+        event {
+          id
+        }
+        venue {
+          id
+        }
+      }
+      child {
+        id
+        occurrences(upcoming: true) {
+          ...EnrolOccurrencesFields
+        }
+        pastEvents {
+          edges {
+            node {
+              id
+            }
           }
         }
-        child {
-          id
-          occurrences(upcoming: true) {
-            edges {
-              node {
-                id
-                time
-                event {
-                  id
-                  image
-                  imageAltText
-                  description
-                  shortDescription
-                  name
-                  duration
-                  participantsPerInvite
-                }
-                venue {
-                  id
-                  name
-                  address
-                  accessibilityInfo
-                  arrivalInstructions
-                  additionalInfo
-                  wwwUrl
-                  wcAndFacilities
-                }
-              }
-            }
-          }
-          pastEvents {
-            edges {
-              node {
-                id
-              }
-            }
-          }
-          availableEvents {
-            edges {
-              node {
-                id
-              }
+        availableEvents {
+          edges {
+            node {
+              id
             }
           }
         }
       }
+    }
+  }
+
+  mutation enrolOccurrenceMutation($input: EnrolOccurrenceMutationInput!) {
+    enrolOccurrence(input: $input) {
+      ...EnrolOccurrenceMutationPayloadFields
     }
   }
 `;

--- a/src/domain/event/mutations/unenrolOccurrenceMutation.ts
+++ b/src/domain/event/mutations/unenrolOccurrenceMutation.ts
@@ -1,60 +1,68 @@
 import { gql } from '@apollo/client';
 
 const unenrolOccurrenceMutation = gql`
-  mutation unenrolOccurrenceMutation($input: UnenrolOccurrenceMutationInput!) {
-    unenrolOccurrence(input: $input) {
-      clientMutationId
-      occurrence {
+  fragment UnenrolOccurrencesFields on OccurrenceNodeConnection {
+    edges {
+      node {
         id
+        time
         event {
           id
+          image
+          imageAltText
+          description
+          shortDescription
+          name
+          duration
+          participantsPerInvite
+        }
+        venue {
+          id
+          name
+          address
+          accessibilityInfo
+          arrivalInstructions
+          additionalInfo
+          wwwUrl
+          wcAndFacilities
         }
       }
-      child {
+    }
+  }
+
+  fragment UnenrolOccurrenceMutationPayloadFields on UnenrolOccurrenceMutationPayload {
+    clientMutationId
+    occurrence {
+      id
+      event {
         id
-        availableEvents {
-          edges {
-            node {
-              id
-            }
-          }
-        }
-        occurrences(upcomingWithOngoing: true) {
-          edges {
-            node {
-              id
-              time
-              event {
-                id
-                image
-                imageAltText
-                description
-                shortDescription
-                name
-                duration
-                participantsPerInvite
-              }
-              venue {
-                id
-                name
-                address
-                accessibilityInfo
-                arrivalInstructions
-                additionalInfo
-                wwwUrl
-                wcAndFacilities
-              }
-            }
-          }
-        }
-        pastEvents {
-          edges {
-            node {
-              id
-            }
+      }
+    }
+    child {
+      id
+      availableEvents {
+        edges {
+          node {
+            id
           }
         }
       }
+      occurrences(upcomingWithOngoing: true) {
+        ...UnenrolOccurrencesFields
+      }
+      pastEvents {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }
+
+  mutation unenrolOccurrenceMutation($input: UnenrolOccurrenceMutationInput!) {
+    unenrolOccurrence(input: $input) {
+      ...UnenrolOccurrenceMutationPayloadFields
     }
   }
 `;

--- a/src/domain/event/partial/OccurrenceInfo.tsx
+++ b/src/domain/event/partial/OccurrenceInfo.tsx
@@ -4,17 +4,15 @@ import { IconCalendar, IconLocation, IconClock } from 'hds-react';
 
 import { formatTime, newMoment } from '../../../common/time/utils';
 import { DEFAULT_DATE_FORMAT } from '../../../common/time/TimeConstants';
-import { OccurrenceQuery } from '../../api/generatedTypes/graphql';
 import { formatOccurrenceTime, getParticipantsIcon } from '../EventUtils';
 import InfoItem, { InfoItemProps } from './InfoItem';
 import styles from './occurrenceInfo.module.scss';
 import { InternalEnrolmentOccurrence } from '../../child/types/ChildByIdQueryTypes';
+import { OccurrenceFields } from '../types/OccurrenceQueryTypes';
 
 type Props = {
   className?: string;
-  occurrence:
-    | NonNullable<OccurrenceQuery['occurrence']>
-    | InternalEnrolmentOccurrence;
+  occurrence: OccurrenceFields | InternalEnrolmentOccurrence;
   show?: string[];
 };
 

--- a/src/domain/event/queries/eventQuery.ts
+++ b/src/domain/event/queries/eventQuery.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
-const OccurrenceFragment = gql`
-  fragment OccurrenceFragment on OccurrenceNode {
+const eventQueryFragments = gql`
+  fragment EventOccurrenceFields on OccurrenceNode {
     id
     time
     remainingCapacity
@@ -26,6 +26,14 @@ const OccurrenceFragment = gql`
       }
     }
   }
+
+  fragment EventOccurrencesFields on OccurrenceNodeConnection {
+    edges {
+      node {
+        ...EventOccurrenceFields
+      }
+    }
+  }
 `;
 
 const eventQuery = gql`
@@ -45,18 +53,10 @@ const eventQuery = gql`
         id
       }
       occurrences(upcoming: true, date: $date, time: $time) {
-        edges {
-          node {
-            ...OccurrenceFragment
-          }
-        }
+        ...EventOccurrencesFields
       }
       allOccurrences: occurrences(upcoming: true) {
-        edges {
-          node {
-            ...OccurrenceFragment
-          }
-        }
+        ...EventOccurrencesFields
       }
       ticketSystem {
         type
@@ -72,17 +72,17 @@ const eventQuery = gql`
     }
   }
 
-  ${OccurrenceFragment}
+  ${eventQueryFragments}
 `;
 
 export const eventOccurrenceQuery = gql`
   query eventOccurrenceQuery($id: ID!, $childId: ID!) {
     occurrence(id: $id) {
-      ...OccurrenceFragment
+      ...EventOccurrenceFields
     }
   }
 
-  ${OccurrenceFragment}
+  ${eventQueryFragments}
 `;
 
 export const eventExternalTicketSystemPasswordQuery = gql`

--- a/src/domain/event/queries/externalTicketSystemEventQuery.ts
+++ b/src/domain/event/queries/externalTicketSystemEventQuery.ts
@@ -1,40 +1,52 @@
 import { gql } from '@apollo/client';
 
 export const externalTicketSystemEventQuery = gql`
-  query externalTicketSystemEventQuery($eventId: ID!, $childId: ID!) {
-    event(id: $eventId) {
-      id
-      name
-      description
-      image
-      imageAltText
-      participantsPerInvite
-      occurrences: occurrences(upcoming: true, first: 1) {
-        edges {
-          node {
-            ticketSystem {
-              type
-              ... on TicketmasterOccurrenceTicketSystem {
-                url
-              }
-              ... on LippupisteOccurrenceTicketSystem {
-                url
-              }
+  fragment TicketmasterEventFields on TicketmasterEventTicketSystem {
+    childPassword(childId: $childId)
+    url
+  }
+
+  fragment LippupisteEventFields on LippupisteEventTicketSystem {
+    childPassword(childId: $childId)
+    url
+  }
+
+  fragment ExternalTicketSystemEventFields on EventNode {
+    id
+    name
+    description
+    image
+    imageAltText
+    participantsPerInvite
+    occurrences: occurrences(upcoming: true, first: 1) {
+      edges {
+        node {
+          ticketSystem {
+            type
+            ... on TicketmasterOccurrenceTicketSystem {
+              url
+            }
+            ... on LippupisteOccurrenceTicketSystem {
+              url
             }
           }
         }
       }
-      ticketSystem {
-        type
-        ... on TicketmasterEventTicketSystem {
-          childPassword(childId: $childId)
-          url
-        }
-        ... on LippupisteEventTicketSystem {
-          childPassword(childId: $childId)
-          url
-        }
+    }
+    ticketSystem {
+      type
+      ... on TicketmasterEventTicketSystem {
+        ...TicketmasterEventFields
       }
+      ... on LippupisteEventTicketSystem {
+        ...LippupisteEventFields
+      }
+    }
+  }
+
+  query externalTicketSystemEventQuery($eventId: ID!, $childId: ID!) {
+    event(id: $eventId) {
+      ...ExternalTicketSystemEventFields
     }
   }
 `;

--- a/src/domain/event/queries/occurrenceQuery.ts
+++ b/src/domain/event/queries/occurrenceQuery.ts
@@ -1,35 +1,47 @@
 import { gql } from '@apollo/client';
 
 const occurrenceQuery = gql`
+  fragment OccurrenceEventFields on EventNode {
+    id
+    image
+    imageAltText
+    description
+    shortDescription
+    name
+    duration
+    participantsPerInvite
+    eventGroup {
+      id
+    }
+  }
+
+  fragment OccurrenceVenueFields on VenueNode {
+    id
+    name
+    address
+    accessibilityInfo
+    arrivalInstructions
+    additionalInfo
+    wwwUrl
+    wcAndFacilities
+  }
+
+  fragment OccurrenceFields on OccurrenceNode {
+    id
+    time
+    remainingCapacity
+    event {
+      ...OccurrenceEventFields
+    }
+    venue {
+      ...OccurrenceVenueFields
+    }
+    childHasFreeSpotNotificationSubscription(childId: $childId)
+  }
+
   query occurrenceQuery($id: ID!, $childId: ID) {
     occurrence(id: $id) {
-      id
-      time
-      remainingCapacity
-      event {
-        id
-        image
-        imageAltText
-        description
-        shortDescription
-        name
-        duration
-        participantsPerInvite
-        eventGroup {
-          id
-        }
-      }
-      venue {
-        id
-        name
-        address
-        accessibilityInfo
-        arrivalInstructions
-        additionalInfo
-        wwwUrl
-        wcAndFacilities
-      }
-      childHasFreeSpotNotificationSubscription(childId: $childId)
+      ...OccurrenceFields
     }
   }
 `;

--- a/src/domain/event/types/EnrolOccurrenceMutationTypes.ts
+++ b/src/domain/event/types/EnrolOccurrenceMutationTypes.ts
@@ -1,7 +1,0 @@
-import { EnrolOccurrenceMutation } from '../../api/generatedTypes/graphql';
-
-export type EnrolOccurrences = NonNullable<
-  NonNullable<
-    NonNullable<EnrolOccurrenceMutation['enrolOccurrence']>['enrolment']
-  >['child']
->['occurrences'];

--- a/src/domain/event/types/EventChildTypes.ts
+++ b/src/domain/event/types/EventChildTypes.ts
@@ -1,5 +1,7 @@
-import { EnrolOccurrences } from './EnrolOccurrenceMutationTypes';
-import { UnenrolOccurrences } from './UnenrolOccurrenceMutationTypes';
+import {
+  EnrolOccurrencesFieldsFragment,
+  UnenrolOccurrencesFieldsFragment,
+} from '../../api/generatedTypes/graphql';
 
 export interface ChildEvents {
   childId: string;
@@ -8,5 +10,7 @@ export interface ChildEvents {
 
 export interface ChildOccurrences {
   childId: string;
-  occurrences: EnrolOccurrences | UnenrolOccurrences;
+  occurrences:
+    | EnrolOccurrencesFieldsFragment
+    | UnenrolOccurrencesFieldsFragment;
 }

--- a/src/domain/event/types/EventQueryTypes.ts
+++ b/src/domain/event/types/EventQueryTypes.ts
@@ -1,9 +1,8 @@
-import { EventQuery } from '../../api/generatedTypes/graphql';
+import {
+  EventOccurrencesFieldsFragment,
+  EventOccurrenceFieldsFragment,
+} from '../../api/generatedTypes/graphql';
 
-export type Occurrences = NonNullable<
-  NonNullable<EventQuery['event']>['occurrences']
->;
+export type Occurrences = EventOccurrencesFieldsFragment;
 
-export type OccurrenceNode = NonNullable<
-  NonNullable<Occurrences['edges'][number]>['node']
->;
+export type OccurrenceNode = EventOccurrenceFieldsFragment;

--- a/src/domain/event/types/ExternalTicketSystemEventQueryTypes.ts
+++ b/src/domain/event/types/ExternalTicketSystemEventQueryTypes.ts
@@ -1,22 +1,8 @@
-import { ExternalTicketSystemEventQuery } from '../../api/generatedTypes/graphql';
-
-type TicketSystem = NonNullable<
-  NonNullable<ExternalTicketSystemEventQuery['event']>['ticketSystem']
->;
-
-type TicketSystemWithRequiredTypename = TicketSystem &
-  Required<Pick<TicketSystem, '__typename'>>;
-
-export type TicketMasterEventTicketSystem = Extract<
-  TicketSystemWithRequiredTypename,
-  { __typename: 'TicketmasterEventTicketSystem' }
->;
-
-export type LippupisteEventTicketSystem = Extract<
-  TicketSystemWithRequiredTypename,
-  { __typename: 'LippupisteEventTicketSystem' }
->;
+import {
+  TicketmasterEventFieldsFragment,
+  LippupisteEventFieldsFragment,
+} from '../../api/generatedTypes/graphql';
 
 export type EventTicketSystem =
-  | TicketMasterEventTicketSystem
-  | LippupisteEventTicketSystem;
+  | TicketmasterEventFieldsFragment
+  | LippupisteEventFieldsFragment;

--- a/src/domain/event/types/OccurrenceQueryTypes.ts
+++ b/src/domain/event/types/OccurrenceQueryTypes.ts
@@ -1,9 +1,11 @@
-import { OccurrenceQuery } from '../../api/generatedTypes/graphql';
+import {
+  OccurrenceVenueFieldsFragment,
+  OccurrenceEventFieldsFragment,
+  OccurrenceFieldsFragment,
+} from '../../api/generatedTypes/graphql';
 
-export type OccurrenceVenue = NonNullable<
-  NonNullable<OccurrenceQuery['occurrence']>['venue']
->;
+export type OccurrenceVenue = OccurrenceVenueFieldsFragment;
 
-export type OccurrenceEvent = NonNullable<
-  OccurrenceQuery['occurrence']
->['event'];
+export type OccurrenceEvent = OccurrenceEventFieldsFragment;
+
+export type OccurrenceFields = OccurrenceFieldsFragment;

--- a/src/domain/event/types/UnenrolOccurrenceMutationTypes.ts
+++ b/src/domain/event/types/UnenrolOccurrenceMutationTypes.ts
@@ -1,5 +1,0 @@
-import { UnenrolOccurrenceMutation } from '../../api/generatedTypes/graphql';
-
-export type UnenrolOccurrences = NonNullable<
-  NonNullable<UnenrolOccurrenceMutation['unenrolOccurrence']>['child']
->['occurrences'];

--- a/src/domain/eventGroup/queries/eventGroupQuery.ts
+++ b/src/domain/eventGroup/queries/eventGroupQuery.ts
@@ -1,24 +1,36 @@
 import { gql } from '@apollo/client';
 
 const eventGroupQuery = gql`
+  fragment EventGroupEventFields on EventNode {
+    id
+    name
+    shortDescription
+    image
+    imageAltText
+    canChildEnroll(childId: $childId)
+  }
+
+  fragment EventGroupEventsFields on EventNodeConnection {
+    edges {
+      node {
+        ...EventGroupEventFields
+      }
+    }
+  }
+
+  fragment EventGroupFields on EventGroupNode {
+    id
+    name
+    shortDescription
+    description
+    events(upcoming: true) {
+      ...EventGroupEventsFields
+    }
+  }
+
   query eventGroupQuery($id: ID!, $childId: ID!) {
     eventGroup(id: $id) {
-      id
-      name
-      shortDescription
-      description
-      events(upcoming: true) {
-        edges {
-          node {
-            id
-            name
-            shortDescription
-            image
-            imageAltText
-            canChildEnroll(childId: $childId)
-          }
-        }
-      }
+      ...EventGroupFields
     }
   }
 `;

--- a/src/domain/eventGroup/types/EventGroupQueryTypes.ts
+++ b/src/domain/eventGroup/types/EventGroupQueryTypes.ts
@@ -1,5 +1,3 @@
-import { EventGroupQuery } from '../../api/generatedTypes/graphql';
+import { EventGroupEventFieldsFragment } from '../../api/generatedTypes/graphql';
 
-export type EventNode = NonNullable<
-  NonNullable<EventGroupQuery['eventGroup']>['events']['edges'][number]
->['node'];
+export type EventNode = EventGroupEventFieldsFragment;

--- a/src/domain/languages/queries/LanguageQueries.ts
+++ b/src/domain/languages/queries/LanguageQueries.ts
@@ -1,14 +1,22 @@
 import { gql } from '@apollo/client';
 
 export const languagesQuery = gql`
+  fragment LanguageFields on LanguageNode {
+    id
+    name
+  }
+
+  fragment LanguagesFields on LanguageNodeConnection {
+    edges {
+      node {
+        ...LanguageFields
+      }
+    }
+  }
+
   query languageQuery {
     languages {
-      edges {
-        node {
-          id
-          name
-        }
-      }
+      ...LanguagesFields
     }
   }
 `;

--- a/src/domain/languages/types/LanguageQueryTypes.ts
+++ b/src/domain/languages/types/LanguageQueryTypes.ts
@@ -1,5 +1,3 @@
-import { LanguageQuery } from '../../api/generatedTypes/graphql';
+import { LanguageFieldsFragment } from '../../api/generatedTypes/graphql';
 
-export type LanguageNode = NonNullable<
-  NonNullable<LanguageQuery['languages']>['edges'][number]
->['node'];
+export type LanguageNode = LanguageFieldsFragment;

--- a/src/domain/profile/children/child/ProfileChildDetail.tsx
+++ b/src/domain/profile/children/child/ProfileChildDetail.tsx
@@ -6,11 +6,11 @@ import { toast } from 'react-toastify';
 import * as Sentry from '@sentry/browser';
 import { IconPen } from 'hds-react';
 
-import { EditChildPayload } from '../../../child/types/UpdateChildMutationTypes';
-import { DeleteChildPayload } from '../../../child/types/DeleteChildMutationTypes';
 import {
   UpdateChildMutationInput,
   ChildByIdQuery,
+  UpdateChildMutationPayloadFieldsFragment,
+  DeleteChildMutationPayloadFieldsFragment,
 } from '../../../api/generatedTypes/graphql';
 import GiveFeedbackButton from '../../../../common/components/giveFeedbackButton/GiveFeedbackButton';
 import ErrorMessage from '../../../../common/components/error/Error';
@@ -55,15 +55,21 @@ const ProfileChildDetail = () => {
   });
   const getPathname = useGetPathname();
 
-  const [deleteChild] = useMutation<DeleteChildPayload>(deleteChildMutation, {
-    refetchQueries: [{ query: profileQuery }],
-  });
+  const [deleteChild] = useMutation<DeleteChildMutationPayloadFieldsFragment>(
+    deleteChildMutation,
+    {
+      refetchQueries: [{ query: profileQuery }],
+    }
+  );
 
-  const [editChild] = useMutation<EditChildPayload>(editChildMutation, {
-    refetchQueries: [
-      { query: childByIdQuery, variables: { id: params.childId } },
-    ],
-  });
+  const [editChild] = useMutation<UpdateChildMutationPayloadFieldsFragment>(
+    editChildMutation,
+    {
+      refetchQueries: [
+        { query: childByIdQuery, variables: { id: params.childId } },
+      ],
+    }
+  );
 
   const [isOpen, setIsOpen] = useState(false);
   if (loading) {

--- a/src/domain/profile/queries/ProfileQuery.ts
+++ b/src/domain/profile/queries/ProfileQuery.ts
@@ -1,93 +1,125 @@
 import { gql } from '@apollo/client';
 
 const profileQuery = gql`
+  fragment MyProfileEnrolmentFields on EnrolmentNode {
+    id
+    occurrence {
+      id
+      time
+      venue {
+        id
+        name
+      }
+      event {
+        id
+        name
+        duration
+      }
+    }
+  }
+
+  fragment MyProfileEnrolmentsFields on EnrolmentNodeConnection {
+    edges {
+      node {
+        ...MyProfileEnrolmentFields
+      }
+    }
+  }
+
+  fragment MyProfileChildProjectFields on ProjectNode {
+    id
+    name
+    year
+  }
+
+  fragment MyProfileChildFields on ChildNode {
+    id
+    firstName
+    lastName
+    birthdate
+    postalCode
+    project {
+      ...MyProfileChildProjectFields
+    }
+    relationships {
+      edges {
+        node {
+          id
+          type
+        }
+      }
+    }
+    upcomingEventsAndEventGroups {
+      edges {
+        node {
+          ... on EventGroupNode {
+            id
+            name
+          }
+          ... on EventNode {
+            id
+            name
+            duration
+            participantsPerInvite
+          }
+        }
+      }
+    }
+    occurrences {
+      edges {
+        node {
+          id
+          event {
+            id
+            name
+            shortDescription
+          }
+        }
+      }
+    }
+    enrolments {
+      ...MyProfileEnrolmentsFields
+    }
+  }
+
+  fragment MyProfileChildrenFields on ChildNodeConnection {
+    edges {
+      node {
+        ...MyProfileChildFields
+      }
+    }
+  }
+
+  fragment LanguageSpokenAtHomeFields on LanguageNode {
+    id
+  }
+
+  fragment LanguagesSpokenAtHomeFields on LanguageNodeConnection {
+    edges {
+      node {
+        ...LanguageSpokenAtHomeFields
+      }
+    }
+  }
+
+  fragment MyProfileFields on GuardianNode {
+    id
+    firstName
+    lastName
+    email
+    phoneNumber
+    language
+    children {
+      ...MyProfileChildrenFields
+    }
+    languagesSpokenAtHome {
+      ...LanguagesSpokenAtHomeFields
+    }
+  }
+
   query profileQuery {
     myProfile {
-      id
-      firstName
-      lastName
-      email
-      phoneNumber
-      language
-      children {
-        edges {
-          node {
-            id
-            firstName
-            lastName
-            birthdate
-            postalCode
-            project {
-              id
-              name
-              year
-            }
-            relationships {
-              edges {
-                node {
-                  id
-                  type
-                }
-              }
-            }
-            upcomingEventsAndEventGroups {
-              edges {
-                node {
-                  ... on EventGroupNode {
-                    id
-                    name
-                  }
-                  ... on EventNode {
-                    id
-                    name
-                    duration
-                    participantsPerInvite
-                  }
-                }
-              }
-            }
-            occurrences {
-              edges {
-                node {
-                  id
-                  event {
-                    id
-                    name
-                    shortDescription
-                  }
-                }
-              }
-            }
-            enrolments {
-              edges {
-                node {
-                  id
-                  occurrence {
-                    id
-                    time
-                    venue {
-                      id
-                      name
-                    }
-                    event {
-                      id
-                      name
-                      duration
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      languagesSpokenAtHome {
-        edges {
-          node {
-            id
-          }
-        }
-      }
+      ...MyProfileFields
     }
   }
 `;

--- a/src/domain/profile/types/ProfileQueryTypes.ts
+++ b/src/domain/profile/types/ProfileQueryTypes.ts
@@ -1,19 +1,20 @@
-import { ProfileQuery } from '../../api/generatedTypes/graphql';
+import {
+  LanguageSpokenAtHomeFieldsFragment,
+  MyProfileChildProjectFieldsFragment,
+  MyProfileEnrolmentFieldsFragment,
+  MyProfileFieldsFragment,
+  MyProfileChildrenFieldsFragment,
+  MyProfileChildFieldsFragment,
+} from '../../api/generatedTypes/graphql';
 
-export type MyProfile = NonNullable<ProfileQuery['myProfile']>;
+export type MyProfile = MyProfileFieldsFragment;
 
-export type MyProfileChildren = MyProfile['children'];
+export type MyProfileChildren = MyProfileChildrenFieldsFragment;
 
-export type MyProfileChild = NonNullable<
-  NonNullable<MyProfileChildren['edges'][number]>['node']
->;
+export type MyProfileChild = MyProfileChildFieldsFragment;
 
-export type MyProfileEnrolment = NonNullable<
-  NonNullable<MyProfileChild['enrolments']['edges'][number]>['node']
->;
+export type MyProfileEnrolment = MyProfileEnrolmentFieldsFragment;
 
-export type LanguagesSpokenAtHomeNode = NonNullable<
-  MyProfile['languagesSpokenAtHome']['edges'][number]
->['node'];
+export type LanguagesSpokenAtHomeNode = LanguageSpokenAtHomeFieldsFragment;
 
-export type Project = MyProfileChild['project'];
+export type Project = MyProfileChildProjectFieldsFragment;

--- a/src/domain/registration/mutations/submitChildrenAndGuardianMutation.ts
+++ b/src/domain/registration/mutations/submitChildrenAndGuardianMutation.ts
@@ -1,6 +1,45 @@
 import { gql } from '@apollo/client';
 
 const submitChildrenAndGuardianMutation = gql`
+  fragment SubmitGuardianFields on GuardianNode {
+    id
+    firstName
+    lastName
+    email
+    phoneNumber
+    language
+    children {
+      edges {
+        node {
+          id
+          firstName
+          lastName
+          birthdate
+          postalCode
+          project {
+            id
+            name
+            year
+          }
+          relationships {
+            edges {
+              node {
+                id
+                type
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  fragment SubmitChildrenAndGuardianMutationPayloadFields on SubmitChildrenAndGuardianMutationPayload {
+    guardian {
+      ...SubmitGuardianFields
+    }
+  }
+
   mutation submitChildrenAndGuardian(
     $children: [ChildInput!]!
     $guardian: GuardianInput!
@@ -8,38 +47,7 @@ const submitChildrenAndGuardianMutation = gql`
     submitChildrenAndGuardian(
       input: { children: $children, guardian: $guardian }
     ) {
-      guardian {
-        id
-        firstName
-        lastName
-        email
-        phoneNumber
-        language
-        children {
-          edges {
-            node {
-              id
-              firstName
-              lastName
-              birthdate
-              postalCode
-              project {
-                id
-                name
-                year
-              }
-              relationships {
-                edges {
-                  node {
-                    id
-                    type
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      ...SubmitChildrenAndGuardianMutationPayloadFields
     }
   }
 `;

--- a/src/domain/registration/types/SubmitChildrenAndGuardianMutationTypes.ts
+++ b/src/domain/registration/types/SubmitChildrenAndGuardianMutationTypes.ts
@@ -1,5 +1,3 @@
-import { SubmitChildrenAndGuardianMutation } from '../../api/generatedTypes/graphql';
+import { SubmitGuardianFieldsFragment } from '../../api/generatedTypes/graphql';
 
-export type Guardian = NonNullable<
-  SubmitChildrenAndGuardianMutation['submitChildrenAndGuardian']
->['guardian'];
+export type Guardian = SubmitGuardianFieldsFragment;


### PR DESCRIPTION
## Description

### refactor: generate most subtypes with graphql-codegen using fragments

Rationale here is to reduce manual maintenance of types and thus make
their maintenance easier.

Didn't find an easy way to generate the exact types for the union types,
e.g. InternalOrTicketSystemEnrolment, so those have to be maintained
manually. There were some union types generated automatically, e.g.
InternalOrTicketSystemEnrolmentUnion, but it seems they are not exactly
the types that are needed.

refs KK-1065

## Context

[KK-1065](https://helsinkisolutionoffice.atlassian.net/browse/KK-1065)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1065]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ