### PR TITLE
fix: languages focus on load removed

### DIFF
--- a/src/domain/languages/LanguagesCombobox.tsx
+++ b/src/domain/languages/LanguagesCombobox.tsx
@@ -3,13 +3,12 @@ import { useMemo } from 'react';
 import Combobox, {
   ComboboxProps,
 } from '../../common/components/formikWrappers/Combobox';
-import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
 import useLanguages from './hooks/useLanguages';
 
 type Props = Omit<ComboboxProps, 'options'>;
 
 const LanguagesCombobox = (props: Props) => {
-  const { languages, loading: isLoadingLanguages } = useLanguages();
+  const { languages } = useLanguages();
 
   const languageOptions = useMemo(
     () =>
@@ -19,10 +18,6 @@ const LanguagesCombobox = (props: Props) => {
       })),
     [languages.items]
   );
-
-  if (isLoadingLanguages) {
-    return <LoadingSpinner isLoading={true} />;
-  }
 
   return <Combobox {...props} clearable={false} options={languageOptions} />;
 };


### PR DESCRIPTION
## Description
For some reason loading spinner on language load causes the initial focus on the combobox. Also tested with default hds combobox, then if there are 2 combo field, always the last one gets focus. Removed loading spinner and now it works.

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[jira-id](https://helsinkisolutionoffice.atlassian.net/browse/<jira-id>)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->
