### PR TITLE
Manage marketing subscriptions

### DIFF
--- a/src/common/route/utils/__tests__/getPathname.test.ts
+++ b/src/common/route/utils/__tests__/getPathname.test.ts
@@ -17,7 +17,7 @@ const testCases = (language: string) => [
 ];
 
 test.each(languages.flatMap((language) => testCases(language)))(
-  'when pathname is %p and language is %p, yields %p',
+  'when pathname is "%s" and language is "%s", yields "%s"',
   (pathname, language, result) => {
     expect(getPathname(pathname, language)).toEqual(result);
   }

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -667,6 +667,11 @@
             "label": "Guardian’s telephone number",
             "placeholder": "Please enter guardian’s telephone number"
           }
+        },
+        "hasAcceptedMarketing": {
+          "input": {
+            "label": "Accepts the marketing communication"
+          }
         }
       },
       "verifyInformation": {

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -797,5 +797,31 @@
       "hours": "{{ hours }} hours",
       "days": "{{ days }} days"
     }
+  },
+  "subscriptions": {
+    "manage": {
+      "title": "Subscriptions Management",
+      "description": "Hello {{firstName}}! In the form below, you can see the status of your subscriptions regarding marketing communications.",
+      "form": {
+        "fields": {
+          "hasAcceptedMarketing": {
+            "label": "I accept marketing communications"
+          }
+        },
+        "submit": {
+          "submitMutation": {
+            "successfulMessage": "Data saved.",
+            "errorMessage": "An error occurred while saving the data. Please try again later."
+          },
+          "button": {
+            "label": "Save selections"
+          }
+        },
+        "query": {
+          "authTokenErrorMessage": "Problem loading your information. Login with your credentials or try again with a newer link to the subscriptions management page.",
+          "authenticatedErrorMessage": "There was a problem loading your data. Please try logging into the service again."
+        }
+      }
+    }
   }
 }

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -667,6 +667,11 @@
             "label": "Puhelinnumero",
             "placeholder": "Lisää puhelinnumero"
           }
+        },
+        "hasAcceptedMarketing": {
+          "input": {
+            "label": "Hyväksyn markkinointiviestinnän"
+          }
         }
       },
       "verifyInformation": {

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -797,5 +797,31 @@
       "hours": "{{ hours }} tuntia",
       "days": "{{ days }} päivää"
     }
+  },
+  "subscriptions": {
+    "manage": {
+      "title": "Viestityksen hallinta",
+      "description": "Hei {{firstName}}! Alla olevassa lomakkeessa näet tehdyn tilauksesi tilan liittyen markkinointiviestintään.",
+      "form": {
+        "fields": {
+          "hasAcceptedMarketing": {
+            "label": "Hyväksyn markkinointiviestinnän"
+          }
+        },
+        "submit": {
+          "submitMutation": {
+            "successfulMessage": "Tiedot tallennettu.",
+            "errorMessage": "Tapahtui virhe tietojen tallennuksessa. Yritä myöhemmin uudestaan."
+          },
+          "button": {
+            "label": "Tallenna valinnat"
+          }
+        },
+        "query": {
+          "authTokenErrorMessage": "Ongelma tietojesi lataamisessa. Kirjaudu sisään tunnuksillasi tai yritä uudelleen uudemmalla hallintasivulle johtavalla linkillä.",
+          "authenticatedErrorMessage": "Ongelma tietojesi lataamisessa. Yritä kirjautua palveluun uudelleen."
+        }
+      }
+    }
   }
 }

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -797,5 +797,31 @@
       "hours": "{{ hours }} timmar",
       "days": "{{ days }} dagar"
     }
+  },
+  "subscriptions": {
+    "manage": {
+      "title": "Meddelandehantering",
+      "description": "Hej {{firstName}}! I formuläret nedan kan du se status för din beställning angående marknadsföringskommunikation.",
+      "form": {
+        "fields": {
+          "hasAcceptedMarketing": {
+            "label": "Jag accepterar marknadskommunikation"
+          }
+        },
+        "submit": {
+          "submitMutation": {
+            "successfulMessage": "Data sparad.",
+            "errorMessage": "Ett fel uppstod när data sparades. Försök igen senare."
+          },
+          "button": {
+            "label": "Spara val"
+          }
+        },
+        "query": {
+          "authTokenErrorMessage": "Problem med att ladda din information. Logga in med dina referenser eller försök igen med en nyare länk till administratörssidan.",
+          "authenticatedErrorMessage": "Det gick inte att ladda dina data. Försök att logga in på tjänsten igen."
+        }
+      }
+    }
   }
 }

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -667,6 +667,11 @@
             "label": "Telefonnummer",
             "placeholder": "Ange telefonnummer"
           }
+        },
+        "hasAcceptedMarketing": {
+          "input": {
+            "label": "Accepterar marknadskommunikationen"
+          }
         }
       },
       "verifyInformation": {

--- a/src/domain/api/generatedTypes/graphql.tsx
+++ b/src/domain/api/generatedTypes/graphql.tsx
@@ -658,6 +658,7 @@ export type FreeSpotNotificationSubscriptionNodeEdge = {
 export type GuardianInput = {
   email?: InputMaybe<Scalars['String']['input']>;
   firstName: Scalars['String']['input'];
+  hasAcceptedMarketing?: InputMaybe<Scalars['Boolean']['input']>;
   language: Language;
   languagesSpokenAtHome?: InputMaybe<Array<Scalars['ID']['input']>>;
   lastName: Scalars['String']['input'];
@@ -4172,6 +4173,7 @@ export type SubmitGuardianFieldsFragment = {
   email: string;
   phoneNumber: string;
   language: Language;
+  hasAcceptedMarketing: boolean;
   children: {
     __typename?: 'ChildNodeConnection';
     edges: Array<{
@@ -4214,6 +4216,7 @@ export type SubmitChildrenAndGuardianMutationPayloadFieldsFragment = {
     email: string;
     phoneNumber: string;
     language: Language;
+    hasAcceptedMarketing: boolean;
     children: {
       __typename?: 'ChildNodeConnection';
       edges: Array<{
@@ -4264,6 +4267,7 @@ export type SubmitChildrenAndGuardianMutation = {
       email: string;
       phoneNumber: string;
       language: Language;
+      hasAcceptedMarketing: boolean;
       children: {
         __typename?: 'ChildNodeConnection';
         edges: Array<{
@@ -4984,6 +4988,7 @@ export const SubmitGuardianFieldsFragmentDoc = gql`
     email
     phoneNumber
     language
+    hasAcceptedMarketing
     children {
       edges {
         node {

--- a/src/domain/api/generatedTypes/graphql.tsx
+++ b/src/domain/api/generatedTypes/graphql.tsx
@@ -135,9 +135,12 @@ export type AddVenueMutationPayload = {
 
 export type AdminNode = Node & {
   __typename?: 'AdminNode';
+  email: Scalars['String']['output'];
   /** The ID of the object. */
   id: Scalars['ID']['output'];
   projects: Maybe<ProjectNodeConnection>;
+  /** Vaaditaan. Enintään 150 merkkiä. Vain kirjaimet, numerot ja @/./+/-/_ ovat sallittuja. */
+  username: Scalars['String']['output'];
 };
 
 export type AdminNodeProjectsArgs = {
@@ -661,6 +664,16 @@ export type GuardianInput = {
   phoneNumber?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type GuardianMarketingSubscriptionsNode = Node & {
+  __typename?: 'GuardianMarketingSubscriptionsNode';
+  firstName: Scalars['String']['output'];
+  hasAcceptedMarketing: Scalars['Boolean']['output'];
+  /** The ID of the object. */
+  id: Scalars['ID']['output'];
+  language: Scalars['String']['output'];
+  lastName: Scalars['String']['output'];
+};
+
 export type GuardianNode = Node & {
   __typename?: 'GuardianNode';
   children: ChildNodeConnection;
@@ -668,6 +681,7 @@ export type GuardianNode = Node & {
   /** If left blank, will be populated with the user's email. */
   email: Scalars['String']['output'];
   firstName: Scalars['String']['output'];
+  hasAcceptedMarketing: Scalars['Boolean']['output'];
   /** The ID of the object. */
   id: Scalars['ID']['output'];
   language: Language;
@@ -957,12 +971,14 @@ export type Mutation = {
   submitChildrenAndGuardian: Maybe<SubmitChildrenAndGuardianMutationPayload>;
   subscribeToFreeSpotNotification: Maybe<SubscribeToFreeSpotNotificationMutationPayload>;
   unenrolOccurrence: Maybe<UnenrolOccurrenceMutationPayload>;
+  unsubscribeFromAllNotifications: Maybe<UnsubscribeFromAllNotificationsMutationPayload>;
   unsubscribeFromFreeSpotNotification: Maybe<UnsubscribeFromFreeSpotNotificationMutationPayload>;
   updateChild: Maybe<UpdateChildMutationPayload>;
   updateEvent: Maybe<UpdateEventMutationPayload>;
   updateEventGroup: Maybe<UpdateEventGroupMutationPayload>;
   updateMessage: Maybe<UpdateMessageMutationPayload>;
   updateMyEmail: Maybe<UpdateMyEmailMutationPayload>;
+  updateMyMarketingSubscriptions: Maybe<UpdateMyMarketingSubscriptionsMutationPayload>;
   updateMyProfile: Maybe<UpdateMyProfileMutationPayload>;
   updateOccurrence: Maybe<UpdateOccurrenceMutationPayload>;
   updateVenue: Maybe<UpdateVenueMutationPayload>;
@@ -1060,6 +1076,10 @@ export type MutationUnenrolOccurrenceArgs = {
   input: UnenrolOccurrenceMutationInput;
 };
 
+export type MutationUnsubscribeFromAllNotificationsArgs = {
+  input: UnsubscribeFromAllNotificationsMutationInput;
+};
+
 export type MutationUnsubscribeFromFreeSpotNotificationArgs = {
   input: UnsubscribeFromFreeSpotNotificationMutationInput;
 };
@@ -1082,6 +1102,10 @@ export type MutationUpdateMessageArgs = {
 
 export type MutationUpdateMyEmailArgs = {
   input: UpdateMyEmailMutationInput;
+};
+
+export type MutationUpdateMyMarketingSubscriptionsArgs = {
+  input: UpdateMyMarketingSubscriptionsMutationInput;
 };
 
 export type MutationUpdateMyProfileArgs = {
@@ -1281,6 +1305,7 @@ export type Query = {
   message: Maybe<MessageNode>;
   messages: Maybe<MessageNodeConnection>;
   myAdminProfile: Maybe<AdminNode>;
+  myMarketingSubscriptions: Maybe<GuardianMarketingSubscriptionsNode>;
   myProfile: Maybe<GuardianNode>;
   occurrence: Maybe<OccurrenceNode>;
   occurrences: Maybe<OccurrenceNodeConnection>;
@@ -1366,6 +1391,10 @@ export type QueryMessagesArgs = {
   offset: InputMaybe<Scalars['Int']['input']>;
   projectId: InputMaybe<Scalars['ID']['input']>;
   protocol: InputMaybe<Scalars['String']['input']>;
+};
+
+export type QueryMyMarketingSubscriptionsArgs = {
+  authToken: InputMaybe<Scalars['String']['input']>;
 };
 
 export type QueryOccurrenceArgs = {
@@ -1586,6 +1615,19 @@ export type UnenrolOccurrenceMutationPayload = {
   occurrence: Maybe<OccurrenceNode>;
 };
 
+export type UnsubscribeFromAllNotificationsMutationInput = {
+  /** Auth token can be used to authorize the action without logging in as an user. */
+  authToken?: InputMaybe<Scalars['String']['input']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UnsubscribeFromAllNotificationsMutationPayload = {
+  __typename?: 'UnsubscribeFromAllNotificationsMutationPayload';
+  clientMutationId: Maybe<Scalars['String']['output']>;
+  guardian: Maybe<GuardianNode>;
+  unsubscribed: Maybe<Scalars['Boolean']['output']>;
+};
+
 export type UnsubscribeFromFreeSpotNotificationMutationInput = {
   childId: Scalars['ID']['input'];
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
@@ -1682,9 +1724,23 @@ export type UpdateMyEmailMutationPayload = {
   myProfile: Maybe<GuardianNode>;
 };
 
+export type UpdateMyMarketingSubscriptionsMutationInput = {
+  /** Auth token can be used to authorize the action without logging in as an user. */
+  authToken?: InputMaybe<Scalars['String']['input']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  hasAcceptedMarketing: Scalars['Boolean']['input'];
+};
+
+export type UpdateMyMarketingSubscriptionsMutationPayload = {
+  __typename?: 'UpdateMyMarketingSubscriptionsMutationPayload';
+  clientMutationId: Maybe<Scalars['String']['output']>;
+  guardian: Maybe<GuardianMarketingSubscriptionsNode>;
+};
+
 export type UpdateMyProfileMutationInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;
+  hasAcceptedMarketing?: InputMaybe<Scalars['Boolean']['input']>;
   language?: InputMaybe<Language>;
   languagesSpokenAtHome?: InputMaybe<Array<Scalars['ID']['input']>>;
   lastName?: InputMaybe<Scalars['String']['input']>;
@@ -3585,6 +3641,24 @@ export type UpdateMyEmailMutation = {
   } | null;
 };
 
+export type UpdateMyMarketingSubscriptionsMutationVariables = Exact<{
+  input: UpdateMyMarketingSubscriptionsMutationInput;
+}>;
+
+export type UpdateMyMarketingSubscriptionsMutation = {
+  __typename?: 'Mutation';
+  updateMyMarketingSubscriptions: {
+    __typename?: 'UpdateMyMarketingSubscriptionsMutationPayload';
+    guardian: {
+      __typename?: 'GuardianMarketingSubscriptionsNode';
+      firstName: string;
+      lastName: string;
+      language: string;
+      hasAcceptedMarketing: boolean;
+    } | null;
+  } | null;
+};
+
 export type UpdateMyProfileMutationVariables = Exact<{
   input: UpdateMyProfileMutationInput;
 }>;
@@ -3600,7 +3674,23 @@ export type UpdateMyProfileMutation = {
       lastName: string;
       language: Language;
       email: string;
+      hasAcceptedMarketing: boolean;
     } | null;
+  } | null;
+};
+
+export type MyMarketingSubscriptionsQueryVariables = Exact<{
+  authToken: InputMaybe<Scalars['String']['input']>;
+}>;
+
+export type MyMarketingSubscriptionsQuery = {
+  __typename?: 'Query';
+  myMarketingSubscriptions: {
+    __typename?: 'GuardianMarketingSubscriptionsNode';
+    firstName: string;
+    lastName: string;
+    language: string;
+    hasAcceptedMarketing: boolean;
   } | null;
 };
 
@@ -3857,6 +3947,7 @@ export type MyProfileFieldsFragment = {
   email: string;
   phoneNumber: string;
   language: Language;
+  hasAcceptedMarketing: boolean;
   children: {
     __typename?: 'ChildNodeConnection';
     edges: Array<{
@@ -3970,6 +4061,7 @@ export type ProfileQuery = {
     email: string;
     phoneNumber: string;
     language: Language;
+    hasAcceptedMarketing: boolean;
     children: {
       __typename?: 'ChildNodeConnection';
       edges: Array<{
@@ -4873,6 +4965,7 @@ export const MyProfileFieldsFragmentDoc = gql`
     email
     phoneNumber
     language
+    hasAcceptedMarketing
     children {
       ...MyProfileChildrenFields
     }
@@ -5363,6 +5456,31 @@ export type UpdateMyEmailMutationMutationOptions = Apollo.BaseMutationOptions<
   UpdateMyEmailMutation,
   UpdateMyEmailMutationVariables
 >;
+export const UpdateMyMarketingSubscriptionsDocument = gql`
+  mutation UpdateMyMarketingSubscriptions(
+    $input: UpdateMyMarketingSubscriptionsMutationInput!
+  ) {
+    updateMyMarketingSubscriptions(input: $input) {
+      guardian {
+        firstName
+        lastName
+        language
+        hasAcceptedMarketing
+      }
+    }
+  }
+`;
+export type UpdateMyMarketingSubscriptionsMutationFn = Apollo.MutationFunction<
+  UpdateMyMarketingSubscriptionsMutation,
+  UpdateMyMarketingSubscriptionsMutationVariables
+>;
+export type UpdateMyMarketingSubscriptionsMutationResult =
+  Apollo.MutationResult<UpdateMyMarketingSubscriptionsMutation>;
+export type UpdateMyMarketingSubscriptionsMutationOptions =
+  Apollo.BaseMutationOptions<
+    UpdateMyMarketingSubscriptionsMutation,
+    UpdateMyMarketingSubscriptionsMutationVariables
+  >;
 export const UpdateMyProfileDocument = gql`
   mutation updateMyProfile($input: UpdateMyProfileMutationInput!) {
     updateMyProfile(input: $input) {
@@ -5372,6 +5490,7 @@ export const UpdateMyProfileDocument = gql`
         lastName
         language
         email
+        hasAcceptedMarketing
       }
     }
   }
@@ -5385,6 +5504,20 @@ export type UpdateMyProfileMutationResult =
 export type UpdateMyProfileMutationOptions = Apollo.BaseMutationOptions<
   UpdateMyProfileMutation,
   UpdateMyProfileMutationVariables
+>;
+export const MyMarketingSubscriptionsDocument = gql`
+  query MyMarketingSubscriptions($authToken: String) {
+    myMarketingSubscriptions(authToken: $authToken) {
+      firstName
+      lastName
+      language
+      hasAcceptedMarketing
+    }
+  }
+`;
+export type MyMarketingSubscriptionsQueryResult = Apollo.QueryResult<
+  MyMarketingSubscriptionsQuery,
+  MyMarketingSubscriptionsQueryVariables
 >;
 export const ProfileChildrenQueryDocument = gql`
   query profileChildrenQuery {

--- a/src/domain/app/layout/SimpleFormPageLayout.tsx
+++ b/src/domain/app/layout/SimpleFormPageLayout.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import PageWrapper from './PageWrapper';
+import SimpleFormTemplate, {
+  SimpleFormTemplateProps,
+} from './utilityComponents/SimpleFormTemplate';
+
+const SimpleFormPageLayout = (props: SimpleFormTemplateProps) => {
+  return (
+    <PageWrapper>
+      <SimpleFormTemplate {...props} />
+    </PageWrapper>
+  );
+};
+
+export default SimpleFormPageLayout;

--- a/src/domain/app/layout/utilityComponents/SimpleFormTemplate.tsx
+++ b/src/domain/app/layout/utilityComponents/SimpleFormTemplate.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import Icon from '../../../../common/components/icon/Icon';
+import styles from './simpleFormTemplate.module.scss';
+
+export type SimpleFormTemplateProps = {
+  title: string | React.ReactElement;
+  description?: string | React.ReactElement;
+  form: React.ReactElement;
+  icon?: string | React.ReactElement;
+
+  classes?: string;
+};
+
+const SimpleFormTemplate = ({
+  title,
+  description,
+  form,
+  icon,
+  classes,
+}: SimpleFormTemplateProps) => {
+  return (
+    <div className={classnames(styles.simpleFormPageLayout, classes)}>
+      <h1 className={styles.simpleFormPageLayoutTitle}>{title}</h1>
+      {typeof icon === 'string' ? (
+        <Icon className={styles.simpleFormPageLayoutFace} src={icon} />
+      ) : (
+        icon
+      )}
+      {description && (
+        <p className={styles.simpleFormPageLayoutDescription}>{description}</p>
+      )}
+      {form}
+    </div>
+  );
+};
+
+export default SimpleFormTemplate;

--- a/src/domain/app/layout/utilityComponents/simpleFormTemplate.module.scss
+++ b/src/domain/app/layout/utilityComponents/simpleFormTemplate.module.scss
@@ -1,0 +1,39 @@
+@import '~styles/layout';
+@import '~styles/variables';
+
+.simpleFormPageLayout {
+  @include respond-below(l) {
+    margin: 0 $baseMargin $largeMargin $baseMargin;
+  }
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  color: $color-black-90;
+
+  .simpleFormPageLayoutFace {
+    height: $spacing-5-xl;
+    width: $spacing-5-xl;
+    margin: 0 0 $spacing-m 0;
+  }
+
+  .simpleFormPageLayoutTitle {
+    font-size: $fontsize-heading-xl;
+  }
+
+  .simpleFormPageLayoutDescription {
+    max-width: $container-width-m;
+    margin-top: 0;
+    margin-bottom: $spacing-xl;
+
+    font-size: $fontsize-body-l;
+    text-align: center;
+  }
+  button[type='submit'] {
+    margin: 2 * $baseMargin;
+    width: min-content;
+    max-width: $container-width-s;
+  }
+}

--- a/src/domain/app/routes/browserRouter.tsx
+++ b/src/domain/app/routes/browserRouter.tsx
@@ -25,6 +25,7 @@ import EventIsEnrolled from '../../event/EventIsEnrolled';
 import EnrolPage from '../../event/enrol/EnrolPage';
 import CookieConsentPage from '../../cookieConsent/CookieConsentPage';
 import Unauthorized from '../../auth/Unauthorized';
+import ManageMarketingSubscriptions from '../../profile/subscriptions/ManageSubscriptions';
 
 const browserRouter = createBrowserRouter([
   { path: '/', Component: NavigateToLocalePath },
@@ -44,15 +45,6 @@ const browserRouter = createBrowserRouter([
       {
         path: 'home',
         element: <AppRoute title={t('appName')} element={<Home />} />,
-      },
-      {
-        path: 'registration/not-eligible',
-        element: (
-          <AppRoute
-            title={t('registration.notEligible.title')}
-            element={<NotEligible />}
-          />
-        ),
       },
       {
         path: 'unauthorized',
@@ -100,6 +92,15 @@ const browserRouter = createBrowserRouter([
         ),
       },
       {
+        path: 'registration/not-eligible',
+        element: (
+          <AppRoute
+            title={t('registration.notEligible.title')}
+            element={<NotEligible />}
+          />
+        ),
+      },
+      {
         path: 'registration/form',
         element: (
           <AppRoute
@@ -126,6 +127,15 @@ const browserRouter = createBrowserRouter([
             index: true,
             element: (
               <AppRoute title={t('profile.heading')} element={<Profile />} />
+            ),
+          },
+          {
+            path: 'subscriptions',
+            element: (
+              <AppRoute
+                title={t('subscriptions.manage.title')}
+                element={<ManageMarketingSubscriptions />}
+              />
             ),
           },
           {

--- a/src/domain/home/form/__test__/HomePreliminaryFormUtils.test.ts
+++ b/src/domain/home/form/__test__/HomePreliminaryFormUtils.test.ts
@@ -18,6 +18,7 @@ const convertFrom: RegistrationFormValues = {
     lastName: 'gln',
     email: 'yomama@example.com',
     languagesSpokenAtHome: ['fi'],
+    hasAcceptedMarketing: false,
   },
   preferLanguage: Language.En,
   agree: false,

--- a/src/domain/profile/modal/EditMyProfileForm.tsx
+++ b/src/domain/profile/modal/EditMyProfileForm.tsx
@@ -25,6 +25,7 @@ import {
   MyProfile,
 } from '../types/ProfileQueryTypes';
 import RelayList from '../../api/relayList';
+import CheckboxField from '../../../common/components/form/fields/checkbox/CheckboxField';
 
 const schema = yup.object().shape({
   firstName: yup
@@ -83,6 +84,7 @@ export default function EditMyProfileForm({
             lastName: payload.lastName,
             phoneNumber: payload.phoneNumber,
             language: payload.language,
+            hasAcceptedMarketing: payload.hasAcceptedMarketing,
             languagesSpokenAtHome: payload.languagesSpokenAtHome,
           },
         },
@@ -186,6 +188,13 @@ export default function EditMyProfileForm({
             name="languagesSpokenAtHome"
             // Block escape from closing the modal
             catchEscapeKey
+          />
+          <CheckboxField
+            id={'hasAcceptedMarketing'}
+            name={'hasAcceptedMarketing'}
+            label={t(
+              'registration.form.guardian.hasAcceptedMarketing.input.label'
+            )}
           />
           <div className={styles.buttonsWrapper}>
             <Button

--- a/src/domain/profile/modal/__tests__/EditProfileModal.test.tsx
+++ b/src/domain/profile/modal/__tests__/EditProfileModal.test.tsx
@@ -18,6 +18,7 @@ const initialValues: MyProfile = {
   phoneNumber: '0904422233',
   email: 'email@example.com',
   language: Language.Sv,
+  hasAcceptedMarketing: false,
   children: {
     edges: [],
   },

--- a/src/domain/profile/mutations/updateMyMarketingSubscriptionsMutation.ts
+++ b/src/domain/profile/mutations/updateMyMarketingSubscriptionsMutation.ts
@@ -1,0 +1,18 @@
+import { gql } from '@apollo/client';
+
+const updateMyMarketingSubscriptionsMutation = gql`
+  mutation UpdateMyMarketingSubscriptions(
+    $input: UpdateMyMarketingSubscriptionsMutationInput!
+  ) {
+    updateMyMarketingSubscriptions(input: $input) {
+      guardian {
+        firstName
+        lastName
+        language
+        hasAcceptedMarketing
+      }
+    }
+  }
+`;
+
+export default updateMyMarketingSubscriptionsMutation;

--- a/src/domain/profile/mutations/updateMyProfileMutation.ts
+++ b/src/domain/profile/mutations/updateMyProfileMutation.ts
@@ -9,6 +9,7 @@ const updateMyProfileMutation = gql`
         lastName
         language
         email
+        hasAcceptedMarketing
       }
     }
   }

--- a/src/domain/profile/queries/MyMarketingSubscriptionsQuery.ts
+++ b/src/domain/profile/queries/MyMarketingSubscriptionsQuery.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+const myMarketingSubscriptionsQuery = gql`
+  query MyMarketingSubscriptions($authToken: String) {
+    myMarketingSubscriptions(authToken: $authToken) {
+      firstName
+      lastName
+      language
+      hasAcceptedMarketing
+    }
+  }
+`;
+export default myMarketingSubscriptionsQuery;

--- a/src/domain/profile/queries/ProfileQuery.ts
+++ b/src/domain/profile/queries/ProfileQuery.ts
@@ -108,6 +108,7 @@ const profileQuery = gql`
     email
     phoneNumber
     language
+    hasAcceptedMarketing
     children {
       ...MyProfileChildrenFields
     }

--- a/src/domain/profile/state/ProfileReducers.tsx
+++ b/src/domain/profile/state/ProfileReducers.tsx
@@ -11,6 +11,7 @@ export const defaultProfileData: MyProfile = {
   phoneNumber: '',
   email: '',
   language: Language.Fi,
+  hasAcceptedMarketing: false,
   children: {
     edges: [],
   },

--- a/src/domain/profile/subscriptions/ManageSubscriptions.tsx
+++ b/src/domain/profile/subscriptions/ManageSubscriptions.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@apollo/client';
+import { toast } from 'react-toastify';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
+import {
+  MyMarketingSubscriptionsDocument,
+  MyMarketingSubscriptionsQuery,
+} from '../../api/generatedTypes/graphql';
+import SimpleFormPageLayout from '../../app/layout/SimpleFormPageLayout';
+import ManageSubscriptionsForm from './ManageSubscriptionsForm';
+import LoadingSpinner from '../../../common/components/spinner/LoadingSpinner';
+import { isAuthenticatedSelector } from '../../auth/state/AuthenticationSelectors';
+
+const ManageSubscriptions = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const authToken = searchParams.get('authToken');
+  const isAuthenticated = useSelector(isAuthenticatedSelector);
+  const {
+    data: subscriptionsData,
+    loading,
+    error,
+  } = useQuery<MyMarketingSubscriptionsQuery>(
+    MyMarketingSubscriptionsDocument,
+    { variables: { authToken } }
+  );
+
+  if (error) {
+    // Navigate to unauthorized ("the login") view
+    // if not an auth token was used while the user was not logged in.
+    if (!isAuthenticated) {
+      toast.error(t('subscriptions.manage.form.query.authTokenErrorMessage'), {
+        toastId: 'MyMarketingSubscriptionsQuery',
+        delay: 0,
+        // close automatically if an auth token has been used.
+        autoClose: isAuthenticated ? false : 5000,
+      });
+      navigate(`/unauthorized?next=${location.pathname}`);
+    } else {
+      toast.error(
+        t('subscriptions.manage.form.query.authenticatedErrorMessage'),
+        {
+          toastId: 'MyMarketingSubscriptionsQuery',
+          delay: 3000,
+          // don't close if the user is authenticated.
+          autoClose: false,
+        }
+      );
+    }
+  }
+
+  const { firstName, hasAcceptedMarketing } =
+    subscriptionsData?.myMarketingSubscriptions ?? {
+      firstName: undefined,
+      hasAcceptedMarketing: true,
+    };
+
+  const initialValues = {
+    hasAcceptedMarketing,
+    authToken,
+  };
+
+  return (
+    <SimpleFormPageLayout
+      title={t('subscriptions.manage.title')}
+      description={t('subscriptions.manage.description', {
+        firstName,
+      })}
+      form={
+        <LoadingSpinner isLoading={loading || !subscriptionsData}>
+          <ManageSubscriptionsForm initialValues={initialValues} />
+        </LoadingSpinner>
+      }
+    />
+  );
+};
+
+export default ManageSubscriptions;

--- a/src/domain/profile/subscriptions/ManageSubscriptionsForm.tsx
+++ b/src/domain/profile/subscriptions/ManageSubscriptionsForm.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+import { Form, Formik } from 'formik';
+import { useMutation } from '@apollo/client';
+import { toast } from 'react-toastify';
+import * as Sentry from '@sentry/browser';
+
+import {
+  UpdateMyMarketingSubscriptionsDocument,
+  UpdateMyMarketingSubscriptionsMutation,
+  UpdateMyMarketingSubscriptionsMutationInput,
+} from '../../api/generatedTypes/graphql';
+import CheckboxField from '../../../common/components/form/fields/checkbox/CheckboxField';
+import Button from '../../../common/components/button/Button';
+
+const schema = yup.object().shape({
+  hasAcceptedMarketing: yup.boolean(),
+});
+
+type ManageSubscriptionsFormProps = {
+  initialValues: UpdateMyMarketingSubscriptionsMutationInput;
+};
+
+const ManageSubscriptionsForm = ({
+  initialValues,
+}: ManageSubscriptionsFormProps) => {
+  const { t } = useTranslation();
+
+  const [updateMySubscriptions] =
+    useMutation<UpdateMyMarketingSubscriptionsMutation>(
+      UpdateMyMarketingSubscriptionsDocument
+    );
+
+  const onSubmit = async ({
+    hasAcceptedMarketing,
+    authToken,
+  }: UpdateMyMarketingSubscriptionsMutationInput) => {
+    try {
+      await updateMySubscriptions({
+        variables: { input: { hasAcceptedMarketing, authToken } },
+      });
+      toast.success(
+        t('subscriptions.manage.form.submit.submitMutation.successfulMessage')
+      );
+    } catch (error) {
+      toast.error(
+        t('subscriptions.manage.form.submit.submitMutation.errorMessage')
+      );
+      Sentry.captureException(error);
+    }
+  };
+  return (
+    <Formik
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      validationSchema={schema}
+    >
+      <Form>
+        <CheckboxField
+          id={'hasAcceptedMarketing'}
+          name={'hasAcceptedMarketing'}
+          label={t(
+            'subscriptions.manage.form.fields.hasAcceptedMarketing.label'
+          )}
+        />
+        <Button type="submit">
+          {t('subscriptions.manage.form.submit.button.label')}
+        </Button>
+      </Form>
+    </Formik>
+  );
+};
+
+export default ManageSubscriptionsForm;

--- a/src/domain/registration/form/RegistrationForm.tsx
+++ b/src/domain/registration/form/RegistrationForm.tsx
@@ -59,6 +59,7 @@ const schema = yup.object().shape({
       .string()
       .required('validation.general.required')
       .max(255, 'validation.maxLength'),
+    hasAcceptedMarketing: yup.boolean(),
     language: yup.string().max(255, 'validation.maxLength'),
   }),
   children: yup.array().of(
@@ -160,6 +161,7 @@ const RegistrationForm = () => {
                 phoneNumber: values.guardian.phoneNumber,
                 language: language,
                 languagesSpokenAtHome: values.guardian.languagesSpokenAtHome,
+                hasAcceptedMarketing: values.guardian.hasAcceptedMarketing,
               };
 
               submitChildrenAndGuardian({
@@ -344,6 +346,13 @@ const RegistrationForm = () => {
                       'registration.form.child.languagesSpokenAtHome.input.label'
                     )}
                     name="guardian.languagesSpokenAtHome"
+                  />
+                  <CheckboxField
+                    id="guardian.hasAcceptedMarketing"
+                    name="guardian.hasAcceptedMarketing"
+                    label={t(
+                      'registration.form.guardian.hasAcceptedMarketing.input.label'
+                    )}
                   />
                   <CheckboxField
                     className={styles.agreeBtn}

--- a/src/domain/registration/mutations/submitChildrenAndGuardianMutation.ts
+++ b/src/domain/registration/mutations/submitChildrenAndGuardianMutation.ts
@@ -8,6 +8,7 @@ const submitChildrenAndGuardianMutation = gql`
     email
     phoneNumber
     language
+    hasAcceptedMarketing
     children {
       edges {
         node {

--- a/src/domain/registration/notEligible/__tests__/NotEligibleUtils.test.ts
+++ b/src/domain/registration/notEligible/__tests__/NotEligibleUtils.test.ts
@@ -18,6 +18,7 @@ const values: RegistrationFormValues = {
     lastName: 'gln',
     email: 'yomama@example.com',
     languagesSpokenAtHome: ['en'],
+    hasAcceptedMarketing: false,
   },
   agree: false,
   verifyInformation: false,

--- a/src/domain/registration/state/RegistrationReducers.tsx
+++ b/src/domain/registration/state/RegistrationReducers.tsx
@@ -25,6 +25,7 @@ export const defaultRegistrationData: RegistrationData = {
       lastName: '',
       phoneNumber: '',
       languagesSpokenAtHome: [],
+      hasAcceptedMarketing: false,
     },
     preferLanguage: Language.Fi,
     agree: false,

--- a/src/domain/registration/types/RegistrationTypes.ts
+++ b/src/domain/registration/types/RegistrationTypes.ts
@@ -9,6 +9,7 @@ export interface RegistrationFormValues {
     lastName: string;
     email: string;
     languagesSpokenAtHome: string[];
+    hasAcceptedMarketing: boolean;
   };
   preferLanguage: Language;
   agree: boolean;


### PR DESCRIPTION
KK-1072 KK-1099.

1. Add "has accepted marketing" -field to the edit my profile form.
2. Add the "has accepted marketing checkbox to registration form. The "accept marketing" input should be available already in when making the
registration.
3. Add a manage subscriptions route to manage marketing subscriptions.

Created a new simple form template and page layout for very simple forms and used it with the ManageSubscriptions route.

The ManageSubscriptions uses the ManageSubscriptionsForm that currently holds only 1 checkbox field to enable or disable the marketing letter notifications. If it is checked, the "has accepted marketing" field will be set to true and a `UpdateMyMarketingSubscriptionsMutation` will be sent to the API.

The page can only be viewed as authenticated or if a valid "authToken" parameter is given. If neither of those applies, the user will be redirected to the unauthorised login view and an error will be toasted.

----

### Usage with auth token

1. Create a new auth verification token in API (and link it to an user).
2. use the authToken as a search param in `/fi/profile/subscriptions` -route. E.g. `/fi/profile/subscriptions?authToken=secret`
3. You should be able to query the data related to the guardian user and the form should be usable. The user's first name is written in the description of the form page.

<img width="1465" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-ui/assets/389204/c44ae7f9-c996-4ebc-9b39-5d15fbfd0c36">

### Usage as logged in

1. Login to the Kukkuu UI.
2. Navigate to`/fi/profile/subscriptions`.
3. You should be able to query the data related to the guardian user and the form should be usable. The user's first name is written in the description of the form page.

<img width="1517" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-ui/assets/389204/0c3e2996-cd76-44f2-8d16-8324117f324f">

### Using invalid or unset authToken as unauthenticated

An error should be toasted about an issue and the user is forwarded to the unauthorized-route where a new login can be made. The user should be redirected back to the subscriptions management page after a successful login, since the next-parameter should be populated in the URL.

<img width="1633" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-ui/assets/389204/d9ebf9aa-72a7-43d1-a88b-564a9f134282">


### Any issue as authenticated

An error should be toasted about an issue and the toaster stays there until it's closed. (Tested without API connection).

<img width="1678" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-ui/assets/389204/f547d1ad-51a1-4e3b-a3b0-72ba7db9db06">


### Swedish

<img width="1109" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-ui/assets/389204/b2917ada-9596-4bd6-85bd-142eb2be542e">


### English

<img width="1110" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-ui/assets/389204/486dc8bd-bcce-4b82-bd9d-5979a78cfca4">
