### PR TITLE
fix: profile page redirects to home when no registrated user

### DIFF
--- a/src/domain/profile/Profile.tsx
+++ b/src/domain/profile/Profile.tsx
@@ -40,7 +40,7 @@ const Profile = () => {
     // registered to kukkuu. In this case we want to redirect them
     // into the landing page where they can start the registration
     // process.
-    if (fetchCalled && !isProfileLoading && !profile) {
+    if (fetchCalled && !isProfileLoading && !profile?.id) {
       // eslint-disable-next-line no-console
       console.info(
         'User has logged in, but not created a profile. Send them to front page for registration.'


### PR DESCRIPTION
KK-1146 KK-1097

Test:
1. Login to the Kukkuu UI with an account that has not registerated yet.
2. When forwarded to the Profile page, the profile page should redirect the user to home page registration form, because there is no suer registrated.