### PR TITLE
fix: registration before authentication flow

### DIFF
--- a/src/domain/home/form/HomePreliminaryForm.tsx
+++ b/src/domain/home/form/HomePreliminaryForm.tsx
@@ -77,7 +77,7 @@ const HomePreliminaryForm: FunctionComponent<Props> = ({
     } else if (isAuthenticated) {
       navigate(getPathname('/registration/form'));
     } else {
-      login({ redirect_uri: `/registration/form` });
+      login({ url_state: 'next=/registration/form' });
     }
   };
 


### PR DESCRIPTION
KK-1035.
The redirect url is wrong when registration is clicked before authentication. The redirect_url should always be the same (/callback), but the url-state can be set to tell where to redirect after the successfull login.