### PR TITLE
fix: locale route navigate should use the location hash

### DIFF
--- a/src/domain/app/routes/useLocaleRouteNavigate.tsx
+++ b/src/domain/app/routes/useLocaleRouteNavigate.tsx
@@ -35,7 +35,7 @@ export const useLocaleRouteNavigate = () => {
     const shouldPrefixPathnameWithLocale =
       !isSupportedLocale(locale) && isSupportedLocale(currentLocale);
     if (shouldPrefixPathnameWithLocale) {
-      const redirectUrl = `/${currentLocale}${location.pathname}${location.search}`;
+      const redirectUrl = `/${currentLocale}${location.pathname}${location.hash}${location.search}`;
       // eslint-disable-next-line no-console
       console.info('Navigate to', redirectUrl);
       navigate(redirectUrl, {


### PR DESCRIPTION
KK-1153.

Because the useLocaleRouteNavigate did not include location hash in the redirect URL, the register-hash of the front page was not included in login-commands or the unauthorized in profile-page redirections.