### PR TITLE
fix: children list should update from CRUD-operations

### DIFF
--- a/src/domain/profile/ProfileProvider.tsx
+++ b/src/domain/profile/ProfileProvider.tsx
@@ -40,8 +40,8 @@ export default function ProfileProvider({
 
   const refetchProfile = React.useCallback(() => {
     if (refetch && data?.myProfile)
-      refetch().then(() => {
-        setProfileToContext(data?.myProfile || null);
+      refetch().then(({ data: refreshedData }) => {
+        setProfileToContext(refreshedData?.myProfile || null);
       });
   }, [data?.myProfile, refetch]);
 

--- a/src/domain/profile/children/ProfileChildrenList.tsx
+++ b/src/domain/profile/children/ProfileChildrenList.tsx
@@ -6,7 +6,10 @@ import * as Sentry from '@sentry/browser';
 import { useMatomo } from '@jonkoops/matomo-tracker-react';
 import { IconPlus } from 'hds-react';
 
-import { UpdateChildMutationInput } from '../../api/generatedTypes/graphql';
+import {
+  ProfileQueryDocument,
+  UpdateChildMutationInput,
+} from '../../api/generatedTypes/graphql';
 import Button from '../../../common/components/button/Button';
 import LoadingSpinner from '../../../common/components/spinner/LoadingSpinner';
 import Text from '../../../common/components/text/Text';
@@ -14,7 +17,6 @@ import List from '../../../common/components/list/List';
 import AddNewChildFormModal from '../../registration/modal/AddNewChildFormModal';
 import { addChildMutation } from '../../child/mutation/ChildMutation';
 import { getSupportedChildData } from '../../child/ChildUtils';
-import profileQuery from '../queries/ProfileQuery';
 import { getProjectsFromProfileQuery } from '../ProfileUtil';
 import ProfileChild from './child/ProfileChild';
 import styles from './profileChildrenList.module.scss';
@@ -28,7 +30,10 @@ const ProfileChildrenList = () => {
   const [addChild, { loading: mutationLoading }] = useMutation(
     addChildMutation,
     {
-      refetchQueries: [{ query: profileQuery }],
+      refetchQueries: [{ query: ProfileQueryDocument }],
+      onCompleted: () => {
+        refetchProfile();
+      },
     }
   );
   const { trackEvent } = useMatomo();
@@ -47,7 +52,6 @@ const ProfileChildrenList = () => {
             addChild({ variables: { input: supportedChildData } })
               .then(() => {
                 trackEvent({ category: 'action', action: 'Add child' });
-                refetchProfile();
               })
               .catch((error) => {
                 toast.error(t('profile.addChildMutation.errorMessage'));

--- a/src/domain/profile/children/child/ProfileChildDetail.tsx
+++ b/src/domain/profile/children/child/ProfileChildDetail.tsx
@@ -11,6 +11,7 @@ import {
   ChildByIdQuery,
   UpdateChildMutationPayloadFieldsFragment,
   DeleteChildMutationPayloadFieldsFragment,
+  ProfileQueryDocument,
 } from '../../../api/generatedTypes/graphql';
 import GiveFeedbackButton from '../../../../common/components/giveFeedbackButton/GiveFeedbackButton';
 import ErrorMessage from '../../../../common/components/error/Error';
@@ -26,11 +27,11 @@ import { childByIdQuery } from '../../../child/queries/ChildQueries';
 import ChildEnrolmentCount from '../../../child/ChildEnrolmentCount';
 import ListPageLayout from '../../../app/layout/ListPageLayout';
 import ProfileEvents from '../../events/ProfileEvents';
-import profileQuery from '../../queries/ProfileQuery';
 import ProfileChildDetailEditModal from './modal/ProfileChildDetailEditModal';
 import styles from './profileChildDetail.module.scss';
 import useAppRouteHref from '../../../app/useAppRouteHref';
 import { useIsFullyLoggedIn } from '../../../auth/useIsFullyLoggedIn';
+import { useProfileContext } from '../../hooks/useProfileContext';
 
 export type ChildDetailEditModalPayload = Omit<UpdateChildMutationInput, 'id'>;
 
@@ -47,6 +48,7 @@ export const useChildRouteGoBackTo = () => {
 const ProfileChildDetail = () => {
   const { t } = useTranslation();
   const params = useParams<{ childId: string }>();
+  const { refetchProfile } = useProfileContext();
   const navigate = useNavigate();
   const goBackTo = useProfileRouteGoBackTo();
   const [isLoginReady] = useIsFullyLoggedIn();
@@ -65,7 +67,10 @@ const ProfileChildDetail = () => {
   const [deleteChild] = useMutation<DeleteChildMutationPayloadFieldsFragment>(
     deleteChildMutation,
     {
-      refetchQueries: [{ query: profileQuery }],
+      refetchQueries: [{ query: ProfileQueryDocument }],
+      onCompleted: () => {
+        refetchProfile();
+      },
     }
   );
 
@@ -75,6 +80,9 @@ const ProfileChildDetail = () => {
       refetchQueries: [
         { query: childByIdQuery, variables: { id: params.childId } },
       ],
+      onCompleted: () => {
+        refetchProfile();
+      },
     }
   );
 

--- a/src/domain/registration/form/RegistrationForm.tsx
+++ b/src/domain/registration/form/RegistrationForm.tsx
@@ -110,6 +110,7 @@ const RegistrationForm = () => {
     profile,
     clearProfile: clearProfileFromContext,
     updateProfile,
+    refetchProfile,
   } = useProfileContext();
   const { loading, error, data } = useQuery<ProfileQuery>(profileQuery);
   const [submitChildrenAndGuardian] =
@@ -118,6 +119,9 @@ const RegistrationForm = () => {
       {
         awaitRefetchQueries: true,
         refetchQueries: [{ query: profileQuery }],
+        onCompleted: () => {
+          refetchProfile();
+        },
       }
     );
   // For new users preferLanguage defaults to their chosen UI language.


### PR DESCRIPTION
KK-1151

The children listing on profile page should update when a new child is added or when 1 is removed or updated. The refetchProfile did not use the new refreshed data, but the old data instead.