### PR TITLE
Fix token renewal reloaded page when user had no profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "graphql": "^16.0.0",
     "immer": "^9.0.0",
     "nth-check": ">=2.0.1",
-    "set-value": ">=4.0.1"
+    "set-value": ">=4.0.1",
+    "hds-core": "3.8.0",
+    "hds-react": "3.8.0"
   },
   "dependencies": {
     "@apollo/client": "^3.7.16",
@@ -91,8 +93,6 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-testcafe": "^0.2.1",
     "formik": "^2.4.5",
-    "hds-core": "^3.7.0",
-    "hds-react": "^3.7.0",
     "html-react-parser": "^4.2.2",
     "i18next": "^23.5.1",
     "i18next-browser-languagedetector": "^7.1.0",

--- a/src/domain/app/__tests__/__snapshots__/Layout.test.tsx.snap
+++ b/src/domain/app/__tests__/__snapshots__/Layout.test.tsx.snap
@@ -14,7 +14,8 @@ exports[`renders without crashing 1`] = `
       class="Footer-module_footer__1aD3T _footer_ca2122"
     >
       <div
-        class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W Footer-module_basic__2VejY"
+        class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"
+        style="height: 15px;"
       >
         <svg
           aria-hidden="true"

--- a/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -6,7 +6,8 @@ exports[`renders snapshot correctly 1`] = `
     class="Footer-module_footer__1aD3T _footer_ca2122"
   >
     <div
-      class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W Footer-module_basic__2VejY"
+      class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"
+      style="height: 15px;"
     >
       <svg
         aria-hidden="true"

--- a/src/domain/profile/ProfileProvider.tsx
+++ b/src/domain/profile/ProfileProvider.tsx
@@ -55,8 +55,8 @@ export default function ProfileProvider({
   // while the profile fetching is still on going
   // and won't refresh the children when it is;
   // This situation needs to be waited.
-  // TODO: Get rid of this loading spinner and sync issue.
-  if (isProfileFetcherLoading && !profile) {
+  // FIXME: Get rid of this loading spinner and sync issue.
+  if (!isFetchCalled && isProfileFetcherLoading) {
     // eslint-disable-next-line no-console
     console.info(
       'Using a loading spinner to wait for profile to be fully fetched from the Kukkuu API.'

--- a/src/domain/profile/hooks/useProfileFetcher.ts
+++ b/src/domain/profile/hooks/useProfileFetcher.ts
@@ -51,11 +51,6 @@ function useProfileFetcher({
       console.info('Fetching profile from Kukkuu API...');
       fetchProfile();
     }
-    return () => {
-      setIsFullyCalled(false);
-      // eslint-disable-next-line no-console
-      console.info('Cleaned the fetchProfile effect.');
-    };
   }, [called, fetchProfile, isLoginReady]);
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8071,20 +8071,20 @@ hastscript@^8.0.0:
     property-information "^6.0.0"
     space-separated-tokens "^2.0.0"
 
-hds-core@3.7.0, hds-core@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-3.7.0.tgz#4a4d65786afac4a8c4d10d1739b10cc8e2fc611f"
-  integrity sha512-rgr7r2b6nGqLiYR7StG2dY/31zXT988hsSLu8ipkDM4hTdFRLGGtqNpPP+6B8WlksAmszVmMwF6BbDxdAxtWfA==
+hds-core@3.8.0, hds-core@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-3.8.0.tgz#39003a0c129de767239fc1f904d89b6424edc9a1"
+  integrity sha512-T0+/tkyT5WCbGYHnSFXZeBE4wRu4PjD29njb2ANfiYFwlQfdkLGx4hCod0bjFb9kde/RktRwhXadwOwpmVg3dA==
 
 hds-design-tokens@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/hds-design-tokens/-/hds-design-tokens-3.7.0.tgz#233636beeff5df39d47cfb4e4861e760a085c3c3"
   integrity sha512-JBfVmsDQbLAPwX1Xh0uX5o3q4xfqQSQSWx4vewXmOBTjNkGcf2au+XCo9S5QvETai9OR85m5GbTh33DXquFLXw==
 
-hds-react@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-3.7.0.tgz#22ca9bbf72efe8ec49e4b4c50c644dbe2a5fd002"
-  integrity sha512-HF4WqO7ciapvCnCmPRjtj568L+A495g7n+m7rmZhsOYr8Q3/uI1C9bQrPA/Kpu794Cw9ulxekbRao905Ju4XhA==
+hds-react@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-3.8.0.tgz#03f65f744f0192af7097846f447621b62fd52681"
+  integrity sha512-nb8c2eUcLdFRvGg+pnyaUZbBm8V5cfDp20emHQQWxbMmo+R3aj6Azc8tM02fjkSkqr/+oqL6xvz2AIxbIDqkqA==
   dependencies:
     "@babel/runtime" "7.17.9"
     "@emotion/styled-base" "^11.0.0"
@@ -8100,7 +8100,7 @@ hds-react@^3.7.0:
     crc-32 "1.2.0"
     date-fns "2.16.1"
     downshift "6.0.6"
-    hds-core "3.7.0"
+    hds-core "3.8.0"
     http-status-typed "^1.0.1"
     jwt-decode "^3.1.2"
     kashe "1.0.4"


### PR DESCRIPTION
KK-1152.

Fix token renewal reloaded page when user had no profile.

Upgrade to the lates tHDS-react with the latest HDS-core. This version had some fixes related to the HDS login provider.