### PR TITLE
KK-1178 | feat: make RegistrationForm's hasAcceptedCommunication checkbox opt-out

### DIFF
--- a/src/domain/registration/form/RegistrationForm.tsx
+++ b/src/domain/registration/form/RegistrationForm.tsx
@@ -93,6 +93,7 @@ const getInitialFormData = (
     email: user?.profile.email || '',
     firstName: (formData.guardian.firstName || user?.profile?.given_name) ?? '',
     lastName: (formData.guardian.lastName || user?.profile?.family_name) ?? '',
+    hasAcceptedCommunication: true, // opt-out by default
   },
 });
 

--- a/src/domain/registration/form/__tests__/RegistrationForm.test.tsx
+++ b/src/domain/registration/form/__tests__/RegistrationForm.test.tsx
@@ -16,3 +16,11 @@ it('email field is disabled', async () => {
   const emailField = await screen.findByTestId(EMAIL_FIELD_TESTID);
   expect(emailField.hasAttribute('disabled'));
 });
+
+it('hasAcceptedCommunication is checked by default', async () => {
+  render(<RegistrationForm />);
+  const hasAcceptedCommunicationCheckbox = await screen.findByRole('checkbox', {
+    name: 'Haluan viestejä uusista kummitapahtumista',
+  });
+  expect(hasAcceptedCommunicationCheckbox).toBeChecked();
+});


### PR DESCRIPTION
## Description

### feat: make RegistrationForm's hasAcceptedCommunication checkbox opt-out

refs KK-1178

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-1178](https://helsinkisolutionoffice.atlassian.net/browse/KK-1178)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1178]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ