### PR TITLE
KK-1190 | feat: add required * and explanation text to Modal & RegistrationForm

### DIFF
--- a/src/common/components/alert/AlertModal.tsx
+++ b/src/common/components/alert/AlertModal.tsx
@@ -29,6 +29,7 @@ const AlertModal: FunctionComponent<AlertModalProps> = ({
       isOpen={isOpen}
       label={heading}
       showLabelIcon={false}
+      showMandatoryFieldLegend={false}
       toggleModal={(value: boolean) => {
         onToggle(value);
       }}

--- a/src/common/components/confirm/ConfirmModal.tsx
+++ b/src/common/components/confirm/ConfirmModal.tsx
@@ -40,6 +40,7 @@ const ConfirmModal: FunctionComponent<ConfirmModalProps> = ({
       isOpen={isOpen}
       label={heading}
       showLabelIcon={false}
+      showMandatoryFieldLegend={false}
       toggleModal={(value: boolean) => {
         setIsOpen(value);
       }}

--- a/src/common/components/mandatoryFieldLegend/MandatoryFieldLegend.tsx
+++ b/src/common/components/mandatoryFieldLegend/MandatoryFieldLegend.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { FunctionComponent } from 'react';
+
+import styles from './mandatoryFieldLegend.module.scss';
+
+export type MandatoryFieldLegendProps = {
+  position: 'left' | 'right';
+};
+
+const MandatoryFieldLegend: FunctionComponent<MandatoryFieldLegendProps> = ({
+  position,
+}: MandatoryFieldLegendProps) => {
+  const { t } = useTranslation();
+  return (
+    <p className={styles[position]} data-testid="mandatory-field-legend">
+      <span className={styles.bold}>*</span>
+      <span> {t('requiredLabelSuffix')}</span>
+    </p>
+  );
+};
+
+export default MandatoryFieldLegend;

--- a/src/common/components/mandatoryFieldLegend/mandatoryFieldLegend.module.scss
+++ b/src/common/components/mandatoryFieldLegend/mandatoryFieldLegend.module.scss
@@ -1,0 +1,11 @@
+.bold {
+  font-weight: bold;
+}
+
+.left {
+  text-align: left;
+}
+
+.right {
+  text-align: right;
+}

--- a/src/common/components/modal/Modal.tsx
+++ b/src/common/components/modal/Modal.tsx
@@ -8,6 +8,7 @@ import styles from './modal.module.scss';
 import Icon from '../icon/Icon';
 import happyChildIcon from '../../../assets/icons/svg/childFaceHappy.svg';
 import Button from '../button/Button';
+import MandatoryFieldLegend from '../mandatoryFieldLegend/MandatoryFieldLegend';
 
 interface ModalProps {
   isOpen: boolean;
@@ -18,6 +19,7 @@ interface ModalProps {
   showHeading?: boolean;
   className?: string;
   icon?: string;
+  showMandatoryFieldLegend?: boolean;
   children?: React.ReactNode;
 }
 
@@ -31,6 +33,7 @@ const Modal: React.FunctionComponent<ModalProps> = ({
   className,
   showHeading = true,
   icon = happyChildIcon,
+  showMandatoryFieldLegend = true,
 }) => {
   const { t } = useTranslation();
   const onClose = () => {
@@ -66,6 +69,9 @@ const Modal: React.FunctionComponent<ModalProps> = ({
               <div className={styles.heading}>
                 {showLabelIcon && <Icon className={styles.icon} src={icon} />}
                 {label && <h2>{label}</h2>}
+                {showMandatoryFieldLegend && (
+                  <MandatoryFieldLegend position="right" />
+                )}
               </div>
             )}
             <div className={styles.modalChildren}>{children}</div>

--- a/src/common/components/modal/__tests__/Modal.test.tsx
+++ b/src/common/components/modal/__tests__/Modal.test.tsx
@@ -1,6 +1,21 @@
 import { render } from '@testing-library/react';
+import ReactModal from 'react-modal';
 
 import Modal from '../Modal';
+import { screen } from '../../../test/testingLibraryUtils';
+
+/**
+ * ReactModal.setAppElement is used to prevent the following warning when
+ * running tests that use an open Modal component:
+ *
+ * "Warning: react-modal: App element is not defined.
+ * Please use `Modal.setAppElement(el)` or set `appElement={el}`.
+ * This is needed so screen readers don't see main content when modal is opened.
+ * It is not recommended, but you can opt-out by setting `ariaHideApp={false}`."
+ */
+ReactModal.setAppElement(
+  document.body.appendChild(document.createElement('div'))
+);
 
 it('renders snapshot correctly', () => {
   const { container: spinner } = render(
@@ -9,4 +24,48 @@ it('renders snapshot correctly', () => {
     </Modal>
   );
   expect(spinner).toMatchSnapshot();
+});
+
+it('renders mandatory field legend by default', async () => {
+  render(
+    <Modal isOpen={true} label="modalLabel" toggleModal={vi.fn()}>
+      foo
+    </Modal>
+  );
+  await screen.findByText('modalLabel');
+  const legend = await screen.getByTestId('mandatory-field-legend');
+  expect(legend.textContent).toBe('* tarkoittaa pakollista kenttää');
+});
+
+it('renders mandatory field legend when asked to', async () => {
+  render(
+    <Modal
+      isOpen={true}
+      label="modalLabel"
+      toggleModal={vi.fn()}
+      showMandatoryFieldLegend
+    >
+      foo
+    </Modal>
+  );
+  await screen.findByText('modalLabel');
+  const legend = await screen.getByTestId('mandatory-field-legend');
+  expect(legend.textContent).toBe('* tarkoittaa pakollista kenttää');
+});
+
+it('omits mandatory field legend when asked to', async () => {
+  render(
+    <Modal
+      isOpen={true}
+      label="modalLabel"
+      toggleModal={vi.fn()}
+      showMandatoryFieldLegend={false}
+    >
+      foo
+    </Modal>
+  );
+  await screen.findByText('modalLabel');
+  expect(
+    screen.queryByTestId('mandatory-field-legend')
+  ).not.toBeInTheDocument();
 });

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -1,4 +1,5 @@
 {
+  "requiredLabelSuffix": "indicates a mandatory field",
   "accessibilityStatement": {
     "title": "Accessibility Statement"
   },

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -1,4 +1,5 @@
 {
+  "requiredLabelSuffix": "tarkoittaa pakollista kenttää",
   "accessibilityStatement": {
     "title": "Saavutettavuusseloste"
   },

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -1,4 +1,5 @@
 {
+  "requiredLabelSuffix": "anger ett obligatoriskt fält",
   "accessibilityStatement": {
     "title": "Tillgänglighetsredogörelse"
   },

--- a/src/domain/registration/form/RegistrationForm.tsx
+++ b/src/domain/registration/form/RegistrationForm.tsx
@@ -39,6 +39,7 @@ import LanguagesCombobox from '../../languages/LanguagesCombobox';
 import { registrationFormDataSelector } from '../state/RegistrationSelectors';
 import { useProfileContext } from '../../profile/hooks/useProfileContext';
 import { MyProfile } from '../../profile/types/ProfileQueryTypes';
+import MandatoryFieldLegend from '../../../common/components/mandatoryFieldLegend/MandatoryFieldLegend';
 
 export const FORM_TESTID = 'registrationForm';
 export const EMAIL_FIELD_TESTID = 'guardian.email';
@@ -311,6 +312,7 @@ const RegistrationForm = () => {
                   <div className={styles.heading}>
                     <Icon src={happyAdultIcon} className={styles.childImage} />
                     <h2>{t('registration.form.guardian.info.heading')}</h2>
+                    <MandatoryFieldLegend position="right" />
                   </div>
                   <FormikTextInput
                     id="guardian.email"
@@ -407,25 +409,28 @@ const RegistrationForm = () => {
                     name="agree"
                     required={true}
                     label={
-                      <Trans
-                        i18nKey="registration.form.agree.input.label"
-                        components={[
-                          // These components receive content in the
-                          // translation definition.
-                          // eslint-disable-next-line jsx-a11y/anchor-has-content
-                          <a
-                            href={t('descriptionOfTheFile.url')}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          />,
-                          // eslint-disable-next-line jsx-a11y/anchor-has-content
-                          <a
-                            href={t('dataProtection.url')}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          />,
-                        ]}
-                      />
+                      <>
+                        <Trans
+                          i18nKey="registration.form.agree.input.label"
+                          components={[
+                            // These components receive content in the
+                            // translation definition.
+                            // eslint-disable-next-line jsx-a11y/anchor-has-content
+                            <a
+                              href={t('descriptionOfTheFile.url')}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            />,
+                            // eslint-disable-next-line jsx-a11y/anchor-has-content
+                            <a
+                              href={t('dataProtection.url')}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            />,
+                          ]}
+                        />
+                        <span className={styles.required}>&nbsp;*</span>
+                      </>
                     }
                   />
 

--- a/src/domain/registration/form/partial/childFormFields.tsx
+++ b/src/domain/registration/form/partial/childFormFields.tsx
@@ -12,6 +12,7 @@ import FormikDropdown from '../../../../common/components/formikWrappers/FormikD
 import { RegistrationFormValues } from '../../types/RegistrationTypes';
 import Button from '../../../../common/components/button/Button';
 import FormikTextInput from '../../../../common/components/formikWrappers/FormikTextInput';
+import MandatoryFieldLegend from '../../../../common/components/mandatoryFieldLegend/MandatoryFieldLegend';
 
 type ChildFormFieldProps = {
   child: Child;
@@ -36,6 +37,11 @@ const ChildFormFields: React.FunctionComponent<ChildFormFieldProps> = ({
         <div className={styles.heading}>
           <Icon src={happyChildIcon} className={styles.childImage} />
           <h2>{t('registration.form.child.info.heading')}</h2>
+
+          {/* Show mandatory field legend only in first child form */}
+          {childIndex === 0 && <MandatoryFieldLegend position="right" />}
+
+          {/* Allow to remove only non-first children */}
           {childIndex !== 0 && (
             <Button
               variant="supplementary"

--- a/src/domain/registration/form/registrationForm.module.scss
+++ b/src/domain/registration/form/registrationForm.module.scss
@@ -77,3 +77,7 @@ $plusIconHeight: 2rem;
 .heading {
   padding: $baseMargin;
 }
+
+.required {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Description

### feat: add required * and explanation text to Modal & RegistrationForm

refs KK-1190

## Context

[KK-1190](https://helsinkisolutionoffice.atlassian.net/browse/KK-1190)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

### Finnish registration form
![localhost_3000_fi_registration_form](https://github.com/City-of-Helsinki/kukkuu-ui/assets/77663720/b4d11c25-360a-464f-bb43-7fd3467bfa2f)

### Swedish registration form
![localhost_3000_sv_registration_form](https://github.com/City-of-Helsinki/kukkuu-ui/assets/77663720/044a57f8-42ad-4ae8-a708-bdfa09d5ba52)

### English registration form
![localhost_3000_en_registration_form](https://github.com/City-of-Helsinki/kukkuu-ui/assets/77663720/f57eed97-03c8-4b5c-b471-a012ea27d6a5)

[KK-1190]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ