### PR TITLE
fix: not eligible component external link

### DIFF
--- a/src/domain/registration/notEligible/NotEligible.tsx
+++ b/src/domain/registration/notEligible/NotEligible.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import styles from './notEligible.module.scss';
 import adultFaceIcon from '../../../assets/icons/svg/adultFace.svg';
@@ -10,21 +10,20 @@ import Button from '../../../common/components/button/Button';
 
 const NotEligible: FunctionComponent = () => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   return (
     <PageWrapper>
       <div>
         <div className={styles.notEligible}>
           <Icon className={styles.notEligibleFace} src={adultFaceIcon} />
           <p>{t('registration.notEligible.text')}</p>
-          <Button
-            className={styles.goBackButton}
-            onClick={() =>
-              navigate(t('registration.notEligible.otherOptionsLink'))
-            }
+          <Link
+            to={t('registration.notEligible.otherOptionsLink')}
+            target="_blank"
           >
-            {t('registration.notEligible.buttonText')}
-          </Button>
+            <Button className={styles.goBackButton}>
+              {t('registration.notEligible.buttonText')}
+            </Button>
+          </Link>
         </div>
       </div>
     </PageWrapper>

--- a/src/domain/registration/notEligible/__tests__/__snapshots__/NotEligible.test.tsx.snap
+++ b/src/domain/registration/notEligible/__tests__/__snapshots__/NotEligible.test.tsx.snap
@@ -23,17 +23,22 @@ exports[`renders snapshot correctly 1`] = `
           <p>
             Valitettavasti lapsen syntymävuosi tai kotipaikkakunta eivät oikeuta häntä Kulttuurin kummilapset -toimintaan.
           </p>
-          <button
-            class="Button-module_button__1msFE button_hds-button__2A0je Button-module_primary__2LfKB button_hds-button--primary__2NVvO _goBackButton_cca70d"
-            style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
-            type="button"
+          <a
+            href="https://tapahtumat.hel.fi/fi/haku?onlyChildrenEvents=true"
+            target="_blank"
           >
-            <span
-              class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+            <button
+              class="Button-module_button__1msFE button_hds-button__2A0je Button-module_primary__2LfKB button_hds-button--primary__2NVvO _goBackButton_cca70d"
+              style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
+              type="button"
             >
-              Löydä lapsille sopivia kulttuuritapahtumia täältä
-            </span>
-          </button>
+              <span
+                class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+              >
+                Löydä lapsille sopivia kulttuuritapahtumia täältä
+              </span>
+            </button>
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
KK-1204

The button appended the full link to the current pathname. To fix this,
the navigate-command is changed to an actual link that wraps the button.
The new page will be opened in a new blank tab.
