### PR TITLE
KK-1223 | fix: "Kultuurin" typo with "Kulttuurin"

### DIFF
--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -431,7 +431,7 @@
     },
     "moreInfo": {
       "description": {
-        "text": "Lataa lisätietoa Kultuurin kummilapset -palvelusta omalla kielelläsi."
+        "text": "Lataa lisätietoa Kulttuurin kummilapset -palvelusta omalla kielelläsi."
       },
       "heading": {
         "text": "Lisätietoa palvelusta eri kielillä"

--- a/src/domain/home/__tests__/__snapshots__/Home.test.jsx.snap
+++ b/src/domain/home/__tests__/__snapshots__/Home.test.jsx.snap
@@ -74,7 +74,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
               Lisätietoa palvelusta eri kielillä
             </h2>
             <p>
-              Lataa lisätietoa Kultuurin kummilapset -palvelusta omalla kielelläsi.
+              Lataa lisätietoa Kulttuurin kummilapset -palvelusta omalla kielelläsi.
             </p>
             <div
               class="_link_0c660e"

--- a/src/domain/home/__tests__/__snapshots__/Home.test.tsx.snap
+++ b/src/domain/home/__tests__/__snapshots__/Home.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
               Lisätietoa palvelusta eri kielillä
             </h2>
             <p>
-              Lataa lisätietoa Kultuurin kummilapset -palvelusta omalla kielelläsi.
+              Lataa lisätietoa Kulttuurin kummilapset -palvelusta omalla kielelläsi.
             </p>
             <div
               class="_link_0c660e"

--- a/src/domain/home/moreInfo/__tests__/__snapshots__/HomeMoreInfo.test.tsx.snap
+++ b/src/domain/home/moreInfo/__tests__/__snapshots__/HomeMoreInfo.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`renders snapshot correctly 1`] = `
         Lisätietoa palvelusta eri kielillä
       </h2>
       <p>
-        Lataa lisätietoa Kultuurin kummilapset -palvelusta omalla kielelläsi.
+        Lataa lisätietoa Kulttuurin kummilapset -palvelusta omalla kielelläsi.
       </p>
       <div
         class="_link_0c660e"


### PR DESCRIPTION
## Description

### fix: "Kultuurin" typo with "Kulttuurin"

refs KK-1223

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-1223](https://helsinkisolutionoffice.atlassian.net/browse/KK-1223)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1223]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ