### PR TITLE
test: add an option to run Testcafe test with chromium

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:watch": "cross-env TZ=Europe/Helsinki vitest",
     "test:browser": "testcafe \"chrome --window-size='1920,1080' --disable-search-engine-choice-screen\" browser-tests/ --live --dev --lang=fi-FI",
     "test:browser:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080' --disable-search-engine-choice-screen\" --lang=fi-FI --screenshots path=report takeOnFails=true --video report browser-tests/",
+    "test:browser:ci:chromium": "testcafe \"chromium:headless --disable-gpu --window-size='1920,1080' --disable-search-engine-choice-screen\" --lang=fi-FI --screenshots path=report takeOnFails=true --video report browser-tests/",
     "test:browser:wsl2win": "testcafe 'path:`/mnt/c/Program Files/Google/Chrome/Application/chrome.exe`' browser-tests/ --live --dev --lang=fi-FI",
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },


### PR DESCRIPTION
KK-1247.

Pipeline changes: https://dev.azure.com/City-of-Helsinki/kukkuu/_git/kukkuu-pipelines/pullrequest/9899

Add an option to run Testcafe browser tests with Chromium instead of Chrome. There have been some issues with the Chrome that prevents using it in CI environment:

- https://github.com/DevExpress/testcafe/issues/8286
- https://github.com/DevExpress/testcafe/issues/8300
- https://github.com/DevExpress/testcafe/issues/8304
- https://github.com/DevExpress/testcafe/issues/8307
