### PR TITLE
KK-1237 | Fix language names Українська → Українська мова and Davvisámi → Davvisámegiella

### DIFF
--- a/src/domain/home/__tests__/__snapshots__/Home.test.tsx.snap
+++ b/src/domain/home/__tests__/__snapshots__/Home.test.tsx.snap
@@ -385,7 +385,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 <span
                   lang="sme"
                 >
-                  Davvisámi
+                  Davvisámegiella
                 </span>
                 <span>
                    
@@ -405,7 +405,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 <span
                   lang="ukr"
                 >
-                  Українська
+                  Українська мова
                 </span>
                 <span>
                    

--- a/src/domain/home/moreInfo/__tests__/__snapshots__/HomeMoreInfo.test.tsx.snap
+++ b/src/domain/home/moreInfo/__tests__/__snapshots__/HomeMoreInfo.test.tsx.snap
@@ -323,7 +323,7 @@ exports[`renders snapshot correctly 1`] = `
           <span
             lang="sme"
           >
-            Davvisámi
+            Davvisámegiella
           </span>
           <span>
              
@@ -343,7 +343,7 @@ exports[`renders snapshot correctly 1`] = `
           <span
             lang="ukr"
           >
-            Українська
+            Українська мова
           </span>
           <span>
              

--- a/src/domain/home/moreInfo/__tests__/__snapshots__/MoreInfoLinkList.test.tsx.snap
+++ b/src/domain/home/moreInfo/__tests__/__snapshots__/MoreInfoLinkList.test.tsx.snap
@@ -311,7 +311,7 @@ exports[`renders snapshot correctly 1`] = `
       <span
         lang="sme"
       >
-        Davvisámi
+        Davvisámegiella
       </span>
       <span>
          
@@ -331,7 +331,7 @@ exports[`renders snapshot correctly 1`] = `
       <span
         lang="ukr"
       >
-        Українська
+        Українська мова
       </span>
       <span>
          

--- a/src/domain/home/moreInfo/constants/MoreInfoConstants.tsx
+++ b/src/domain/home/moreInfo/constants/MoreInfoConstants.tsx
@@ -81,12 +81,12 @@ export const moreInfoLinks: MoreInfoLink[] = [
     url: '/brochures/fi.pdf',
   },
   {
-    langName: 'Davvisámi',
+    langName: 'Davvisámegiella',
     langCode: 'sme',
     url: '/brochures/sme.pdf',
   },
   {
-    langName: 'Українська',
+    langName: 'Українська мова',
     langCode: 'ukr',
     url: '/brochures/ukr.pdf',
   },


### PR DESCRIPTION
## Description

Set language names for Ukrainian and Sami languages to texts given by the product owner.

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-588](https://helsinkisolutionoffice.atlassian.net/browse/KK-588) (Sami)
[KK-1237](https://helsinkisolutionoffice.atlassian.net/browse/KK-1237) (Ukrainian)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-588]: https://helsinkisolutionoffice.atlassian.net/browse/KK-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KK-1237]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ