### PR TITLE
KK-1375 | Fix browser tests by using existing project year 2020 as child's birthyear

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Browser tests are ran against PR and staging environments when after they have b
 To run browser tests locally, you need to configure the browser testing environment:
 
 1. Run a local Kukkuu API instance with the browser testing JWT features set on. Like that the UI client can issue new JWT for authorization by itself.
-2. Run a local Kukkuu Admin UI.
+2. Run a local Kukkuu UI (i.e. this repository's app).
 3. Carefully double check that the UI instance is configured to use the local API. The browser test JWT token configurations also needs to match in order to successfully verify the newly issued tokens. You navigate through the UI manually to see that everything is working as expected.
 4. Run the browser test with `yarn test:browser` or `yarn test:browser:ci`.
 

--- a/browser-tests/childrenFeature.ts
+++ b/browser-tests/childrenFeature.ts
@@ -16,10 +16,11 @@ import {
 } from './utils/jwt/mocks/testJWTAuthRequests';
 import { browserTestUser } from './utils/jwt/users';
 import { authorizedGuardian } from './userRoles';
+import { EXISTING_PROJECT_YEAR } from './constants';
 
 function buildAddChild() {
   return {
-    birthYear: '2020',
+    birthYear: EXISTING_PROJECT_YEAR.toString(),
     city: 'Helsinki',
     postalCode: '00000',
     name: 'Gilly Girod',

--- a/browser-tests/constants.ts
+++ b/browser-tests/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Project for year 2020 should always exist in backend as
+ * it is created in the backend's migration scripts.
+ */
+export const EXISTING_PROJECT_YEAR = 2020;

--- a/browser-tests/utils/register.ts
+++ b/browser-tests/utils/register.ts
@@ -4,11 +4,12 @@ import {
   registrationDone,
 } from '../pages/register';
 import getDropdownOption from './getDropdownOption';
+import { EXISTING_PROJECT_YEAR } from '../constants';
 
 // Firstime sign up requires registration
 export const register = async (t: TestController) => {
   const registerChild = {
-    birthYear: '2023',
+    birthYear: EXISTING_PROJECT_YEAR.toString(),
     city: 'Helsinki',
     postalCode: '00000',
     name: 'Hertta Citron',


### PR DESCRIPTION
## Description

Fix browser tests by using existing project year 2020 as child's birthyear

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-1375](https://helsinkisolutionoffice.atlassian.net/browse/KK-1375)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1375]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ