### PR TITLE
KK-1372 | Handle most warnings from running tests

### DIFF
--- a/src/domain/app/__tests__/Layout.test.tsx
+++ b/src/domain/app/__tests__/Layout.test.tsx
@@ -1,8 +1,31 @@
+import { MockedResponse } from '@apollo/client/testing';
+import { graphql, HttpResponse } from 'msw';
+
 import { render } from '../../../common/test/testingLibraryUtils';
 import Layout from '../Layout';
+import { footerMenuMock } from '../footer/__mocks__/footerMenuMock';
+import { languagesMock } from '../footer/__mocks__/languagesMock';
+import { headerMenuMock } from '../navigation/__mocks__/headerMenuMock';
+import { notificationMock } from '../notification/__mocks__/notificationMock';
+import { server } from '../../../test/msw/server';
+import AppConfig from '../AppConfig';
+import pageQueryResponse from './__mocks__/pageQueryResponse';
 
-// TODO: Add some apollo mocks
+const mocks: MockedResponse[] = [
+  footerMenuMock,
+  headerMenuMock,
+  languagesMock,
+  notificationMock,
+];
+
+beforeEach(() => {
+  const headlessCms = graphql.link(AppConfig.cmsUri);
+  server.use(
+    headlessCms.query('page', () => HttpResponse.json({ ...pageQueryResponse }))
+  );
+});
+
 it('renders without crashing', () => {
-  const { container } = render(<Layout />);
+  const { container } = render(<Layout />, mocks);
   expect(container).toMatchSnapshot();
 });

--- a/src/domain/app/__tests__/__mocks__/pageQueryResponse.ts
+++ b/src/domain/app/__tests__/__mocks__/pageQueryResponse.ts
@@ -1,0 +1,70 @@
+/**
+ * This is a mock of the response from the page query.
+ * Data taken from production CMS query response, and simplified.
+ */
+const pageQueryResponse = {
+  data: {
+    page: {
+      id: 'cG9zdDo1MDg=',
+      content: '<p>Logging in has changed</p>',
+      slug: 'news',
+      title: 'News',
+      uri: '/news/',
+      link: 'https://kukkuu.content.api.hel.fi/news/',
+      lead: '',
+      seo: {
+        title: 'News - Kukkuu',
+        description: 'Logging in has changed',
+        openGraphTitle: 'News',
+        openGraphDescription: 'Logging in has changed',
+        openGraphType: 'website',
+        twitterTitle: 'News',
+        twitterDescription: 'Logging in has changed',
+        canonicalUrl: '',
+        socialImage: null,
+        __typename: 'SEO',
+      },
+      hero: {
+        background_color: '',
+        background_image_url: '',
+        description: '',
+        link: {
+          target: null,
+          title: null,
+          url: null,
+          __typename: 'Link',
+        },
+        title: '',
+        wave_motif: '',
+        __typename: 'Hero',
+      },
+      language: {
+        code: 'FI',
+        id: 'TGFuZ3VhZ2U6Zmk=',
+        locale: 'fi',
+        name: 'Suomi',
+        slug: 'fi',
+        __typename: 'Language',
+      },
+      translations: [],
+      featuredImage: null,
+      breadcrumbs: [
+        {
+          title: 'Etusivu',
+          uri: '/',
+          __typename: 'Breadcrumb',
+        },
+        {
+          title: 'News',
+          uri: '/news/',
+          __typename: 'Breadcrumb',
+        },
+      ],
+      sidebar: [],
+      modules: [],
+      __typename: 'Page',
+    },
+  },
+} as const;
+
+export default pageQueryResponse;

--- a/src/domain/app/navigation/Navigation.tsx
+++ b/src/domain/app/navigation/Navigation.tsx
@@ -13,7 +13,7 @@ import UserNavigation from './UserNavigation';
 import { useCmsLanguageOptions } from '../../../hooks/useCmsLanguageOptions';
 import { stripLocaleFromUri } from '../../../utils/cmsUtils';
 
-const languageToMenuNameMap = {
+export const languageToMenuNameMap = {
   [SUPPORT_LANGUAGES.FI]: 'Main Navigation FI',
   [SUPPORT_LANGUAGES.SV]: 'Main Navigation SV',
   [SUPPORT_LANGUAGES.EN]: 'Main Navigation EN',

--- a/src/domain/app/navigation/__mocks__/headerMenuMock.ts
+++ b/src/domain/app/navigation/__mocks__/headerMenuMock.ts
@@ -1,0 +1,123 @@
+import { MenuDocument } from 'react-helsinki-headless-cms/apollo';
+import { MockedResponse } from '@apollo/client/testing';
+
+import { languageToMenuNameMap } from '../Navigation';
+
+/**
+ * This is a mock of the response from the header menu query.
+ * Data taken from production CMS query response, and strongly
+ * reduced in size for simplicity.
+ */
+export const headerMenuQueryResponse = {
+  data: {
+    menu: {
+      id: 'dGVybToxNg==',
+      menuItems: {
+        nodes: [
+          {
+            id: 'cG9zdDo1MTU=',
+            parentId: null,
+            order: 1,
+            target: null,
+            title: null,
+            path: '/ajankohtaista/',
+            label: 'Ajankohtaista',
+            connectedNode: {
+              node: {
+                id: 'cG9zdDo1MDU=',
+                content: '<p>Kirjautuminen palveluun on muuttunut</p>',
+                slug: 'ajankohtaista',
+                title: 'Ajankohtaista',
+                uri: '/ajankohtaista/',
+                link: 'https://kukkuu.content.api.hel.fi/ajankohtaista/',
+                lead: '',
+                seo: {
+                  title: 'Ajankohtaista &#x2d; Kukkuu',
+                  description: 'Kirjautuminen palveluun on muuttunut',
+                  openGraphTitle: 'Ajankohtaista',
+                  openGraphDescription: 'Kirjautuminen palveluun on muuttunut',
+                  openGraphType: 'website',
+                  twitterTitle: 'Ajankohtaista',
+                  twitterDescription: 'Kirjautuminen palveluun on muuttunut',
+                  canonicalUrl: '',
+                  socialImage: null,
+                  __typename: 'SEO',
+                },
+                hero: {
+                  background_color: '',
+                  background_image_url: '',
+                  description: '',
+                  link: {
+                    target: null,
+                    title: null,
+                    url: null,
+                    __typename: 'Link',
+                  },
+                  title: '',
+                  wave_motif: '',
+                  __typename: 'Hero',
+                },
+                language: {
+                  code: 'FI',
+                  id: 'TGFuZ3VhZ2U6Zmk=',
+                  locale: 'fi',
+                  name: 'Suomi',
+                  slug: 'fi',
+                  __typename: 'Language',
+                },
+                translations: [],
+                featuredImage: null,
+                breadcrumbs: [
+                  {
+                    title: 'Etusivu',
+                    uri: '/',
+                    __typename: 'Breadcrumb',
+                  },
+                  {
+                    title: 'Ajankohtaista',
+                    uri: '/ajankohtaista/',
+                    __typename: 'Breadcrumb',
+                  },
+                ],
+                sidebar: [],
+                modules: [],
+                __typename: 'Page',
+                children: {
+                  nodes: [],
+                  __typename:
+                    'HierarchicalContentNodeToContentNodeChildrenConnection',
+                },
+              },
+              __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            },
+            __typename: 'MenuItem',
+          },
+        ],
+        __typename: 'MenuToMenuItemConnection',
+      },
+      __typename: 'Menu',
+    },
+  },
+} as const;
+
+export const headerMenuMock: MockedResponse = {
+  request: {
+    query: MenuDocument,
+    variables: {
+      id: languageToMenuNameMap['fi'],
+      menuIdentifiersOnly: false,
+    },
+  },
+  result: headerMenuQueryResponse,
+};
+
+export const emptyHeaderMenuQueryResponse = {
+  data: {
+    menu: {
+      id: 'empty-header-menu',
+      menuItems: {
+        nodes: [],
+      },
+    },
+  },
+} as const;

--- a/src/domain/app/notification/__mocks__/notificationMock.ts
+++ b/src/domain/app/notification/__mocks__/notificationMock.ts
@@ -1,0 +1,31 @@
+import { MockedResponse } from '@apollo/client/testing';
+
+import notificationQuery from '../notificationQuery';
+
+/**
+ * This is a mock of the response from the notification query.
+ * Data taken from production CMS query response, and cleaned/simplified.
+ */
+export const notificationQueryResponse = {
+  data: {
+    notification: {
+      content:
+        '<p>Kirjautuminen Kulttuurin kummilapset -palveluun on muuttunut 17.6.2024 alkaen.</p>',
+      title: 'Huom.!',
+      level: 'info',
+      startDate: '2024-06-17T00:00:00+03:00',
+      endDate: '',
+      linkText: 'Lue lisää',
+      linkUrl: 'https://kummilapset.hel.fi/fi/ajankohtaista/',
+      __typename: 'Notification',
+    },
+  },
+} as const;
+
+export const notificationMock: MockedResponse = {
+  request: {
+    query: notificationQuery,
+    variables: { language: 'fi' },
+  },
+  result: notificationQueryResponse,
+};

--- a/src/domain/app/notification/notificationQuery.ts
+++ b/src/domain/app/notification/notificationQuery.ts
@@ -1,0 +1,17 @@
+import { gql } from '@apollo/client';
+
+export const notificationQuery = gql`
+  query notification($language: String! = "fi") {
+    notification(language: $language) {
+      content
+      title
+      level
+      startDate
+      endDate
+      linkText
+      linkUrl
+    }
+  }
+`;
+
+export default notificationQuery;

--- a/src/domain/auth/Unauthorized.tsx
+++ b/src/domain/auth/Unauthorized.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { IconSignin } from 'hds-react/icons';
-import { useOidcClient } from 'hds-react';
+import { IconSignin, useOidcClient } from 'hds-react';
 import React from 'react';
 
 import InfoPageLayout from '../app/layout/InfoPageLayout';

--- a/src/domain/event/__tests__/EventIsEnrolled.test.tsx
+++ b/src/domain/event/__tests__/EventIsEnrolled.test.tsx
@@ -1,7 +1,24 @@
+import { MockedResponse } from '@apollo/client/testing';
+
 import { render } from '../../../common/test/testingLibraryUtils';
 import EventIsEnrolled from '../EventIsEnrolled';
+import occurrenceQuery from '../queries/occurrenceQuery';
+
+const emptyOccurrenceMock: MockedResponse = {
+  request: {
+    query: occurrenceQuery,
+    variables: { id: undefined, childId: undefined },
+  },
+  result: {
+    data: {
+      occurrence: {},
+    },
+  },
+};
+
+const mocks: MockedResponse[] = [emptyOccurrenceMock];
 
 it('renders snapshot correctly', () => {
-  const { container } = render(<EventIsEnrolled />);
+  const { container } = render(<EventIsEnrolled />, mocks);
   expect(container).toMatchSnapshot();
 });

--- a/src/domain/event/__tests__/EventOccurrence.test.tsx
+++ b/src/domain/event/__tests__/EventOccurrence.test.tsx
@@ -34,14 +34,17 @@ const getWrapper = (props: any = {}) =>
   render(
     <table>
       <tbody>
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-        <EventOccurrence {...defaultProps} {...(props as any)} />
+        <EventOccurrence
+          key={mockedNode.id}
+          {...defaultProps}
+          {...(props as any)}
+        />
       </tbody>
     </table>
   );
 
 it('renders snapshot correctly', () => {
-  const { container } = getWrapper({ key: mockedNode.id });
+  const { container } = getWrapper();
 
   expect(container).toMatchSnapshot();
 });

--- a/src/domain/event/__tests__/EventOccurrenceList.test.tsx
+++ b/src/domain/event/__tests__/EventOccurrenceList.test.tsx
@@ -7,7 +7,7 @@ const mockedOccurrences: Occurrences = {
   edges: [
     {
       node: {
-        id: 'T2NjdXJyZW5jZU5vZGU6Mg==',
+        id: 'T2NjdXJyZW5jZU5vZGU6MQ==', // Base64 encoded 'OccurrenceNode:1'
         time: '2020-03-08T04:00:00+00:00',
         remainingCapacity: 99,
         event: {
@@ -26,7 +26,7 @@ const mockedOccurrences: Occurrences = {
     },
     {
       node: {
-        id: 'T2NjdXJyZW5jZU5vZGU6Mg==',
+        id: 'T2NjdXJyZW5jZU5vZGU6Mg==', // Base64 encoded 'OccurrenceNode:2'
         time: '2020-04-08T04:00:00+00:00',
         remainingCapacity: 88,
         event: {

--- a/src/domain/event/__tests__/__snapshots__/EventOccurrenceList.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventOccurrenceList.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`renders snapshot correctly 1`] = `
           <a
             class="hds-button _button_f33f10"
             data-discover="true"
-            href="/occurrence/T2NjdXJyZW5jZU5vZGU6Mg==/enrol"
+            href="/occurrence/T2NjdXJyZW5jZU5vZGU6MQ==/enrol"
           >
             <span
               class="hds-button__label"
@@ -93,7 +93,7 @@ exports[`renders snapshot correctly 1`] = `
           <a
             class="hds-button _button_f33f10"
             data-discover="true"
-            href="/occurrence/T2NjdXJyZW5jZU5vZGU6Mg==/enrol"
+            href="/occurrence/T2NjdXJyZW5jZU5vZGU6MQ==/enrol"
           >
             <span
               class="hds-button__label"

--- a/src/domain/event/enrol/__tests__/Enrol.test.tsx
+++ b/src/domain/event/enrol/__tests__/Enrol.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import { MockedResponse } from '@apollo/client/testing';
 
 import {
   render,
@@ -8,13 +9,23 @@ import {
 } from '../../../../common/test/testingLibraryUtils';
 import initModal from '../../../../common/test/initModal';
 import Enrol from '../Enrol';
+import {
+  EventParticipantsPerInvite,
+  SubscribeToFreeSpotNotificationMutationDocument,
+  UnsubscribeFromFreeSpotNotificationMutationDocument,
+} from '../../../api/generatedTypes/graphql';
+import eventQuery from '../../queries/eventQuery';
+
+const testChildId = '123';
+const testEventId = 'zzaaz';
+const testOccurrenceId = 'T2NjdXJyZW5jZU5vZGU6Mg==';
 
 const occurrence = {
-  id: 'T2NjdXJyZW5jZU5vZGU6Mg==',
+  id: testOccurrenceId,
   time: '2020-03-08T04:00:00+00:00',
   remainingCapacity: 99,
   event: {
-    id: 'zzaaz',
+    id: testEventId,
     name: 'event name',
   },
   venue: {
@@ -25,7 +36,7 @@ const occurrence = {
   childHasFreeSpotNotificationSubscription: false,
 };
 const defaultProps = {
-  childId: '123',
+  childId: testChildId,
   isSubscriptionModalOpen: false,
   occurrence,
   onCancel: vi.fn(),
@@ -36,10 +47,92 @@ const defaultProps = {
   setIsSubscriptionModalOpen: vi.fn(),
 };
 
+const eventMock: MockedResponse = {
+  request: {
+    query: eventQuery,
+    variables: {
+      id: testEventId,
+      childId: testChildId,
+    },
+  },
+  result: {
+    data: {
+      event: {
+        id: testEventId,
+        name: 'event name',
+        description: 'event description',
+        shortDescription: 'event short description',
+        image: 'event image',
+        imageAltText: 'event image alt text',
+        participantsPerInvite: EventParticipantsPerInvite.ChildAndGuardian,
+        duration: 60,
+        capacityPerOccurrence: 100,
+        canChildEnroll: true,
+        ticketSystem: null,
+        eventGroup: null,
+        occurrences: {
+          edges: [],
+          pageInfo: {
+            endCursor: null,
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+          },
+        },
+        allOccurrences: { edges: [] },
+      },
+    },
+  },
+};
+
+const subscribeToFreeSpotNotificationMock: MockedResponse = {
+  request: {
+    query: SubscribeToFreeSpotNotificationMutationDocument,
+    variables: {
+      input: {
+        occurrenceId: testOccurrenceId,
+        childId: testChildId,
+      },
+    },
+  },
+  result: {
+    data: {
+      subscribeToFreeSpotNotification: {
+        clientMutationId: null,
+      },
+    },
+  },
+};
+
+const unsubscribeFromFreeSpotNotificationMock: MockedResponse = {
+  request: {
+    query: UnsubscribeFromFreeSpotNotificationMutationDocument,
+    variables: {
+      input: {
+        occurrenceId: testOccurrenceId,
+        childId: testChildId,
+      },
+    },
+  },
+  result: {
+    data: {
+      unsubscribeFromFreeSpotNotification: {
+        clientMutationId: null,
+      },
+    },
+  },
+};
+
+const mocks: MockedResponse[] = [
+  eventMock,
+  subscribeToFreeSpotNotificationMock,
+  unsubscribeFromFreeSpotNotificationMock,
+];
+
 const renderEnrol = (props?: unknown) =>
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  render(<Enrol {...defaultProps} {...props} />);
+  render(<Enrol {...defaultProps} {...props} />, mocks);
 
 describe('<Enrol />', () => {
   it('the user should be able to sign in to an event', async () => {

--- a/src/domain/profile/__tests__/Profile.test.tsx
+++ b/src/domain/profile/__tests__/Profile.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as HdsReact from 'hds-react';
 import * as ReactRouterDom from 'react-router-dom';
 
@@ -33,6 +34,16 @@ vi.mock('react-router-dom', async (importOriginal: any) => {
   };
 });
 
+// Mock the console.info calls to avoid them in the test output
+// but also check that they are called correctly in the tests
+beforeEach(() => {
+  vi.spyOn(console, 'info').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  (console.info as ReturnType<typeof vi.fn>).mockRestore();
+});
+
 describe('Profile', () => {
   it('renders profile correctly', () => {
     vi.spyOn(HdsReact, 'useOidcClient').mockImplementation(
@@ -50,6 +61,7 @@ describe('Profile', () => {
     );
     const { container } = render(<Profile />);
     expect(container).toMatchSnapshot();
+    expect(console.info).not.toHaveBeenCalled();
   });
 
   it('redirects to the register section in home page if user is authenticated but has no profile', async () => {
@@ -78,6 +90,16 @@ describe('Profile', () => {
         });
       },
       { timeout: 15000 }
+    );
+
+    expect(console.info).toHaveBeenCalledTimes(2);
+    expect(console.info).toHaveBeenNthCalledWith(
+      1,
+      'Using a loading spinner to wait for profile to be added in the context.'
+    );
+    expect(console.info).toHaveBeenNthCalledWith(
+      2,
+      'User has logged in, but not created a profile. Send them to front page for registration.'
     );
   });
 });

--- a/src/domain/profile/events/__tests__/ProfileEvents.test.tsx
+++ b/src/domain/profile/events/__tests__/ProfileEvents.test.tsx
@@ -1,5 +1,10 @@
+import { MockedResponse } from '@apollo/client/testing';
+
 import ProfileEvents from '../ProfileEvents';
-import { EventParticipantsPerInvite } from '../../../api/generatedTypes/graphql';
+import {
+  ChildEnrolmentCountDocument,
+  EventParticipantsPerInvite,
+} from '../../../api/generatedTypes/graphql';
 import { render } from '../../../../common/test/testingLibraryUtils';
 import {
   ChildByIdResponse,
@@ -173,29 +178,63 @@ const childOnlyPastEvents = {
   pastEvents: pastEvents,
 };
 
+const childEnrolmentCountMock: MockedResponse = {
+  request: {
+    query: ChildEnrolmentCountDocument,
+    variables: {
+      childId: childData.id,
+    },
+  },
+  result: {
+    data: {
+      child: {
+        id: childData.id,
+        enrolmentCount: 0,
+        pastEnrolmentCount: 0,
+        project: {
+          id: childData.project.id,
+          enrolmentLimit: 1,
+        },
+      },
+    },
+  },
+};
+
+const mocks: MockedResponse[] = [childEnrolmentCountMock];
+
 test('Renders "No events" when no events"', () => {
-  const { container } = render(<ProfileEvents child={childNoEvents} />);
+  const { container } = render(<ProfileEvents child={childNoEvents} />, mocks);
   expect(container).toMatchSnapshot();
 });
 
 test('Renders events list when events of any type', () => {
-  const { container } = render(<ProfileEvents child={childWithEvents} />);
+  const { container } = render(
+    <ProfileEvents child={childWithEvents} />,
+    mocks
+  );
   expect(container).toMatchSnapshot();
 });
 
 test('Renders events list when only upcomingEventsAndEventGroups', () => {
   const { container } = render(
-    <ProfileEvents child={childOnlyAvailableEvents} />
+    <ProfileEvents child={childOnlyAvailableEvents} />,
+    mocks
   );
   expect(container).toMatchSnapshot();
 });
 
 test('Renders events list when only enrolments', () => {
-  const { container } = render(<ProfileEvents child={childOnlyEnrolments} />);
+  const { container } = render(
+    <ProfileEvents child={childOnlyEnrolments} />,
+    mocks
+  );
   expect(container).toMatchSnapshot();
 });
 
 test('Renders events list when only past events', () => {
-  const { container } = render(<ProfileEvents child={childOnlyPastEvents} />);
+  const { container } = render(
+    <ProfileEvents child={childOnlyPastEvents} />,
+    mocks
+  );
   expect(container).toMatchSnapshot();
 });

--- a/src/domain/profile/events/__tests__/ProfileEventsList.test.tsx
+++ b/src/domain/profile/events/__tests__/ProfileEventsList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MockedProvider } from '@apollo/client/testing';
+import { MockedResponse } from '@apollo/client/testing';
 
 import { render, screen } from '../../../../common/test/testingLibraryUtils';
 import ProfileEventsList from '../ProfileEventsList';
@@ -10,6 +10,7 @@ import {
   PastEvents,
   InternalAndTicketSystemEnrolments,
 } from '../../../child/types/ChildByIdQueryTypes';
+import { childEnrolmentCountQuery } from '../../../child/queries/ChildEnrolmentCountQuery';
 
 vi.mock('react-qrcode-logo', async (importOriginal: any) => {
   const mod = await importOriginal();
@@ -19,8 +20,10 @@ vi.mock('react-qrcode-logo', async (importOriginal: any) => {
   };
 });
 
+const testChildId = 'zzaf';
+
 const childData: ChildByIdResponse = {
-  id: '',
+  id: testChildId,
   name: '',
   birthyear: 0,
   postalCode: '',
@@ -182,36 +185,56 @@ const childWithTixlyEnrolment: ChildByIdResponse = {
   pastEvents: null,
 };
 
+const childEnrolmentCountMock: MockedResponse = {
+  request: {
+    query: childEnrolmentCountQuery,
+    variables: { childId: testChildId },
+  },
+  result: {
+    data: {
+      child: {
+        id: childData.id,
+        enrolmentCount: 0,
+        pastEnrolmentCount: 0,
+        project: {
+          id: childData.project.id,
+          enrolmentLimit: 1,
+        },
+      },
+    },
+  },
+};
+
+const mocks: MockedResponse[] = [childEnrolmentCountMock];
+
 test('Renders snapshot correctly', () => {
   const { container } = render(
-    <MockedProvider>
-      <ProfileEventsList
-        upcomingEventsAndEventGroups={
-          childWithEvents.upcomingEventsAndEventGroups
-        }
-        enrolments={childOnlyEnrolments.activeInternalAndTicketSystemEnrolments}
-        pastEvents={childWithEvents.pastEvents}
-        childId="zzaf"
-      />
-    </MockedProvider>
+    <ProfileEventsList
+      upcomingEventsAndEventGroups={
+        childWithEvents.upcomingEventsAndEventGroups
+      }
+      enrolments={childOnlyEnrolments.activeInternalAndTicketSystemEnrolments}
+      pastEvents={childWithEvents.pastEvents}
+      childId={testChildId}
+    />,
+    mocks
   );
   expect(container).toMatchSnapshot();
 });
 
 test('Renders only upcoming events and event groups when no other inputs', () => {
   render(
-    <MockedProvider>
-      <ProfileEventsList
-        upcomingEventsAndEventGroups={
-          childOnlyAvailableEvents.upcomingEventsAndEventGroups
-        }
-        enrolments={
-          childOnlyAvailableEvents.activeInternalAndTicketSystemEnrolments
-        }
-        pastEvents={childOnlyAvailableEvents.pastEvents}
-        childId="zzaf"
-      />
-    </MockedProvider>
+    <ProfileEventsList
+      upcomingEventsAndEventGroups={
+        childOnlyAvailableEvents.upcomingEventsAndEventGroups
+      }
+      enrolments={
+        childOnlyAvailableEvents.activeInternalAndTicketSystemEnrolments
+      }
+      pastEvents={childOnlyAvailableEvents.pastEvents}
+      childId={testChildId}
+    />,
+    mocks
   );
   expect(
     screen.getByRole('heading', { name: 'Tapahtumakutsut' })
@@ -226,16 +249,15 @@ test('Renders only upcoming events and event groups when no other inputs', () =>
 
 test('Renders only enrolments when no other inputs', () => {
   render(
-    <MockedProvider>
-      <ProfileEventsList
-        upcomingEventsAndEventGroups={
-          childOnlyEnrolments.upcomingEventsAndEventGroups
-        }
-        enrolments={childOnlyEnrolments.activeInternalAndTicketSystemEnrolments}
-        pastEvents={childOnlyEnrolments.pastEvents}
-        childId="zzaf"
-      />
-    </MockedProvider>
+    <ProfileEventsList
+      upcomingEventsAndEventGroups={
+        childOnlyEnrolments.upcomingEventsAndEventGroups
+      }
+      enrolments={childOnlyEnrolments.activeInternalAndTicketSystemEnrolments}
+      pastEvents={childOnlyEnrolments.pastEvents}
+      childId={testChildId}
+    />,
+    mocks
   );
 
   expect(
@@ -261,18 +283,17 @@ test.each([
   ['Tixly', childWithTixlyEnrolment.activeInternalAndTicketSystemEnrolments],
 ])('Renders %s enrolment', (_, enrolments) => {
   render(
-    <MockedProvider>
-      <ProfileEventsList
-        upcomingEventsAndEventGroups={{
-          edges: [],
-        }}
-        enrolments={enrolments}
-        pastEvents={{
-          edges: [],
-        }}
-        childId="zzaf"
-      />
-    </MockedProvider>
+    <ProfileEventsList
+      upcomingEventsAndEventGroups={{
+        edges: [],
+      }}
+      enrolments={enrolments}
+      pastEvents={{
+        edges: [],
+      }}
+      childId={testChildId}
+    />,
+    mocks
   );
 
   expect(screen.getByText('eventti')).toBeInTheDocument();

--- a/src/domain/profile/modal/__tests__/EditProfileModal.test.tsx
+++ b/src/domain/profile/modal/__tests__/EditProfileModal.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-node-access */
-import { MockedProvider } from '@apollo/client/testing';
 import React from 'react';
 import { screen } from '@testing-library/react';
+import { MockedResponse } from '@apollo/client/testing';
 
 import EditProfileModal from '../EditProfileModal';
 import { MyProfile } from '../../types/ProfileQueryTypes';
@@ -12,6 +12,8 @@ import {
   waitFor,
 } from '../../../../common/test/testingLibraryUtils';
 import initModal from '../../../../common/test/initModal';
+import { languagesQueryResponse } from '../../../app/footer/__mocks__/languagesMock';
+import { languagesQuery } from '../../../languages/queries/LanguageQueries';
 
 const initialValues: MyProfile = {
   id: 'yuiop',
@@ -40,6 +42,16 @@ const formData = {
   firstName: 'George',
   lastName: 'Lopez',
 };
+
+const languagesMock: MockedResponse = {
+  request: {
+    query: languagesQuery,
+    variables: {},
+  },
+  result: { ...languagesQueryResponse },
+};
+
+const mocks: MockedResponse[] = [languagesMock];
 
 const getHdsSelect = (elements: HTMLElement[]) => {
   return elements[0].parentElement;
@@ -74,20 +86,19 @@ const selectOption = (
 it('renders snapshot correctly', () => {
   initModal();
   const { container } = render(
-    <MockedProvider>
-      <EditProfileModal
-        initialValues={initialValues}
-        isOpen={true}
-        setIsOpen={vi.fn()}
-      />
-    </MockedProvider>
+    <EditProfileModal
+      initialValues={initialValues}
+      isOpen={true}
+      setIsOpen={vi.fn()}
+    />,
+    mocks
   );
   expect(container).toMatchSnapshot();
 });
 
 it('should allow all fields to be filled', async () => {
   initModal();
-  render(<EditProfileModal {...defaultProps} />);
+  render(<EditProfileModal {...defaultProps} />, mocks);
 
   fireEvent.change(screen.getByRole('textbox', { name: 'Puhelinnumero *' }), {
     target: { value: formData.phoneNumber },

--- a/src/domain/registration/form/RegistrationForm.tsx
+++ b/src/domain/registration/form/RegistrationForm.tsx
@@ -405,40 +405,38 @@ const RegistrationForm = () => {
                       'registration.form.guardian.hasAcceptedCommunication.input.label'
                     )}
                   />
-                  <CheckboxField
-                    className={styles.agreeBtn}
-                    type="checkbox"
-                    id="agree"
-                    name="agree"
-                    required={true}
-                    label={
-                      <>
-                        <Trans
-                          i18nKey="registration.form.agree.input.label"
-                          components={[
-                            // These components receive content in the
-                            // translation definition.
-                            // eslint-disable-next-line jsx-a11y/anchor-has-content
-                            <a
-                              href={t('descriptionOfTheFile.url')}
-                              key="agree.descriptionOfTheFile.url"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            />,
-                            // eslint-disable-next-line jsx-a11y/anchor-has-content
-                            <a
-                              href={t('dataProtection.url')}
-                              key="agree.dataProtection.url"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            />,
-                          ]}
-                        />
-                        <span className={styles.required}>&nbsp;*</span>
-                      </>
-                    }
-                  />
-
+                  <div className={styles.agreeContainer}>
+                    <CheckboxField
+                      className={styles.agreeBtn}
+                      type="checkbox"
+                      id="agree"
+                      name="agree"
+                      required={true}
+                      aria-label={t('registration.form.agree.input.label')}
+                    />
+                    <div className={styles.agreeLabel}>
+                      <Trans
+                        i18nKey="registration.form.agree.input.label"
+                        components={[
+                          <a
+                            href={t('descriptionOfTheFile.url')}
+                            key="agree.descriptionOfTheFile.url"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title={t('descriptionOfTheFile.title')}
+                          />,
+                          <a
+                            href={t('dataProtection.url')}
+                            key="agree.dataProtection.url"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title={t('dataProtection.title')}
+                          />,
+                        ]}
+                      />
+                      <span className={styles.required}>&nbsp;*</span>
+                    </div>
+                  </div>
                   <Button
                     type="submit"
                     className={styles.submitButton}

--- a/src/domain/registration/form/__tests__/RegistrationForm.test.tsx
+++ b/src/domain/registration/form/__tests__/RegistrationForm.test.tsx
@@ -1,24 +1,52 @@
+import { MockedResponse } from '@apollo/client/testing';
+
 import RegistrationForm, {
   EMAIL_FIELD_TESTID,
   FORM_TESTID,
 } from '../RegistrationForm';
 import { render, screen } from '../../../../common/test/testingLibraryUtils';
+import { languagesQuery } from '../../../languages/queries/LanguageQueries';
+import { languagesQueryResponse } from '../../../app/footer/__mocks__/languagesMock';
+import profileQuery from '../../../profile/queries/ProfileQuery';
 
-// TODO: Needs mocks for profile query and redux selector.
-it.skip('renders snapshot correctly', async () => {
-  const { container } = render(<RegistrationForm />);
+const emptyProfileMock: MockedResponse = {
+  request: {
+    query: profileQuery,
+    variables: {},
+  },
+  result: {
+    data: { myProfile: null },
+  },
+};
+
+const languagesMock: MockedResponse = {
+  request: {
+    query: languagesQuery,
+    variables: {},
+  },
+  result: { ...languagesQueryResponse },
+};
+
+const mocks: MockedResponse[] = [emptyProfileMock, languagesMock];
+
+function renderRegistrationForm(props = {}) {
+  return render(<RegistrationForm {...props} />, mocks);
+}
+
+it('renders snapshot correctly', async () => {
+  const { container } = renderRegistrationForm();
   await screen.findByTestId(FORM_TESTID);
   expect(container).toMatchSnapshot();
 });
 
 it('email field is disabled', async () => {
-  render(<RegistrationForm />);
+  renderRegistrationForm();
   const emailField = await screen.findByTestId(EMAIL_FIELD_TESTID);
   expect(emailField).toBeDisabled();
 });
 
 it('hasAcceptedCommunication is checked by default', async () => {
-  render(<RegistrationForm />);
+  renderRegistrationForm();
   const hasAcceptedCommunicationCheckbox = await screen.findByRole('checkbox', {
     name: 'Haluan viestejä uusista kummitapahtumista',
   });

--- a/src/domain/registration/form/__tests__/__snapshots__/RegistrationForm.test.tsx.snap
+++ b/src/domain/registration/form/__tests__/__snapshots__/RegistrationForm.test.tsx.snap
@@ -1,52 +1,622 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`renders snapshot correctly 1`] = `
-<Provider
-  store={
-    Object {
-      "dispatch": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-      Symbol(observable): [Function],
-    }
-  }
->
-  <MockedProvider
-    addTypename={false}
+<div>
+  <div
+    class="_pageWrapper_e42bcd _grayBackground_72244b"
   >
-    <HelmetProvider
-      context={Object {}}
+    <div
+      class="_container_533ff0"
     >
-      <Router
-        history={
-          Object {
-            "action": "POP",
-            "block": [Function],
-            "createHref": [Function],
-            "go": [Function],
-            "goBack": [Function],
-            "goForward": [Function],
-            "length": 1,
-            "listen": [Function],
-            "location": Object {
-              "hash": "",
-              "pathname": "/",
-              "search": "",
-              "state": undefined,
-            },
-            "push": [Function],
-            "replace": [Function],
-          }
-        }
+      <div
+        class="_registrationFormContainer_72244b"
       >
-        <MockedProvider
-          addTypename={true}
+        <div
+          class="_registrationForm_72244b"
         >
-          <RegistrationForm />
-        </MockedProvider>
-      </Router>
-    </HelmetProvider>
-  </MockedProvider>
-</Provider>
+          <form
+            data-testid="registrationForm"
+            id="registrationForm"
+          >
+            <div
+              class="_registrationGrayContainer_72244b"
+            >
+              <h1>
+                Tule mukaan
+              </h1>
+            </div>
+            <div
+              class="_childrenInfo_72244b _registrationWhiteContainer_72244b"
+            >
+              <div
+                class="_childFields_284205"
+              >
+                <div
+                  class="_childInfo_284205"
+                >
+                  <div
+                    class="_heading_284205"
+                  >
+                    <div
+                      class="_imgWrapper_73ff55 _childImage_284205"
+                    >
+                      <img
+                        alt=""
+                        src="/icons/svg/childFaceHappy.svg"
+                      />
+                    </div>
+                    <h2>
+                      Lapsen tiedot
+                    </h2>
+                    <p
+                      class="_right_8fd5d0"
+                      data-testid="mandatory-field-legend"
+                    >
+                      <span
+                        class="_bold_8fd5d0"
+                      >
+                        *
+                      </span>
+                      <span>
+                         
+                        tarkoittaa pakollista kenttää
+                      </span>
+                    </p>
+                  </div>
+                  <div
+                    class="_childFixedInfo_284205"
+                  >
+                    <div
+                      class="_childBirthyear_284205"
+                    >
+                      <label>
+                        Lapsen syntymävuosi
+                      </label>
+                      <p>
+                        2024
+                      </p>
+                    </div>
+                    <div
+                      class="_childHomeCity_284205"
+                    >
+                      <label>
+                        Lapsen kotipaikkakunta
+                      </label>
+                      <p />
+                    </div>
+                  </div>
+                  <div
+                    class="_childName_284205"
+                  >
+                    <div>
+                      <div
+                        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                      >
+                        <label
+                          class="FieldLabel-module_label__1zrXK "
+                          for="children[0].name"
+                        >
+                          Lapsen nimi
+                        </label>
+                        <div
+                          class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                        >
+                          <input
+                            autocomplete="new-password"
+                            class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                            id="children[0].name"
+                            name="children[0].name"
+                            placeholder="Lisää lapsen nimi"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                    >
+                      <label
+                        class="FieldLabel-module_label__1zrXK "
+                        for="children[0].postalCode"
+                      >
+                        Postinumero
+                        <span
+                          class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                        >
+                          *
+                        </span>
+                      </label>
+                      <div
+                        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                      >
+                        <input
+                          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                          id="children[0].postalCode"
+                          name="children[0].postalCode"
+                          placeholder="Lisää postinumero"
+                          required=""
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="Select-module_root__Ka5uO _formField_b4a938"
+                  >
+                    <label
+                      class="FieldLabel-module_label__1zrXK "
+                      for="children[0].relationship.type-toggle-button"
+                      id="children[0].relationship.type-label"
+                    >
+                      Ilmoittajan suhde lapseen
+                      <span
+                        class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                      >
+                        *
+                      </span>
+                    </label>
+                    <div
+                      class="Select-module_wrapper__1WQXs"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-labelledby="children[0].relationship.type-label children[0].relationship.type-toggle-button"
+                        aria-owns="children[0].relationship.type-menu"
+                        class="Select-module_button__1aIsm"
+                        id="children[0].relationship.type-toggle-button"
+                        type="button"
+                      >
+                        <span
+                          class="Select-module_buttonLabel__1fqu5"
+                        >
+                          Valitse
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Select-module_angleIcon__2-9AD"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                      <ul
+                        aria-labelledby="children[0].relationship.type-label"
+                        aria-required="true"
+                        class="Select-module_menu__1H2aU"
+                        id="children[0].relationship.type-menu"
+                        role="listbox"
+                        style="max-height: 260px;"
+                        tabindex="-1"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="_registrationGrayContainer_72244b"
+            >
+              <button
+                aria-label="Lisää lapsi"
+                class="Button-module_button__1msFE button_hds-button__2A0je Button-module_primary__2LfKB button_hds-button--primary__2NVvO _addNewChildButton_72244b"
+                style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
+                type="button"
+              >
+                <div
+                  aria-hidden="true"
+                  class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="plus-circle"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM13 7V11H17V13H13V17H11V13H7V11H11V7H13Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <span
+                  class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                >
+                  Lisää lapsi
+                </span>
+              </button>
+            </div>
+            <div
+              class="_guardianInfo_72244b _registrationWhiteContainer_72244b"
+            >
+              <div
+                class="_heading_72244b"
+              >
+                <div
+                  class="_imgWrapper_73ff55 _childImage_72244b"
+                >
+                  <img
+                    alt=""
+                    src="/icons/svg/adultFaceHappy.svg"
+                  />
+                </div>
+                <h2>
+                  Lähiaikuisen tiedot
+                </h2>
+                <p
+                  class="_right_8fd5d0"
+                  data-testid="mandatory-field-legend"
+                >
+                  <span
+                    class="_bold_8fd5d0"
+                  >
+                    *
+                  </span>
+                  <span>
+                     
+                    tarkoittaa pakollista kenttää
+                  </span>
+                </p>
+              </div>
+              <div>
+                <div
+                  class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                >
+                  <label
+                    class="FieldLabel-module_label__1zrXK "
+                    for="guardian.email"
+                  >
+                    Sähköpostiosoite
+                    <span
+                      class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                    >
+                      *
+                    </span>
+                  </label>
+                  <div
+                    class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                  >
+                    <input
+                      class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                      data-testid="guardian.email"
+                      disabled=""
+                      id="guardian.email"
+                      name="guardian.email"
+                      placeholder="Lisää sähköpostiosoite"
+                      required=""
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                >
+                  <label
+                    class="FieldLabel-module_label__1zrXK "
+                    for="guardian.phoneNumber"
+                  >
+                    Puhelinnumero
+                    <span
+                      class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                    >
+                      *
+                    </span>
+                  </label>
+                  <div
+                    class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                  >
+                    <input
+                      class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                      id="guardian.phoneNumber"
+                      name="guardian.phoneNumber"
+                      placeholder="Lisää puhelinnumero"
+                      required=""
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="_guardianName_72244b"
+              >
+                <div>
+                  <div
+                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                  >
+                    <label
+                      class="FieldLabel-module_label__1zrXK "
+                      for="guardian.firstName"
+                    >
+                      Etunimi
+                      <span
+                        class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                      >
+                        *
+                      </span>
+                    </label>
+                    <div
+                      class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                    >
+                      <input
+                        class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                        id="guardian.firstName"
+                        name="guardian.firstName"
+                        placeholder="Lisää etunimi"
+                        required=""
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                  >
+                    <label
+                      class="FieldLabel-module_label__1zrXK "
+                      for="guardian.lastName"
+                    >
+                      Sukunimi
+                      <span
+                        class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                      >
+                        *
+                      </span>
+                    </label>
+                    <div
+                      class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+                    >
+                      <input
+                        class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                        id="guardian.lastName"
+                        name="guardian.lastName"
+                        placeholder="Lisää sukunimi"
+                        required=""
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="Select-module_root__Ka5uO _formField_b4a938"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="preferLanguage-toggle-button"
+                  id="preferLanguage-label"
+                >
+                  Asiointikieli
+                  <span
+                    class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
+                  >
+                    *
+                  </span>
+                </label>
+                <div
+                  class="Select-module_wrapper__1WQXs"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-labelledby="preferLanguage-label preferLanguage-toggle-button"
+                    aria-owns="preferLanguage-menu"
+                    class="Select-module_button__1aIsm"
+                    id="preferLanguage-toggle-button"
+                    type="button"
+                  >
+                    <span
+                      class="Select-module_buttonLabel__1fqu5"
+                    >
+                      Suomi
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="angle-down"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Select-module_angleIcon__2-9AD"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                  <ul
+                    aria-labelledby="preferLanguage-label"
+                    aria-required="true"
+                    class="Select-module_menu__1H2aU"
+                    id="preferLanguage-menu"
+                    role="listbox"
+                    style="max-height: 260px;"
+                    tabindex="-1"
+                  />
+                </div>
+              </div>
+              <div
+                class="Combobox-module_root__Hs8Hg Combobox-module_multiselect__3vNbJ _formField_b4a938"
+              >
+                <label
+                  class="FieldLabel-module_label__1zrXK "
+                  for="languagesSpokenAtHome-input"
+                  id="languagesSpokenAtHome-label"
+                >
+                  Kotona puhutut kielet
+                </label>
+                <div
+                  class="Combobox-module_wrapper__3kVTg"
+                >
+                  <input
+                    aria-autocomplete="list"
+                    aria-controls="languagesSpokenAtHome-menu"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-labelledby="languagesSpokenAtHome-label languagesSpokenAtHome-helper languagesSpokenAtHome-input"
+                    aria-owns="languagesSpokenAtHome-menu"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="Combobox-module_input__Dcmdn"
+                    id="languagesSpokenAtHome-input"
+                    role="combobox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-expanded="false"
+                    aria-label="Kotona puhutut kielet: Avaa valikko"
+                    class="Combobox-module_button__1W9PN"
+                    id="languagesSpokenAtHome-toggle-button"
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label="angle-down"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Combobox-module_angleIcon__10DvA"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                  <ul
+                    aria-labelledby="languagesSpokenAtHome-label"
+                    aria-multiselectable="true"
+                    class="Combobox-module_menu__3jA0e"
+                    id="languagesSpokenAtHome-menu"
+                    role="listbox"
+                    style="max-height: 260px;"
+                  />
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="Combobox-module_helperText__1qPYf"
+                  id="languagesSpokenAtHome-helper"
+                >
+                  Mitä kieltä tai kieliä puhutte kotona? Jos kieli ei ole listassa, valitse “muu kieli”.
+                </div>
+              </div>
+              <div>
+                <div
+                  class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz _checkboxField_639ec5"
+                  style="--background-hover: var(--color-summer-dark); --background-selected: var(--color-summer); --background-color-selected-hover: var(--color-summer-dark); --background-color-selected-focus: var(--color-summer-dark); --background-color-selected-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer-dark); --border-color-selected-hover-focus: var(--color-summer-dark); --icon-color-selected: var(--color-black);"
+                >
+                  <input
+                    checked=""
+                    class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+                    id="guardian.hasAcceptedCommunication"
+                    name="guardian.hasAcceptedCommunication"
+                    type="checkbox"
+                    value="true"
+                  />
+                  <label
+                    class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+                    for="guardian.hasAcceptedCommunication"
+                  >
+                    Haluan viestejä uusista kummitapahtumista
+                  </label>
+                </div>
+              </div>
+              <div
+                class="_agreeContainer_72244b"
+              >
+                <div>
+                  <div
+                    class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz _checkboxField_639ec5"
+                    style="--background-hover: var(--color-summer-dark); --background-selected: var(--color-summer); --background-color-selected-hover: var(--color-summer-dark); --background-color-selected-focus: var(--color-summer-dark); --background-color-selected-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer-dark); --border-color-selected-hover-focus: var(--color-summer-dark); --icon-color-selected: var(--color-black);"
+                  >
+                    <input
+                      aria-label="Olen tutustunut <0>tämän palvelun rekisteriselosteeseen</0> ja <1>kaupungin tietosuojakäytäntöön</1>. Minuun voidaan olla yhteydessä antamieni tietojen avulla."
+                      class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+                      id="agree"
+                      name="agree"
+                      required=""
+                      type="checkbox"
+                      value="false"
+                    />
+                    <label
+                      class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3 Checkbox-module_noLabel__2wGzf checkbox_hds-checkbox__label--hidden__3zwtj"
+                      for="agree"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="_agreeLabel_72244b"
+                >
+                  Olen tutustunut 
+                  <a
+                    href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Kulttuurin%20kummilapset%20-kummiperherekisteri.pdf"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    title="Rekisteriseloste"
+                  >
+                    tämän palvelun rekisteriselosteeseen
+                  </a>
+                   ja 
+                  <a
+                    href="https://www.hel.fi/fi/paatoksenteko-ja-hallinto/tietoa-helsingista/tietosuoja-ja-tiedonhallinta/tietosuoja"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    title="Tietosuoja"
+                  >
+                    kaupungin tietosuojakäytäntöön
+                  </a>
+                  . Minuun voidaan olla yhteydessä antamieni tietojen avulla.
+                  <span
+                    class="_required_72244b"
+                  >
+                     *
+                  </span>
+                </div>
+              </div>
+              <button
+                class="Button-module_button__1msFE button_hds-button__2A0je Button-module_primary__2LfKB button_hds-button--primary__2NVvO _submitButton_72244b"
+                style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
+                type="submit"
+              >
+                <span
+                  class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                >
+                  Ilmoittaudu mukaan
+                </span>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;

--- a/src/domain/registration/form/registrationForm.module.scss
+++ b/src/domain/registration/form/registrationForm.module.scss
@@ -81,3 +81,12 @@ $plusIconHeight: 2rem;
 .required {
   font-weight: bold;
 }
+
+.agreeContainer {
+  display: flex;
+  align-items: center;
+}
+
+.agreeLabel {
+  margin-left: -3px;
+}

--- a/tests/vitest-setup.ts
+++ b/tests/vitest-setup.ts
@@ -30,6 +30,11 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }));
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mockScrollTo = vi.fn((x?: number | ScrollToOptions, y?: number) => {});
+
+window.scrollTo = mockScrollTo;
+
 beforeAll(() => {
   setLocale('fi');
   server.listen();

--- a/tests/vitest-setup.ts
+++ b/tests/vitest-setup.ts
@@ -3,10 +3,15 @@
 require('dotenv').config({ path: './.env.test' });
 import { beforeAll, afterEach, afterAll, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
+import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev';
 
 import setLocale from '../src/common/localization/setLocale';
 import { server } from '../src/test/msw/server';
 import '../src/common/test/testi18nInit';
+
+// Load error messages for Apollo client so it's easier to debug errors
+loadDevMessages();
+loadErrorMessages();
 
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),

--- a/tests/vitest-setup.ts
+++ b/tests/vitest-setup.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import/first */
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 require('dotenv').config({ path: './.env.test' });
+
+import Modal from 'react-modal';
 import { beforeAll, afterEach, afterAll, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev';
@@ -12,6 +14,15 @@ import '../src/common/test/testi18nInit';
 // Load error messages for Apollo client so it's easier to debug errors
 loadDevMessages();
 loadErrorMessages();
+
+// Set an appElement for react-modal for tests. For production it is set in
+// src/index.tsx. Otherwise react-modal raises warning:
+//
+// "Warning: react-modal: App element is not defined. Please use
+// `Modal.setAppElement(el)` or set `appElement={el}`. This is needed so screen
+// readers don't see main content when modal is opened. It is not recommended,
+// but you can opt-out by setting `ariaHideApp={false}`."
+Modal.setAppElement(document.createElement('div'));
 
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),


### PR DESCRIPTION
## Description

Handle most warnings from running tests.

Two deprecation warning categories from react are not fixed:
 - From react because of hds-react package's use:
   - Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
 - From CSSTransition component in react-transition-group package related to toast animation:
   - findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node
   - https://18.react.dev/reference/react-dom/findDOMNode

<details>

<summary>Test warnings before this PR (Click to expand)</summary>

```
$ yarn test
yarn run v1.22.22
$ cross-env TZ=Europe/Helsinki vitest run

 RUN  v2.1.7 C:/dev/projects/City-of-Helsinki/kukkuu-ui

stderr | src/domain/profile/events/__tests__/ProfileEvents.test.tsx > Renders events list when events of any type
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":""}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/events/__tests__/ProfileEvents.test.tsx > Renders events list when only upcomingEventsAndEventGroups
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":""}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/events/__tests__/ProfileEvents.test.tsx > Renders events list when only enrolments
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":""}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/events/__tests__/ProfileEvents.test.tsx > Renders events list when only past events
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":""}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/event/__tests__/EventOccurrenceList.test.tsx > renders snapshot correctly
Warning: Encountered two children with the same key, `T2NjdXJyZW5jZU5vZGU6Mg==`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
    at tbody
    at table
    at EventOccurrenceList (kukkuu-ui\src\domain\event\EventOccurrenceList.tsx:9:32)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stderr | src/domain/event/__tests__/EventOccurrence.test.tsx > renders snapshot correctly
Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, occurrence: ...};
  <EventOccurrence {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {occurrence: ...};
  <EventOccurrence key={someKey} {...props} />

stderr | src/domain/event/enrol/__tests__/Enrol.test.tsx > <Enrol /> > when the event is full > the user should be able to subscribe to notifications
No more mocked responses for the query: mutation subscribeToFreeSpotNotificationMutation($input: SubscribeToFreeSpotNotificationMutationInput!) {
  subscribeToFreeSpotNotification(input: $input) {
    clientMutationId
    __typename
  }
}
Expected variables: {"input":{"occurrenceId":"T2NjdXJyZW5jZU5vZGU6Mg==","childId":"123"}}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/event/enrol/__tests__/Enrol.test.tsx > <Enrol /> > when the event is full and te user has subscribed > the user should be able to unsubscribe
No more mocked responses for the query: mutation unsubscribeFromFreeSpotNotificationMutation($input: UnsubscribeFromFreeSpotNotificationMutationInput!) {
  unsubscribeFromFreeSpotNotification(input: $input) {
    clientMutationId
    __typename
  }
}
Expected variables: {"input":{"childId":"123","occurrenceId":"T2NjdXJyZW5jZU5vZGU6Mg=="}}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/events/__tests__/ProfileEventsList.test.tsx > Renders snapshot correctly
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":"zzaf"}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/events/__tests__/ProfileEventsList.test.tsx > Renders only upcoming events and event groups when no other inputs
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":"zzaf"}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/events/__tests__/ProfileEventsList.test.tsx > Renders only enrolments when no other inputs
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":"zzaf"}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/events/__tests__/ProfileEventsList.test.tsx > Renders Ticketmaster enrolment
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":"zzaf"}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/events/__tests__/ProfileEventsList.test.tsx > Renders Lippupiste enrolment
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":"zzaf"}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/events/__tests__/ProfileEventsList.test.tsx > Renders Tixly enrolment
No more mocked responses for the query: query ChildEnrolmentCount($childId: ID!) {
  child(id: $childId) {
    id
    enrolmentCount
    pastEnrolmentCount
    project {
      id
      enrolmentLimit
      __typename
    }
    __typename
  }
}
Expected variables: {"childId":"zzaf"}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/modal/__tests__/EditProfileModal.test.tsx > renders snapshot correctly
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at form
    at kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1413:22
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at EditMyProfileForm (kukkuu-ui\src\domain\profile\modal\EditMyProfileForm.tsx:54:30)
    at div
    at div
    at div
    at div
    at ModalPortal (kukkuu-ui\node_modules\react-modal\lib\components\ModalPortal.js:79:5)
    at Modal (kukkuu-ui\node_modules\react-modal\lib\components\Modal.js:73:5)
    at div
    at Modal (kukkuu-ui\src\common\components\modal\Modal.tsx:23:18)
    at div
    at EditProfileModal (kukkuu-ui\src\domain\profile\modal\EditProfileModal.tsx:19:29)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: Mi: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Mi (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:346609)
    at Combobox (kukkuu-ui\src\common\components\formikWrappers\Combobox.tsx:11:21)
    at LanguagesCombobox (kukkuu-ui\src\domain\languages\LanguagesCombobox.tsx:10:56)
    at form
    at kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1413:22
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at EditMyProfileForm (kukkuu-ui\src\domain\profile\modal\EditMyProfileForm.tsx:54:30)
    at div
    at div
    at div
    at div
    at ModalPortal (kukkuu-ui\node_modules\react-modal\lib\components\ModalPortal.js:79:5)
    at Modal (kukkuu-ui\node_modules\react-modal\lib\components\Modal.js:73:5)
    at div
    at Modal (kukkuu-ui\src\common\components\modal\Modal.tsx:23:18)
    at div
    at EditProfileModal (kukkuu-ui\src\domain\profile\modal\EditProfileModal.tsx:19:29)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
No more mocked responses for the query: fragment LanguageFields on LanguageNode {
  id
  name
  __typename
}

fragment LanguagesFields on LanguageNodeConnection {
  edges {
    node {
      ...LanguageFields
      __typename
    }
    __typename
  }
  __typename
}

query languageQuery {
  languages {
    ...LanguagesFields
    __typename
  }
}
Expected variables: {}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/profile/modal/__tests__/EditProfileModal.test.tsx > should allow all fields to be filled
No more mocked responses for the query: fragment LanguageFields on LanguageNode {
  id
  name
  __typename
}

fragment LanguagesFields on LanguageNodeConnection {
  edges {
    node {
      ...LanguageFields
      __typename
    }
    __typename
  }
  __typename
}

query languageQuery {
  languages {
    ...LanguagesFields
    __typename
  }
}
Expected variables: {}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stdout | src/domain/profile/__tests__/Profile.test.tsx > Profile > redirects to the register section in home page if user is authenticated but has no profile
Using a loading spinner to wait for profile to be added in the context.
User has logged in, but not created a profile. Send them to front page for registration.

stderr | src/domain/child/form/__tests__/ChildForm.test.tsx > <ChildForm /> > as a user I do not want to see the city control when editing
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at form
    at kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1413:22
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at ChildForm (kukkuu-ui\src\domain\child\form\ChildForm.tsx:43:22)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stderr | src/common/components/formikWrappers/__tests__/FormikDropdown.test.tsx > renders snapshot correctly
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at Dropdown
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at TestForm

stderr | src/domain/registration/form/__tests__/RegistrationForm.test.tsx > email field is disabled
No more mocked responses for the query: fragment MyProfileEnrolmentFields on EnrolmentNode {
  id
  occurrence {
    id
    time
    venue {
      id
      name
      __typename
    }
    event {
      id
      name
      duration
      __typename
    }
    __typename
  }
  __typename
}

fragment MyProfileEnrolmentsFields on EnrolmentNodeConnection {
  edges {
    node {
      ...MyProfileEnrolmentFields
      __typename
    }
    __typename
  }
  __typename
}

fragment MyProfileChildProjectFields on ProjectNode {
  id
  name
  year
  __typename
}

fragment MyProfileChildFields on ChildNode {
  id
  name
  birthyear
  postalCode
  project {
    ...MyProfileChildProjectFields
    __typename
  }
  relationships {
    edges {
      node {
        id
        type
        __typename
      }
      __typename
    }
    __typename
  }
  upcomingEventsAndEventGroups {
    edges {
      node {
        ... on EventGroupNode {
          id
          name
          __typename
        }
        ... on EventNode {
          id
          name
          duration
          participantsPerInvite
          __typename
        }
        __typename
      }
      __typename
    }
    __typename
  }
  occurrences {
    edges {
      node {
        id
        event {
          id
          name
          shortDescription
          __typename
        }
        __typename
      }
      __typename
    }
    __typename
  }
  enrolments {
    ...MyProfileEnrolmentsFields
    __typename
  }
  __typename
}

fragment MyProfileChildrenFields on ChildNodeConnection {
  edges {
    node {
      ...MyProfileChildFields
      __typename
    }
    __typename
  }
  __typename
}

fragment LanguageSpokenAtHomeFields on LanguageNode {
  id
  __typename
}

fragment LanguagesSpokenAtHomeFields on LanguageNodeConnection {
  edges {
    node {
      ...LanguageSpokenAtHomeFields
      __typename
    }
    __typename
  }
  __typename
}

fragment MyProfileFields on GuardianNode {
  id
  firstName
  lastName
  email
  phoneNumber
  language
  hasAcceptedCommunication
  children {
    ...MyProfileChildrenFields
    __typename
  }
  languagesSpokenAtHome {
    ...LanguagesSpokenAtHomeFields
    __typename
  }
  __typename
}

query profileQuery {
  myProfile {
    ...MyProfileFields
    __typename
  }
}
Expected variables: {}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/app/footer/__tests__/Footer.test.tsx > Footer matches snapshot
Warning: Hl: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Hl (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:396245)
    at div
    at div
    at Jl.Base (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:405206)
    at div
    at div
    at footer
    at Jl (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:403879)
    at Footer (kukkuu-ui\src\domain\app\footer\Footer.tsx:19:47)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stdout | src/domain/registration/form/__tests__/RegistrationForm.test.tsx > email field is disabled
ProfileContext profile cleared

stderr | src/domain/registration/form/__tests__/RegistrationForm.test.tsx > email field is disabled
Warning: Cannot update a component (`ProfileProvider`) while rendering a different component (`RegistrationForm`). To locate the bad setState() call inside `RegistrationForm`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
    at RegistrationForm (kukkuu-ui\src\domain\registration\form\RegistrationForm.tsx:106:47)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at div
    at div
    at ChildFormFields (kukkuu-ui\src\domain\registration\form\partial\childFormFields.tsx:25:28)
    at FieldArrayInner (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1608:30)
    at FormikConnect(FieldArrayInner)
    at div
    at form
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at div
    at div
    at div
    at Container (kukkuu-ui\src\domain\app\layout\Container.tsx:9:22)
    at div
    at PageWrapper (kukkuu-ui\src\domain\app\layout\PageWrapper.tsx:11:24)
    at RegistrationForm (kukkuu-ui\src\domain\registration\form\RegistrationForm.tsx:106:47)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: Mi: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Mi (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:346609)
    at Combobox (kukkuu-ui\src\common\components\formikWrappers\Combobox.tsx:11:21)
    at LanguagesCombobox (kukkuu-ui\src\domain\languages\LanguagesCombobox.tsx:10:56)
    at div
    at form
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at div
    at div
    at div
    at Container (kukkuu-ui\src\domain\app\layout\Container.tsx:9:22)
    at div
    at PageWrapper (kukkuu-ui\src\domain\app\layout\PageWrapper.tsx:11:24)
    at RegistrationForm (kukkuu-ui\src\domain\registration\form\RegistrationForm.tsx:106:47)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Using ReactElement as a label is against good usability and accessibility practices. Please prefer plain strings.
No more mocked responses for the query: fragment LanguageFields on LanguageNode {
  id
  name
  __typename
}

fragment LanguagesFields on LanguageNodeConnection {
  edges {
    node {
      ...LanguageFields
      __typename
    }
    __typename
  }
  __typename
}

query languageQuery {
  languages {
    ...LanguagesFields
    __typename
  }
}
Expected variables: {}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stdout | src/domain/registration/form/__tests__/RegistrationForm.test.tsx > email field is disabled
ProfileContext profile cleared

stderr | src/domain/registration/form/__tests__/RegistrationForm.test.tsx > hasAcceptedCommunication is checked by default
No more mocked responses for the query: fragment MyProfileEnrolmentFields on EnrolmentNode {
  id
  occurrence {
    id
    time
    venue {
      id
      name
      __typename
    }
    event {
      id
      name
      duration
      __typename
    }
    __typename
  }
  __typename
}

fragment MyProfileEnrolmentsFields on EnrolmentNodeConnection {
  edges {
    node {
      ...MyProfileEnrolmentFields
      __typename
    }
    __typename
  }
  __typename
}

fragment MyProfileChildProjectFields on ProjectNode {
  id
  name
  year
  __typename
}

fragment MyProfileChildFields on ChildNode {
  id
  name
  birthyear
  postalCode
  project {
    ...MyProfileChildProjectFields
    __typename
  }
  relationships {
    edges {
      node {
        id
        type
        __typename
      }
      __typename
    }
    __typename
  }
  upcomingEventsAndEventGroups {
    edges {
      node {
        ... on EventGroupNode {
          id
          name
          __typename
        }
        ... on EventNode {
          id
          name
          duration
          participantsPerInvite
          __typename
        }
        __typename
      }
      __typename
    }
    __typename
  }
  occurrences {
    edges {
      node {
        id
        event {
          id
          name
          shortDescription
          __typename
        }
        __typename
      }
      __typename
    }
    __typename
  }
  enrolments {
    ...MyProfileEnrolmentsFields
    __typename
  }
  __typename
}

fragment MyProfileChildrenFields on ChildNodeConnection {
  edges {
    node {
      ...MyProfileChildFields
      __typename
    }
    __typename
  }
  __typename
}

fragment LanguageSpokenAtHomeFields on LanguageNode {
  id
  __typename
}

fragment LanguagesSpokenAtHomeFields on LanguageNodeConnection {
  edges {
    node {
      ...LanguageSpokenAtHomeFields
      __typename
    }
    __typename
  }
  __typename
}

fragment MyProfileFields on GuardianNode {
  id
  firstName
  lastName
  email
  phoneNumber
  language
  hasAcceptedCommunication
  children {
    ...MyProfileChildrenFields
    __typename
  }
  languagesSpokenAtHome {
    ...LanguagesSpokenAtHomeFields
    __typename
  }
  __typename
}

query profileQuery {
  myProfile {
    ...MyProfileFields
    __typename
  }
}
Expected variables: {}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stdout | src/domain/registration/form/__tests__/RegistrationForm.test.tsx > hasAcceptedCommunication is checked by default
ProfileContext profile cleared

stderr | src/domain/registration/form/__tests__/RegistrationForm.test.tsx > hasAcceptedCommunication is checked by default
Using ReactElement as a label is against good usability and accessibility practices. Please prefer plain strings.
No more mocked responses for the query: fragment LanguageFields on LanguageNode {
  id
  name
  __typename
}

fragment LanguagesFields on LanguageNodeConnection {
  edges {
    node {
      ...LanguageFields
      __typename
    }
    __typename
  }
  __typename
}

query languageQuery {
  languages {
    ...LanguagesFields
    __typename
  }
}
Expected variables: {}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

stderr | src/domain/event/enrol/__tests__/SuccessToast.test.tsx > renders snapshot correctly
Warning: findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node
    at Transition (kukkuu-ui\node_modules\react-transition-group\cjs\Transition.js:135:30)
    at CSSTransition (kukkuu-ui\node_modules\react-transition-group\cjs\CSSTransition.js:120:35)
    at SuccessToast (kukkuu-ui\src\domain\event\enrol\SuccessToast.tsx:24:41)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stderr | src/domain/registration/modal/__tests__/AddNewChildFormModal.test.tsx > renders snapshot correctly
Warning: react-modal: App element is not defined. Please use `Modal.setAppElement(el)` or set `appElement={el}`. This is needed so screen readers don't see main content when modal is opened. It is not recommended, but you can opt-out by setting `ariaHideApp={false}`.
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at form
    at kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1413:22
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at ChildForm (kukkuu-ui\src\domain\child\form\ChildForm.tsx:43:22)
    at div
    at div
    at div
    at div
    at ModalPortal (kukkuu-ui\node_modules\react-modal\lib\components\ModalPortal.js:79:5)
    at Modal (kukkuu-ui\node_modules\react-modal\lib\components\Modal.js:73:5)
    at div
    at Modal (kukkuu-ui\src\common\components\modal\Modal.tsx:23:18)
    at div
    at ChildFormModal (kukkuu-ui\src\domain\child\modal\ChildFormModal.tsx:19:27)
    at AddNewChildFormModal (kukkuu-ui\src\domain\registration\modal\AddNewChildFormModal.tsx:21:33)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: react-modal: App element is not defined. Please use `Modal.setAppElement(el)` or set `appElement={el}`. This is needed so screen readers don't see main content when modal is opened. It is not recommended, but you can opt-out by setting `ariaHideApp={false}`.

stderr | src/domain/app/__tests__/Layout.test.tsx > renders without crashing
Warning: Ts: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Ts (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:447987)
    at rs (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:427855)
    at Cu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:521338)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-_WdvQ3fd.js:18991:19)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\apollo.js:60:23)
    at Navigation (kukkuu-ui\src\domain\app\navigation\Navigation.tsx:27:44)
    at div
    at div
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at PageLayout (kukkuu-ui\src\domain\app\layout\PageLayout.tsx:19:23)
    at Layout (kukkuu-ui\src\domain\app\Layout.tsx:16:34)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: bd: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at bd (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:470570)
    at div
    at header
    at wu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:520910)
    at Ts (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:447987)
    at rs (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:427855)
    at Cu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:521338)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-_WdvQ3fd.js:18991:19)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\apollo.js:60:23)
    at Navigation (kukkuu-ui\src\domain\app\navigation\Navigation.tsx:27:44)
    at div
    at div
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at PageLayout (kukkuu-ui\src\domain\app\layout\PageLayout.tsx:19:23)
    at Layout (kukkuu-ui\src\domain\app\Layout.tsx:16:34)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: Ws: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Ws (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:460806)
    at UserNavigation (kukkuu-ui\src\domain\app\navigation\UserNavigation.tsx:32:41)
    at div
    at div
    at div
    at bd (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:470570)
    at div
    at header
    at wu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:520910)
    at Ts (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:447987)
    at rs (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:427855)
    at Cu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:521338)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-_WdvQ3fd.js:18991:19)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\apollo.js:60:23)
    at Navigation (kukkuu-ui\src\domain\app\navigation\Navigation.tsx:27:44)
    at div
    at div
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at PageLayout (kukkuu-ui\src\domain\app\layout\PageLayout.tsx:19:23)
    at Layout (kukkuu-ui\src\domain\app\Layout.tsx:16:34)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: Hl: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Hl (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:396245)
    at div
    at div
    at Jl.Base (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:405206)
    at div
    at div
    at footer
    at Jl (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:403879)
    at Footer (kukkuu-ui\src\domain\app\footer\Footer.tsx:19:47)
    at div
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at PageLayout (kukkuu-ui\src\domain\app\layout\PageLayout.tsx:19:23)
    at Layout (kukkuu-ui\src\domain\app\Layout.tsx:16:34)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Error: Not implemented: window.scrollTo
    at module.exports (kukkuu-ui\node_modules\jsdom\lib\jsdom\browser\not-implemented.js:9:17)
    at scrollTo (kukkuu-ui\node_modules\jsdom\lib\jsdom\browser\Window.js:960:7)
    at kukkuu-ui\src\common\route\RouteUtils.ts:25:12
    at commitHookEffectListMount (kukkuu-ui\node_modules\react-dom\cjs\react-dom.development.js:23189:26)
    at commitPassiveMountOnFiber (kukkuu-ui\node_modules\react-dom\cjs\react-dom.development.js:24970:11)
    at commitPassiveMountEffects_complete (kukkuu-ui\node_modules\react-dom\cjs\react-dom.development.js:24930:9)
    at commitPassiveMountEffects_begin (kukkuu-ui\node_modules\react-dom\cjs\react-dom.development.js:24917:7)
    at commitPassiveMountEffects (kukkuu-ui\node_modules\react-dom\cjs\react-dom.development.js:24905:3)
    at flushPassiveEffectsImpl (kukkuu-ui\node_modules\react-dom\cjs\react-dom.development.js:27078:3)
    at flushPassiveEffects (kukkuu-ui\node_modules\react-dom\cjs\react-dom.development.js:27023:14) undefined
No more mocked responses for the query: query languages {
  languages {
    ...Language
    __typename
  }
}

fragment Language on Language {
  code
  id
  locale
  name
  slug
  __typename
}
Expected variables: {}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.
No more mocked responses for the query: query menu($id: ID!, $menuIdentifiersOnly: Boolean = false) {
  menu(idType: NAME, id: $id) {
    id
    menuItems(first: 100) {
      nodes {
        ...MenuItem
        __typename
      }
      __typename
    }
    __typename
  }
}

fragment MenuItem on MenuItem {
  id
  parentId
  order
  target
  title
  path
  label
  connectedNode {
    node {
      ... on Page {
        ...menuPageFields @skip(if: $menuIdentifiersOnly)
        ...menuPageIdentifiers @include(if: $menuIdentifiersOnly)
        children {
          nodes {
            ...menuPageFields @skip(if: $menuIdentifiersOnly)
            ...menuPageIdentifiers @include(if: $menuIdentifiersOnly)
            __typename
          }
          __typename
        }
        __typename
      }
      __typename
    }
    __typename
  }
  __typename
}

fragment menuPageFields on Page {
  ...Page
  translations {
    ...Page
    __typename
  }
  __typename
}

fragment Page on Page {
  id
  content
  slug
  title
  uri
  link
  lead
  seo {
    ...SEO
    __typename
  }
  hero {
    background_color
    background_image_url
    description
    link {
      target
      title
      url
      __typename
    }
    title
    wave_motif
    __typename
  }
  language {
    ...Language
    __typename
  }
  translations {
    uri
    slug
    language {
      ...Language
      __typename
    }
    seo {
      ...SEO
      __typename
    }
    __typename
  }
  featuredImage {
    node {
      mediaItemUrl
      link
      altText
      mimeType
      title
      uri
      photographerName
      medium_large: sourceUrl(size: MEDIUM_LARGE)
      medium: sourceUrl(size: MEDIUM)
      thumbnail: sourceUrl(size: THUMBNAIL)
      __typename
    }
    __typename
  }
  breadcrumbs {
    title
    uri
    __typename
  }
  sidebar {
    ... on LayoutLinkList {
      ...LayoutLinkList
      __typename
    }
    ... on LayoutArticles {
      ...LayoutArticles
      __typename
    }
    ... on LayoutPages {
      ...LayoutPages
      __typename
    }
    ... on LayoutCards {
      ...LayoutCards
      __typename
    }
    __typename
  }
  modules {
    ... on LayoutArticles {
      ...LayoutArticles
      __typename
    }
    ... on LayoutArticlesCarousel {
      ...LayoutArticlesCarousel
      __typename
    }
    ... on LayoutPages {
      ...LayoutPages
      __typename
    }
    ... on LayoutPagesCarousel {
      ...LayoutPagesCarousel
      __typename
    }
    ... on EventSearch {
      ...EventSearch
      __typename
    }
    ... on EventSelected {
      ...EventSelected
      __typename
    }
    ... on EventSearchCarousel {
      ...EventSearchCarousel
      __typename
    }
    ... on EventSelectedCarousel {
      ...EventSelectedCarousel
      __typename
    }
    ... on LayoutCollection {
      ...LayoutCollection
      __typename
    }
    ... on LocationsSelected {
      ...LocationsSelected
      __typename
    }
    ... on LocationsSelectedCarousel {
      ...LocationsSelectedCarousel
      __typename
    }
    ... on LayoutContent {
      ...LayoutContent
      __typename
    }
    ... on LayoutCard {
      ...LayoutCard
      __typename
    }
    ... on LayoutCards {
      ...LayoutCards
      __typename
    }
    ... on LayoutImage {
      ...LayoutImage
      __typename
    }
    ... on LayoutImageGallery {
      ...LayoutImageGallery
      __typename
    }
    ... on LayoutSteps {
      ...LayoutSteps
      __typename
    }
    ... on LayoutSocialMediaFeed {
      ...LayoutSocialMediaFeed
      __typename
    }
    __typename
  }
  __typename
}

fragment SEO on SEO {
  title
  description
  openGraphTitle
  openGraphDescription
  openGraphType
  twitterTitle
  twitterDescription
  canonicalUrl
  socialImage {
    mediaItemUrl
    __typename
  }
  __typename
}

fragment Language on Language {
  code
  id
  locale
  name
  slug
  __typename
}

fragment LayoutLinkList on LayoutLinkList {
  anchor
  title
  description
  links {
    target
    title
    url
    __typename
  }
  __typename
}

fragment LayoutArticles on LayoutArticles {
  title
  articles {
    id
    uri
    slug
    link
    date
    title
    lead
    featuredImage {
      node {
        altText
        mediaItemUrl
        medium_large: sourceUrl(size: MEDIUM_LARGE)
        medium: sourceUrl(size: MEDIUM)
        thumbnail: sourceUrl(size: THUMBNAIL)
        __typename
      }
      __typename
    }
    categories {
      nodes {
        name
        __typename
      }
      __typename
    }
    __typename
  }
  showAllLink
  __typename
}

fragment LayoutPages on LayoutPages {
  title
  description
  pages {
    id
    uri
    slug
    link
    date
    title
    lead
    featuredImage {
      node {
        altText
        mediaItemUrl
        medium_large: sourceUrl(size: MEDIUM_LARGE)
        medium: sourceUrl(size: MEDIUM)
        thumbnail: sourceUrl(size: THUMBNAIL)
        __typename
      }
      __typename
    }
    __typename
  }
  showAllLink
  __typename
}

fragment LayoutCards on LayoutCards {
  cards {
    backgroundColor
    description
    icon
    link {
      target
      title
      url
      __typename
    }
    title
    __typename
  }
  __typename
}

fragment LayoutArticlesCarousel on LayoutArticlesCarousel {
  title
  articles {
    id
    uri
    slug
    link
    date
    title
    lead
    featuredImage {
      node {
        altText
        mediaItemUrl
        medium_large: sourceUrl(size: MEDIUM_LARGE)
        medium: sourceUrl(size: MEDIUM)
        thumbnail: sourceUrl(size: THUMBNAIL)
        __typename
      }
      __typename
    }
    categories {
      nodes {
        name
        __typename
      }
      __typename
    }
    __typename
  }
  showMore
  showAllLink
  __typename
}

fragment LayoutPagesCarousel on LayoutPagesCarousel {
  title
  description
  pages {
    id
    uri
    slug
    link
    date
    title
    lead
    featuredImage {
      node {
        altText
        mediaItemUrl
        medium_large: sourceUrl(size: MEDIUM_LARGE)
        medium: sourceUrl(size: MEDIUM)
        thumbnail: sourceUrl(size: THUMBNAIL)
        __typename
      }
      __typename
    }
    __typename
  }
  __typename
}

fragment EventSearch on EventSearch {
  title
  url
  module
  showAllLink
  showAllLinkCustom
  __typename
}

fragment EventSelected on EventSelected {
  title
  events
  module
  __typename
}

fragment EventSearchCarousel on EventSearchCarousel {
  title
  url
  orderNewestFirst
  eventsNearby
  amountOfCards
  showAllLink
  showAllLinkCustom
  __typename
}

fragment EventSelectedCarousel on EventSelectedCarousel {
  title
  module
  eventsNearby
  events
  amountOfCardsPerRow
  amountOfCards
  __typename
}

fragment LayoutCollection on LayoutCollection {
  collection {
    title
    __typename
  }
  __typename
}

fragment LocationsSelected on LocationsSelected {
  title
  locations
  module
  __typename
}

fragment LocationsSelectedCarousel on LocationsSelectedCarousel {
  title
  locations
  module
  __typename
}

fragment LayoutContent on LayoutContent {
  backgroundColor
  content
  title
  __typename
}

fragment LayoutCard on LayoutCard {
  alignment
  backgroundColor
  description
  link {
    target
    title
    url
    __typename
  }
  title
  image {
    caption
    description
    large
    medium
    medium_large
    thumbnail
    title
    __typename
  }
  __typename
}

fragment LayoutImage on LayoutImage {
  border
  photographer_name
  image {
    caption
    description
    large
    medium
    thumbnail
    title
    medium_large
    __typename
  }
  show_on_lightbox
  __typename
}

fragment LayoutImageGallery on LayoutImageGallery {
  gallery {
    caption
    description
    large
    medium
    thumbnail
    title
    medium_large
    __typename
  }
  __typename
}

fragment LayoutSteps on LayoutSteps {
  color
  description
  steps {
    content
    title
    __typename
  }
  title
  type
  __typename
}

fragment LayoutSocialMediaFeed on LayoutSocialMediaFeed {
  anchor
  script
  title
  __typename
}

fragment menuPageIdentifiers on Page {
  ...menuPageIdentifierFields
  translations {
    ...menuPageIdentifierFields
    __typename
  }
  __typename
}

fragment menuPageIdentifierFields on Page {
  id
  uri
  slug
  parentId
  title
  __typename
}
Expected variables: {"menuIdentifiersOnly":false,"id":"Main Navigation FI"}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.
No more mocked responses for the query: query notification($language: String! = "fi") {
  notification(language: $language) {
    content
    title
    level
    startDate
    endDate
    linkText
    linkUrl
    __typename
  }
}
Expected variables: {"language":"fi"}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.
No more mocked responses for the query: query menu($id: ID!, $menuIdentifiersOnly: Boolean = false) {
  menu(idType: NAME, id: $id) {
    id
    menuItems(first: 100) {
      nodes {
        ...MenuItem
        __typename
      }
      __typename
    }
    __typename
  }
}

fragment MenuItem on MenuItem {
  id
  parentId
  order
  target
  title
  path
  label
  connectedNode {
    node {
      ... on Page {
        ...menuPageFields @skip(if: $menuIdentifiersOnly)
        ...menuPageIdentifiers @include(if: $menuIdentifiersOnly)
        children {
          nodes {
            ...menuPageFields @skip(if: $menuIdentifiersOnly)
            ...menuPageIdentifiers @include(if: $menuIdentifiersOnly)
            __typename
          }
          __typename
        }
        __typename
      }
      __typename
    }
    __typename
  }
  __typename
}

fragment menuPageFields on Page {
  ...Page
  translations {
    ...Page
    __typename
  }
  __typename
}

fragment Page on Page {
  id
  content
  slug
  title
  uri
  link
  lead
  seo {
    ...SEO
    __typename
  }
  hero {
    background_color
    background_image_url
    description
    link {
      target
      title
      url
      __typename
    }
    title
    wave_motif
    __typename
  }
  language {
    ...Language
    __typename
  }
  translations {
    uri
    slug
    language {
      ...Language
      __typename
    }
    seo {
      ...SEO
      __typename
    }
    __typename
  }
  featuredImage {
    node {
      mediaItemUrl
      link
      altText
      mimeType
      title
      uri
      photographerName
      medium_large: sourceUrl(size: MEDIUM_LARGE)
      medium: sourceUrl(size: MEDIUM)
      thumbnail: sourceUrl(size: THUMBNAIL)
      __typename
    }
    __typename
  }
  breadcrumbs {
    title
    uri
    __typename
  }
  sidebar {
    ... on LayoutLinkList {
      ...LayoutLinkList
      __typename
    }
    ... on LayoutArticles {
      ...LayoutArticles
      __typename
    }
    ... on LayoutPages {
      ...LayoutPages
      __typename
    }
    ... on LayoutCards {
      ...LayoutCards
      __typename
    }
    __typename
  }
  modules {
    ... on LayoutArticles {
      ...LayoutArticles
      __typename
    }
    ... on LayoutArticlesCarousel {
      ...LayoutArticlesCarousel
      __typename
    }
    ... on LayoutPages {
      ...LayoutPages
      __typename
    }
    ... on LayoutPagesCarousel {
      ...LayoutPagesCarousel
      __typename
    }
    ... on EventSearch {
      ...EventSearch
      __typename
    }
    ... on EventSelected {
      ...EventSelected
      __typename
    }
    ... on EventSearchCarousel {
      ...EventSearchCarousel
      __typename
    }
    ... on EventSelectedCarousel {
      ...EventSelectedCarousel
      __typename
    }
    ... on LayoutCollection {
      ...LayoutCollection
      __typename
    }
    ... on LocationsSelected {
      ...LocationsSelected
      __typename
    }
    ... on LocationsSelectedCarousel {
      ...LocationsSelectedCarousel
      __typename
    }
    ... on LayoutContent {
      ...LayoutContent
      __typename
    }
    ... on LayoutCard {
      ...LayoutCard
      __typename
    }
    ... on LayoutCards {
      ...LayoutCards
      __typename
    }
    ... on LayoutImage {
      ...LayoutImage
      __typename
    }
    ... on LayoutImageGallery {
      ...LayoutImageGallery
      __typename
    }
    ... on LayoutSteps {
      ...LayoutSteps
      __typename
    }
    ... on LayoutSocialMediaFeed {
      ...LayoutSocialMediaFeed
      __typename
    }
    __typename
  }
  __typename
}

fragment SEO on SEO {
  title
  description
  openGraphTitle
  openGraphDescription
  openGraphType
  twitterTitle
  twitterDescription
  canonicalUrl
  socialImage {
    mediaItemUrl
    __typename
  }
  __typename
}

fragment Language on Language {
  code
  id
  locale
  name
  slug
  __typename
}

fragment LayoutLinkList on LayoutLinkList {
  anchor
  title
  description
  links {
    target
    title
    url
    __typename
  }
  __typename
}

fragment LayoutArticles on LayoutArticles {
  title
  articles {
    id
    uri
    slug
    link
    date
    title
    lead
    featuredImage {
      node {
        altText
        mediaItemUrl
        medium_large: sourceUrl(size: MEDIUM_LARGE)
        medium: sourceUrl(size: MEDIUM)
        thumbnail: sourceUrl(size: THUMBNAIL)
        __typename
      }
      __typename
    }
    categories {
      nodes {
        name
        __typename
      }
      __typename
    }
    __typename
  }
  showAllLink
  __typename
}

fragment LayoutPages on LayoutPages {
  title
  description
  pages {
    id
    uri
    slug
    link
    date
    title
    lead
    featuredImage {
      node {
        altText
        mediaItemUrl
        medium_large: sourceUrl(size: MEDIUM_LARGE)
        medium: sourceUrl(size: MEDIUM)
        thumbnail: sourceUrl(size: THUMBNAIL)
        __typename
      }
      __typename
    }
    __typename
  }
  showAllLink
  __typename
}

fragment LayoutCards on LayoutCards {
  cards {
    backgroundColor
    description
    icon
    link {
      target
      title
      url
      __typename
    }
    title
    __typename
  }
  __typename
}

fragment LayoutArticlesCarousel on LayoutArticlesCarousel {
  title
  articles {
    id
    uri
    slug
    link
    date
    title
    lead
    featuredImage {
      node {
        altText
        mediaItemUrl
        medium_large: sourceUrl(size: MEDIUM_LARGE)
        medium: sourceUrl(size: MEDIUM)
        thumbnail: sourceUrl(size: THUMBNAIL)
        __typename
      }
      __typename
    }
    categories {
      nodes {
        name
        __typename
      }
      __typename
    }
    __typename
  }
  showMore
  showAllLink
  __typename
}

fragment LayoutPagesCarousel on LayoutPagesCarousel {
  title
  description
  pages {
    id
    uri
    slug
    link
    date
    title
    lead
    featuredImage {
      node {
        altText
        mediaItemUrl
        medium_large: sourceUrl(size: MEDIUM_LARGE)
        medium: sourceUrl(size: MEDIUM)
        thumbnail: sourceUrl(size: THUMBNAIL)
        __typename
      }
      __typename
    }
    __typename
  }
  __typename
}

fragment EventSearch on EventSearch {
  title
  url
  module
  showAllLink
  showAllLinkCustom
  __typename
}

fragment EventSelected on EventSelected {
  title
  events
  module
  __typename
}

fragment EventSearchCarousel on EventSearchCarousel {
  title
  url
  orderNewestFirst
  eventsNearby
  amountOfCards
  showAllLink
  showAllLinkCustom
  __typename
}

fragment EventSelectedCarousel on EventSelectedCarousel {
  title
  module
  eventsNearby
  events
  amountOfCardsPerRow
  amountOfCards
  __typename
}

fragment LayoutCollection on LayoutCollection {
  collection {
    title
    __typename
  }
  __typename
}

fragment LocationsSelected on LocationsSelected {
  title
  locations
  module
  __typename
}

fragment LocationsSelectedCarousel on LocationsSelectedCarousel {
  title
  locations
  module
  __typename
}

fragment LayoutContent on LayoutContent {
  backgroundColor
  content
  title
  __typename
}

fragment LayoutCard on LayoutCard {
  alignment
  backgroundColor
  description
  link {
    target
    title
    url
    __typename
  }
  title
  image {
    caption
    description
    large
    medium
    medium_large
    thumbnail
    title
    __typename
  }
  __typename
}

fragment LayoutImage on LayoutImage {
  border
  photographer_name
  image {
    caption
    description
    large
    medium
    thumbnail
    title
    medium_large
    __typename
  }
  show_on_lightbox
  __typename
}

fragment LayoutImageGallery on LayoutImageGallery {
  gallery {
    caption
    description
    large
    medium
    thumbnail
    title
    medium_large
    __typename
  }
  __typename
}

fragment LayoutSteps on LayoutSteps {
  color
  description
  steps {
    content
    title
    __typename
  }
  title
  type
  __typename
}

fragment LayoutSocialMediaFeed on LayoutSocialMediaFeed {
  anchor
  script
  title
  __typename
}

fragment menuPageIdentifiers on Page {
  ...menuPageIdentifierFields
  translations {
    ...menuPageIdentifierFields
    __typename
  }
  __typename
}

fragment menuPageIdentifierFields on Page {
  id
  uri
  slug
  parentId
  title
  __typename
}
Expected variables: {"menuIdentifiersOnly":true,"id":"Footer Navigation FI"}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.
[MSW] Warning: intercepted a request without a matching request handler:

  • POST https://kukkuu.app-staging.hkih.hion.dev/graphql

  • Request body: {"operationName":"page","variables":{"id":""},"query":"query page($id: ID!) {\n  page(id: $id, idType: URI) {\n    ...Page\n    __typename\n  }\n}\n\nfragment Page on Page {\n  id\n  content\n  slug\n  title\n  uri\n  link\n  lead\n  seo {\n    ...SEO\n    __typename\n  }\n  hero {\n    background_color\n    background_image_url\n    description\n    link {\n      target\n      title\n      url\n      __typename\n    }\n    title\n    wave_motif\n    __typename\n  }\n  language {\n    ...Language\n    __typename\n  }\n  translations {\n    uri\n    slug\n    language {\n      ...Language\n      __typename\n    }\n    seo {\n      ...SEO\n      __typename\n    }\n    __typename\n  }\n  featuredImage {\n    node {\n      mediaItemUrl\n      link\n      altText\n      mimeType\n      title\n      uri\n      photographerName\n      medium_large: sourceUrl(size: MEDIUM_LARGE)\n      medium: sourceUrl(size: MEDIUM)\n      thumbnail: sourceUrl(size: THUMBNAIL)\n      __typename\n    }\n    __typename\n  }\n  breadcrumbs {\n    title\n    uri\n    __typename\n  }\n  sidebar {\n    ... on LayoutLinkList {\n      ...LayoutLinkList\n      __typename\n    }\n    ... on LayoutArticles {\n      ...LayoutArticles\n      __typename\n    }\n    ... on LayoutPages {\n      ...LayoutPages\n      __typename\n    }\n    ... on LayoutCards {\n      ...LayoutCards\n      __typename\n    }\n    __typename\n  }\n  modules {\n    ... on LayoutArticles {\n      ...LayoutArticles\n      __typename\n    }\n    ... on LayoutArticlesCarousel {\n      ...LayoutArticlesCarousel\n      __typename\n    }\n    ... on LayoutPages {\n      ...LayoutPages\n      __typename\n    }\n    ... on LayoutPagesCarousel {\n      ...LayoutPagesCarousel\n      __typename\n    }\n    ... on EventSearch {\n      ...EventSearch\n      __typename\n    }\n    ... on EventSelected {\n      ...EventSelected\n      __typename\n    }\n    ... on EventSearchCarousel {\n      ...EventSearchCarousel\n      __typename\n    }\n    ... on EventSelectedCarousel {\n      ...EventSelectedCarousel\n      __typename\n    }\n    ... on LayoutCollection {\n      ...LayoutCollection\n      __typename\n    }\n    ... on LocationsSelected {\n      ...LocationsSelected\n      __typename\n    }\n    ... on LocationsSelectedCarousel {\n      ...LocationsSelectedCarousel\n      __typename\n    }\n    ... on LayoutContent {\n      ...LayoutContent\n      __typename\n    }\n    ... on LayoutCard {\n      ...LayoutCard\n      __typename\n    }\n    ... on LayoutCards {\n      ...LayoutCards\n      __typename\n    }\n    ... on LayoutImage {\n      ...LayoutImage\n      __typename\n    }\n    ... on LayoutImageGallery {\n      ...LayoutImageGallery\n      __typename\n    }\n    ... on LayoutSteps {\n      ...LayoutSteps\n      __typename\n    }\n    ... on LayoutSocialMediaFeed {\n      ...LayoutSocialMediaFeed\n      __typename\n    }\n    __typename\n  }\n  __typename\n}\n\nfragment SEO on SEO {\n  title\n  description\n  openGraphTitle\n  openGraphDescription\n  openGraphType\n  twitterTitle\n  twitterDescription\n  canonicalUrl\n  socialImage {\n    mediaItemUrl\n    __typename\n  }\n  __typename\n}\n\nfragment Language on Language {\n  code\n  id\n  locale\n  name\n  slug\n  __typename\n}\n\nfragment LayoutLinkList on LayoutLinkList {\n  anchor\n  title\n  description\n  links {\n    target\n    title\n    url\n    __typename\n  }\n  __typename\n}\n\nfragment LayoutArticles on LayoutArticles {\n  title\n  articles {\n    id\n    uri\n    slug\n    link\n    date\n    title\n    lead\n    featuredImage {\n      node {\n        altText\n        mediaItemUrl\n        medium_large: sourceUrl(size: MEDIUM_LARGE)\n        medium: sourceUrl(size: MEDIUM)\n        thumbnail: sourceUrl(size: THUMBNAIL)\n        __typename\n      }\n      __typename\n    }\n    categories {\n      nodes {\n        name\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n  showAllLink\n  __typename\n}\n\nfragment LayoutPages on LayoutPages {\n  title\n  description\n  pages {\n    id\n    uri\n    slug\n    link\n    date\n    title\n    lead\n    featuredImage {\n      node {\n        altText\n        mediaItemUrl\n        medium_large: sourceUrl(size: MEDIUM_LARGE)\n        medium: sourceUrl(size: MEDIUM)\n        thumbnail: sourceUrl(size: THUMBNAIL)\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n  showAllLink\n  __typename\n}\n\nfragment LayoutCards on LayoutCards {\n  cards {\n    backgroundColor\n    description\n    icon\n    link {\n      target\n      title\n      url\n      __typename\n    }\n    title\n    __typename\n  }\n  __typename\n}\n\nfragment LayoutArticlesCarousel on LayoutArticlesCarousel {\n  title\n  articles {\n    id\n    uri\n    slug\n    link\n    date\n    title\n    lead\n    featuredImage {\n      node {\n        altText\n        mediaItemUrl\n        medium_large: sourceUrl(size: MEDIUM_LARGE)\n        medium: sourceUrl(size: MEDIUM)\n        thumbnail: sourceUrl(size: THUMBNAIL)\n        __typename\n      }\n      __typename\n    }\n    categories {\n      nodes {\n        name\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n  showMore\n  showAllLink\n  __typename\n}\n\nfragment LayoutPagesCarousel on LayoutPagesCarousel {\n  title\n  description\n  pages {\n    id\n    uri\n    slug\n    link\n    date\n    title\n    lead\n    featuredImage {\n      node {\n        altText\n        mediaItemUrl\n        medium_large: sourceUrl(size: MEDIUM_LARGE)\n        medium: sourceUrl(size: MEDIUM)\n        thumbnail: sourceUrl(size: THUMBNAIL)\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n  __typename\n}\n\nfragment EventSearch on EventSearch {\n  title\n  url\n  module\n  showAllLink\n  showAllLinkCustom\n  __typename\n}\n\nfragment EventSelected on EventSelected {\n  title\n  events\n  module\n  __typename\n}\n\nfragment EventSearchCarousel on EventSearchCarousel {\n  title\n  url\n  orderNewestFirst\n  eventsNearby\n  amountOfCards\n  showAllLink\n  showAllLinkCustom\n  __typename\n}\n\nfragment EventSelectedCarousel on EventSelectedCarousel {\n  title\n  module\n  eventsNearby\n  events\n  amountOfCardsPerRow\n  amountOfCards\n  __typename\n}\n\nfragment LayoutCollection on LayoutCollection {\n  collection {\n    title\n    __typename\n  }\n  __typename\n}\n\nfragment LocationsSelected on LocationsSelected {\n  title\n  locations\n  module\n  __typename\n}\n\nfragment LocationsSelectedCarousel on LocationsSelectedCarousel {\n  title\n  locations\n  module\n  __typename\n}\n\nfragment LayoutContent on LayoutContent {\n  backgroundColor\n  content\n  title\n  __typename\n}\n\nfragment LayoutCard on LayoutCard {\n  alignment\n  backgroundColor\n  description\n  link {\n    target\n    title\n    url\n    __typename\n  }\n  title\n  image {\n    caption\n    description\n    large\n    medium\n    medium_large\n    thumbnail\n    title\n    __typename\n  }\n  __typename\n}\n\nfragment LayoutImage on LayoutImage {\n  border\n  photographer_name\n  image {\n    caption\n    description\n    large\n    medium\n    thumbnail\n    title\n    medium_large\n    __typename\n  }\n  show_on_lightbox\n  __typename\n}\n\nfragment LayoutImageGallery on LayoutImageGallery {\n  gallery {\n    caption\n    description\n    large\n    medium\n    thumbnail\n    title\n    medium_large\n    __typename\n  }\n  __typename\n}\n\nfragment LayoutSteps on LayoutSteps {\n  color\n  description\n  steps {\n    content\n    title\n    __typename\n  }\n  title\n  type\n  __typename\n}\n\nfragment LayoutSocialMediaFeed on LayoutSocialMediaFeed {\n  anchor\n  script\n  title\n  __typename\n}"}

If you still wish to intercept this unhandled request, please create a request handler for it.
Read more: https://mswjs.io/docs/getting-started/mocks

stderr | src/domain/event/__tests__/EventIsEnrolled.test.tsx > renders snapshot correctly
No more mocked responses for the query: fragment OccurrenceEventFields on EventNode {
  id
  image
  imageAltText
  description
  shortDescription
  name
  duration
  participantsPerInvite
  eventGroup {
    id
    __typename
  }
  __typename
}

fragment OccurrenceVenueFields on VenueNode {
  id
  name
  address
  accessibilityInfo
  arrivalInstructions
  additionalInfo
  wwwUrl
  wcAndFacilities
  __typename
}

fragment OccurrenceFields on OccurrenceNode {
  id
  time
  remainingCapacity
  event {
    ...OccurrenceEventFields
    __typename
  }
  venue {
    ...OccurrenceVenueFields
    __typename
  }
  childHasFreeSpotNotificationSubscription(childId: $childId)
  __typename
}

query occurrenceQuery($id: ID!, $childId: ID) {
  occurrence(id: $id) {
    ...OccurrenceFields
    __typename
  }
}
Expected variables: {"id":<undefined>,"childId":<undefined>}

This typically indicates a configuration error in your mocks setup, usually due to a typo or mismatched variable.

 ✓ src/common/__tests__/commonUtils.test.tsx (2)
   ✓ converts CRLFs to brs
   ✓ converts LFs to brs
 ✓ src/domain/__tests__/Config.test.tsx (2)
   ✓ Config (2)
     ✓ featureFlagShowCoronaInfo (2)
       ✓ should return true when VITE_FEATURE_FLAG_SHOW_CORONAVIRUS_INFO is true
       ✓ should return false otherwise
 ✓ src/common/AriaLive/__tests__/AriaLive.test.tsx (1) 657ms
   ✓ AriaLive (1) 655ms
     ✓ should update an aria-live region 654ms
 ✓ src/common/time/__tests__/utils.test.tsx (2)
   ✓ Converts human-readable month to zero based
   ✓ Converts human-readable string month to zero based integer
 ✓ src/domain/api/__tests__/client.test.ts (1)
   ✓ graphql client (1)
     ✓ sets Authorization-header to requests from currently authenticated user
 ✓ src/domain/auth/__tests__/Unauthorized.test.tsx (2)
   ✓ Unauthorized page (2)
     ✓ redirects to profile page if user is authenticated
     ✓ redirects to nextPath URL parameter when it is given
 ✓ src/domain/app/__tests__/Layout.test.tsx (1)
   ✓ renders without crashing
 ✓ src/domain/child/__tests__/ChildUtils.test.ts (1)
   ✓ ChildUtil (1)
     ✓ getChildFormModalValues (1)
       ✓ does not return fields which are irrelevant
 ✓ src/domain/cookieConsent/__tests__/CookieConsentPage.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/__tests__/Event.test.tsx (2)
   ✓ Event (2)
     ✓ utilities (2)
       ✓ getDateOptions should return a list of options without duplicates
       ✓ getTimeOptions should return an ordered list without duplicates
 ✓ src/domain/event/__tests__/EventIsEnrolled.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/__tests__/EventOccurrence.test.tsx (5)
   ✓ renders snapshot correctly
   ✓ renders button for signing up to an event
   ✓ when event is full (3)
     ✓ should show full label instead of remaining capacity
     ✓ and child has not subscribed to notifications (1)
       ✓ user should be able to subscribe
     ✓ and child has subscribed to notifications (1)
       ✓ user should be able to unsubscribe
 ✓ src/domain/event/__tests__/EventOccurrenceList.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/__tests__/EventPage.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/__tests__/EventUtils.test.ts (1)
   ✓ EventUtils (1)
     ✓ formatOccurrenceTime (1)
       ✓ should format correctly
 ✓ src/domain/event/__tests__/VenueFeatures.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/eventGroup/__tests__/EventGroup.test.tsx (6) 1280ms
   ✓ <EventGroup /> (6) 1276ms
     ✓ renders loading if loading
     ✓ renders error if error
     ✓ renders title and description
     ✓ renders events
     ✓ clicking on event should take user to event 1046ms
     ✓ sets title to name of event group
 ✓ src/domain/headlessCms/__tests__/client.test.ts (1)
   ✓ Headless CMS Client (1)
     ✓ returns a page when a page query is requested
 ✓ src/domain/profile/__tests__/Profile.test.tsx (2)
   ✓ Profile (2)
     ✓ renders profile correctly
     ✓ redirects to the register section in home page if user is authenticated but has no profile
 ✓ src/domain/profile/__tests__/ProfileUtils.test.ts (1)
   ✓ ProfileUtils (1)
     ✓ normalizeProfileChild (1)
       ✓ input a fetched child and return a child for mutation
 ✓ src/domain/home/__tests__/Home.test.tsx (2) 1350ms
   ✓ <Home /> (2) 1347ms
     ✓ renders snapshot correctly 348ms
     ✓ does not show the link to the godchild profile if the user is no longer authenticated 998ms
 ✓ src/common/route/utils/__tests__/getPathname.test.ts (9)
   ✓ when pathname is "/" and language is "fi", yields "/"
   ✓ when pathname is "/profile" and language is "fi", yields "/profile"
   ✓ when pathname is "profile" and language is "fi", yields "/profile"
   ✓ when pathname is "/" and language is "sv", yields "/sv"
   ✓ when pathname is "/profile" and language is "sv", yields "/sv/profile"
   ✓ when pathname is "profile" and language is "sv", yields "/sv/profile"
   ✓ when pathname is "/" and language is "en", yields "/en"
   ✓ when pathname is "/profile" and language is "en", yields "/en/profile"
   ✓ when pathname is "profile" and language is "en", yields "/en/profile"
 ✓ src/domain/app/footer/__tests__/Footer.test.tsx (1)
   ✓ Footer matches snapshot
 ✓ src/domain/child/form/__tests__/ChildForm.test.tsx (2)
   ✓ <ChildForm /> (2)
     ✓ as a user I do not want to see the city control when editing
     ✓ implementation details (1)
       ✓ the form should have the noValidate prop so that browser validation is not used
 ✓ src/domain/child/modal/__tests__/ChildFormModal.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/common/components/button/__tests__/Button.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/common/components/card/__tests__/Card.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/common/components/confirm/__tests__/NavigationConfirm.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/common/components/formikWrappers/__tests__/FormikDropdown.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/common/components/form/__tests__/validationUtils.test.tsx (6)
   ✓ Form validation utilities (6)
     ✓ validatePostalCode (4)
       ✓ postal code has characters
       ✓ postal code is of wrong length
       ✓ postal code should not be empty
       ✓ valid postal code
     ✓ validateRequire (2)
       ✓ will show error if field is empty
       ✓ will show custom error message if field is empty and custom message is defined
 ✓ src/common/components/modal/__tests__/Modal.test.tsx (4)
   ✓ renders snapshot correctly
   ✓ renders mandatory field legend by default
   ✓ renders mandatory field legend when asked to
   ✓ omits mandatory field legend when asked to
 ✓ src/common/components/spinner/__tests__/LoadingSpinner.test.tsx (3)
   ✓ renders snapshot correctly
   ✓ render spinner if isLoading is true
   ✓ render child component if isLoading is false
 ✓ src/domain/event/enrol/__tests__/Enrol.test.tsx (5) 437ms
   ✓ <Enrol /> (5) 431ms
     ✓ the user should be able to sign in to an event
     ✓ the user should be able to cancel
     ✓ when the event is full (2)
       ✓ the user should be able to subscribe to notifications
       ✓ should have a special title and description
     ✓ when the event is full and te user has subscribed (1)
       ✓ the user should be able to unsubscribe
 ✓ src/domain/event/enrol/__tests__/SuccessToast.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/eventCard/__tests__/EventCard.test.tsx (6) 1002ms
   ✓ <EventCard /> (6) 997ms
     ✓ should show event name, short description and image 493ms
     ✓ should show primary action by default and it should map to action
     ✓ should allow for primary action to be toggled off
     ✓ should show a placeholder image if none is provided
     ✓ should gives highest priority to custom imageElement
     ✓ should show focal content
 ✓ src/domain/event/partial/__tests__/InfoItem.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/partial/__tests__/OccurrenceInfo.test.tsx (3)
   ✓ renders snapshot correctly
   ✓ renders occurrence snapshot correctly
   ✓ renders childByIdQuery occurrence snapshot correctly
 ✓ src/domain/profile/events/__tests__/ProfileEvents.test.tsx (5)
   ✓ Renders "No events" when no events"
   ✓ Renders events list when events of any type
   ✓ Renders events list when only upcomingEventsAndEventGroups
   ✓ Renders events list when only enrolments
   ✓ Renders events list when only past events
 ✓ src/domain/profile/events/__tests__/ProfileEventsList.test.tsx (6) 1053ms
   ✓ Renders snapshot correctly
   ✓ Renders only upcoming events and event groups when no other inputs 701ms
   ✓ Renders only enrolments when no other inputs
   ✓ Renders Ticketmaster enrolment
   ✓ Renders Lippupiste enrolment
   ✓ Renders Tixly enrolment
 ✓ src/domain/profile/modal/__tests__/EditProfileModal.test.tsx (2) 2403ms
   ✓ renders snapshot correctly
   ✓ should allow all fields to be filled 2179ms
 ✓ src/domain/home/moreInfo/__tests__/HomeMoreInfo.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/home/moreInfo/__tests__/MoreInfoLinkList.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/home/partners/__tests__/HomePartners.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/home/partners/__tests__/PartnersLogoList.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/home/video/__tests__/HomeVideo.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/registration/form/__tests__/RegistrationForm.test.tsx (3) 1328ms
   ↓ renders snapshot correctly [skipped]
   ✓ email field is disabled 336ms
   ✓ hasAcceptedCommunication is checked by default 988ms
 ✓ src/domain/registration/modal/__tests__/AddNewChildFormModal.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/registration/notEligible/__tests__/NotEligible.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/registration/notEligible/__tests__/NotEligibleUtils.test.ts (9)
   ✓ notEligibleUtils.test.ts (9)
     ✓ A random city should not be eligible
     ✓ A random city should be eligible when editing a child
     ✓ Verify that all cities in VITE_ELIGIBLE_CITIES are eligible
     ✓ Verify that cities are eligible even when user adds whitespace
     ✓ Verify that getEligibleCities returns an array of eligible cities
     ✓ Verify that all cities in VITE_ELIGIBLE_CITIES in uppercase are eligible
     ✓ Verify that a date too far into the past is not eligible
     ✓ Verify that a date after supported start date is eligible
     ✓ Verify that an invalid date is not eligible
 ✓ src/domain/registration/welcome/__tests__/Welcome.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/app/layout/utilityComponents/__tests__/Page.test.tsx (5)
   ✓ <Page /> (5)
     ✓ should set title
     ✓ should show loading spinner when isLoading is true
     ✓ should show generic error when error is true
     ✓ should show custom error when error is an object
     ✓ should render children when isReady is true

 Test Files  51 passed (51)
      Tests  120 passed | 1 skipped (121)
   Start at  09:51:58
   Duration  26.90s (transform 39.47s, setup 74.04s, collect 185.82s, tests 13.67s, environment 49.42s, prepare 8.39s)
```

</details>


<details>

<summary>Test warnings after this PR (Click to expand)</summary>

```
$ yarn test
yarn run v1.22.22
$ cross-env TZ=Europe/Helsinki vitest run

 RUN  v2.1.7 C:/dev/projects/City-of-Helsinki/kukkuu-ui

stderr | src/domain/registration/form/__tests__/RegistrationForm.test.tsx > renders snapshot correctly
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at div
    at div
    at ChildFormFields (kukkuu-ui\src\domain\registration\form\partial\childFormFields.tsx:25:28)
    at FieldArrayInner (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1608:30)
    at FormikConnect(FieldArrayInner)
    at div
    at form
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at div
    at div
    at div
    at Container (kukkuu-ui\src\domain\app\layout\Container.tsx:9:22)
    at div
    at PageWrapper (kukkuu-ui\src\domain\app\layout\PageWrapper.tsx:11:24)
    at RegistrationForm (kukkuu-ui\src\domain\registration\form\RegistrationForm.tsx:106:47)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: Mi: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Mi (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:346609)
    at Combobox (kukkuu-ui\src\common\components\formikWrappers\Combobox.tsx:11:21)
    at LanguagesCombobox (kukkuu-ui\src\domain\languages\LanguagesCombobox.tsx:10:56)
    at div
    at form
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at div
    at div
    at div
    at Container (kukkuu-ui\src\domain\app\layout\Container.tsx:9:22)
    at div
    at PageWrapper (kukkuu-ui\src\domain\app\layout\PageWrapper.tsx:11:24)
    at RegistrationForm (kukkuu-ui\src\domain\registration\form\RegistrationForm.tsx:106:47)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stderr | src/domain/profile/modal/__tests__/EditProfileModal.test.tsx > renders snapshot correctly
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at form
    at kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1413:22
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at EditMyProfileForm (kukkuu-ui\src\domain\profile\modal\EditMyProfileForm.tsx:54:30)
    at div
    at div
    at div
    at div
    at ModalPortal (kukkuu-ui\node_modules\react-modal\lib\components\ModalPortal.js:79:5)
    at Modal (kukkuu-ui\node_modules\react-modal\lib\components\Modal.js:73:5)
    at div
    at Modal (kukkuu-ui\src\common\components\modal\Modal.tsx:23:18)
    at div
    at EditProfileModal (kukkuu-ui\src\domain\profile\modal\EditProfileModal.tsx:19:29)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: Mi: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Mi (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:346609)
    at Combobox (kukkuu-ui\src\common\components\formikWrappers\Combobox.tsx:11:21)
    at LanguagesCombobox (kukkuu-ui\src\domain\languages\LanguagesCombobox.tsx:10:56)
    at form
    at kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1413:22
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at EditMyProfileForm (kukkuu-ui\src\domain\profile\modal\EditMyProfileForm.tsx:54:30)
    at div
    at div
    at div
    at div
    at ModalPortal (kukkuu-ui\node_modules\react-modal\lib\components\ModalPortal.js:79:5)
    at Modal (kukkuu-ui\node_modules\react-modal\lib\components\Modal.js:73:5)
    at div
    at Modal (kukkuu-ui\src\common\components\modal\Modal.tsx:23:18)
    at div
    at EditProfileModal (kukkuu-ui\src\domain\profile\modal\EditProfileModal.tsx:19:29)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stderr | src/domain/child/form/__tests__/ChildForm.test.tsx > <ChildForm /> > as a user I do not want to see the city control when editing
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at form
    at kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1413:22
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at ChildForm (kukkuu-ui\src\domain\child\form\ChildForm.tsx:43:22)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stderr | src/common/components/formikWrappers/__tests__/FormikDropdown.test.tsx > renders snapshot correctly
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at Dropdown
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at TestForm

stderr | src/domain/app/footer/__tests__/Footer.test.tsx > Footer matches snapshot
Warning: Hl: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Hl (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:396245)
    at div
    at div
    at Jl.Base (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:405206)
    at div
    at div
    at footer
    at Jl (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:403879)
    at Footer (kukkuu-ui\src\domain\app\footer\Footer.tsx:19:47)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stderr | src/domain/app/__tests__/Layout.test.tsx > renders without crashing
Warning: Ts: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Ts (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:447987)
    at rs (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:427855)
    at Cu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:521338)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-_WdvQ3fd.js:18991:19)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\apollo.js:60:23)
    at Navigation (kukkuu-ui\src\domain\app\navigation\Navigation.tsx:28:44)
    at div
    at div
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at PageLayout (kukkuu-ui\src\domain\app\layout\PageLayout.tsx:19:23)
    at Layout (kukkuu-ui\src\domain\app\Layout.tsx:16:34)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: bd: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at bd (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:470570)
    at div
    at header
    at wu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:520910)
    at Ts (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:447987)
    at rs (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:427855)
    at Cu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:521338)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-_WdvQ3fd.js:18991:19)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\apollo.js:60:23)
    at Navigation (kukkuu-ui\src\domain\app\navigation\Navigation.tsx:28:44)
    at div
    at div
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at PageLayout (kukkuu-ui\src\domain\app\layout\PageLayout.tsx:19:23)
    at Layout (kukkuu-ui\src\domain\app\Layout.tsx:16:34)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: Ws: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Ws (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:460806)
    at UserNavigation (kukkuu-ui\src\domain\app\navigation\UserNavigation.tsx:32:41)
    at div
    at div
    at div
    at bd (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:470570)
    at div
    at header
    at wu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:520910)
    at Ts (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:447987)
    at rs (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:427855)
    at Cu (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:521338)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-_WdvQ3fd.js:18991:19)
    at Navigation (kukkuu-ui\node_modules\react-helsinki-headless-cms\apollo.js:60:23)
    at Navigation (kukkuu-ui\src\domain\app\navigation\Navigation.tsx:28:44)
    at div
    at div
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at PageLayout (kukkuu-ui\src\domain\app\layout\PageLayout.tsx:19:23)
    at Layout (kukkuu-ui\src\domain\app\Layout.tsx:16:34)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)
Warning: Hl: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Hl (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:396245)
    at div
    at div
    at Jl.Base (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:405206)
    at div
    at div
    at footer
    at Jl (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:403879)
    at Footer (kukkuu-ui\src\domain\app\footer\Footer.tsx:19:47)
    at div
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at PageLayout (kukkuu-ui\src\domain\app\layout\PageLayout.tsx:19:23)
    at Layout (kukkuu-ui\src\domain\app\Layout.tsx:16:34)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stderr | src/domain/event/enrol/__tests__/SuccessToast.test.tsx > renders snapshot correctly
Warning: findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node
    at Transition (kukkuu-ui\node_modules\react-transition-group\cjs\Transition.js:135:30)
    at CSSTransition (kukkuu-ui\node_modules\react-transition-group\cjs\CSSTransition.js:120:35)
    at SuccessToast (kukkuu-ui\src\domain\event\enrol\SuccessToast.tsx:24:41)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

stderr | src/domain/registration/modal/__tests__/AddNewChildFormModal.test.tsx > renders snapshot correctly
Warning: Li: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Li (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:318591)
    at FormikDropdown (kukkuu-ui\src\common\components\formikWrappers\FormikDropdown.tsx:15:27)
    at form
    at kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1413:22
    at Formik (kukkuu-ui\node_modules\formik\dist\formik.cjs.development.js:1077:19)
    at ChildForm (kukkuu-ui\src\domain\child\form\ChildForm.tsx:43:22)
    at div
    at div
    at div
    at div
    at ModalPortal (kukkuu-ui\node_modules\react-modal\lib\components\ModalPortal.js:79:5)
    at Modal (kukkuu-ui\node_modules\react-modal\lib\components\Modal.js:73:5)
    at div
    at Modal (kukkuu-ui\src\common\components\modal\Modal.tsx:23:18)
    at div
    at ChildFormModal (kukkuu-ui\src\domain\child\modal\ChildFormModal.tsx:19:27)
    at AddNewChildFormModal (kukkuu-ui\src\domain\registration\modal\AddNewChildFormModal.tsx:21:33)
    at Router (kukkuu-ui\node_modules\react-router\dist\development\index.js:5130:13)
    at BrowserRouter (kukkuu-ui\node_modules\react-router\dist\development\index.js:7204:3)
    at _HelmetProvider (kukkuu-ui\node_modules\react-helmet-async\lib\index.js:483:5)
    at ConfigProvider (kukkuu-ui\node_modules\react-helsinki-headless-cms\index.js:95:25)
    at RHHCConfigProviderWithMockedApolloClient (kukkuu-ui\src\common\test\TestProviders.tsx:78:53)
    at ProfileProvider (kukkuu-ui\src\domain\profile\ProfileProvider.tsx:11:28)
    at _t (kukkuu-ui\node_modules\react-idle-timer\dist\index.esm.js:6:21671)
    at IdleTimer (kukkuu-ui\src\domain\auth\IdleTimerProvider.tsx:11:22)
    at Gc (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:485694)
    at exports.LoginProvider (kukkuu-ui\node_modules\hds-react\cjs\index.js:1:869509)
    at KukkuuHDSLoginProvider (kukkuu-ui\src\domain\auth\KukkuuHDSLoginProvider.tsx:13:35)
    at ApolloProvider (kukkuu-ui\node_modules\@apollo\client\react\context\context.cjs:50:21)
    at MockedProvider (kukkuu-ui\node_modules\@apollo\client\testing\testing.cjs:30:28)
    at Provider (file:///kukkuu-ui/node_modules/react-redux/dist/react-redux.mjs:1036:3)
    at TestProviders (kukkuu-ui\src\common\test\TestProviders.tsx:24:13)
    at wrapper (kukkuu-ui\src\common\test\testingLibraryUtils.tsx:8:21)

 ✓ src/common/__tests__/commonUtils.test.tsx (2)
   ✓ converts CRLFs to brs
   ✓ converts LFs to brs
 ✓ src/domain/__tests__/Config.test.tsx (2)
   ✓ Config (2)
     ✓ featureFlagShowCoronaInfo (2)
       ✓ should return true when VITE_FEATURE_FLAG_SHOW_CORONAVIRUS_INFO is true
       ✓ should return false otherwise
 ✓ src/common/AriaLive/__tests__/AriaLive.test.tsx (1) 765ms
   ✓ AriaLive (1) 760ms
     ✓ should update an aria-live region 759ms
 ✓ src/common/time/__tests__/utils.test.tsx (2)
   ✓ Converts human-readable month to zero based
   ✓ Converts human-readable string month to zero based integer
 ✓ src/domain/auth/__tests__/Unauthorized.test.tsx (2)
   ✓ Unauthorized page (2)
     ✓ redirects to profile page if user is authenticated
     ✓ redirects to nextPath URL parameter when it is given
 ✓ src/domain/api/__tests__/client.test.ts (1)
   ✓ graphql client (1)
     ✓ sets Authorization-header to requests from currently authenticated user
 ✓ src/domain/app/__tests__/Layout.test.tsx (1) 402ms
   ✓ renders without crashing 392ms
 ✓ src/domain/child/__tests__/ChildUtils.test.ts (1)
   ✓ ChildUtil (1)
     ✓ getChildFormModalValues (1)
       ✓ does not return fields which are irrelevant
 ✓ src/domain/cookieConsent/__tests__/CookieConsentPage.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/eventGroup/__tests__/EventGroup.test.tsx (6) 1232ms
   ✓ <EventGroup /> (6) 1229ms
     ✓ renders loading if loading
     ✓ renders error if error
     ✓ renders title and description
     ✓ renders events
     ✓ clicking on event should take user to event 957ms
     ✓ sets title to name of event group
 ✓ src/domain/event/__tests__/Event.test.tsx (2)
   ✓ Event (2)
     ✓ utilities (2)
       ✓ getDateOptions should return a list of options without duplicates
       ✓ getTimeOptions should return an ordered list without duplicates
 ✓ src/domain/event/__tests__/EventIsEnrolled.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/__tests__/EventOccurrence.test.tsx (5)
   ✓ renders snapshot correctly
   ✓ renders button for signing up to an event
   ✓ when event is full (3)
     ✓ should show full label instead of remaining capacity
     ✓ and child has not subscribed to notifications (1)
       ✓ user should be able to subscribe
     ✓ and child has subscribed to notifications (1)
       ✓ user should be able to unsubscribe
 ✓ src/domain/event/__tests__/EventOccurrenceList.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/__tests__/EventPage.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/__tests__/EventUtils.test.ts (1)
   ✓ EventUtils (1)
     ✓ formatOccurrenceTime (1)
       ✓ should format correctly
 ✓ src/domain/event/__tests__/VenueFeatures.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/headlessCms/__tests__/client.test.ts (1)
   ✓ Headless CMS Client (1)
     ✓ returns a page when a page query is requested
 ✓ src/domain/home/__tests__/Home.test.tsx (2) 921ms
   ✓ <Home /> (2) 918ms
     ✓ renders snapshot correctly
     ✓ does not show the link to the godchild profile if the user is no longer authenticated 643ms
 ✓ src/domain/profile/__tests__/Profile.test.tsx (2)
   ✓ Profile (2)
     ✓ renders profile correctly
     ✓ redirects to the register section in home page if user is authenticated but has no profile
 ✓ src/domain/profile/__tests__/ProfileUtils.test.ts (1)
   ✓ ProfileUtils (1)
     ✓ normalizeProfileChild (1)
       ✓ input a fetched child and return a child for mutation
 ✓ src/common/components/card/__tests__/Card.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/common/components/button/__tests__/Button.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/common/components/confirm/__tests__/NavigationConfirm.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/common/components/form/__tests__/validationUtils.test.tsx (6)
   ✓ Form validation utilities (6)
     ✓ validatePostalCode (4)
       ✓ postal code has characters
       ✓ postal code is of wrong length
       ✓ postal code should not be empty
       ✓ valid postal code
     ✓ validateRequire (2)
       ✓ will show error if field is empty
       ✓ will show custom error message if field is empty and custom message is defined
 ✓ src/common/components/formikWrappers/__tests__/FormikDropdown.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/common/components/modal/__tests__/Modal.test.tsx (4)
   ✓ renders snapshot correctly
   ✓ renders mandatory field legend by default
   ✓ renders mandatory field legend when asked to
   ✓ omits mandatory field legend when asked to
 ✓ src/common/components/spinner/__tests__/LoadingSpinner.test.tsx (3)
   ✓ renders snapshot correctly
   ✓ render spinner if isLoading is true
   ✓ render child component if isLoading is false
 ✓ src/common/route/utils/__tests__/getPathname.test.ts (9)
   ✓ when pathname is "/" and language is "fi", yields "/"
   ✓ when pathname is "/profile" and language is "fi", yields "/profile"
   ✓ when pathname is "profile" and language is "fi", yields "/profile"
   ✓ when pathname is "/" and language is "sv", yields "/sv"
   ✓ when pathname is "/profile" and language is "sv", yields "/sv/profile"
   ✓ when pathname is "profile" and language is "sv", yields "/sv/profile"
   ✓ when pathname is "/" and language is "en", yields "/en"
   ✓ when pathname is "/profile" and language is "en", yields "/en/profile"
   ✓ when pathname is "profile" and language is "en", yields "/en/profile"
 ✓ src/domain/app/footer/__tests__/Footer.test.tsx (1)
   ✓ Footer matches snapshot
 ✓ src/domain/child/form/__tests__/ChildForm.test.tsx (2)
   ✓ <ChildForm /> (2)
     ✓ as a user I do not want to see the city control when editing
     ✓ implementation details (1)
       ✓ the form should have the noValidate prop so that browser validation is not used
 ✓ src/domain/child/modal/__tests__/ChildFormModal.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/enrol/__tests__/Enrol.test.tsx (5) 491ms
   ✓ <Enrol /> (5) 487ms
     ✓ the user should be able to sign in to an event
     ✓ the user should be able to cancel
     ✓ when the event is full (2)
       ✓ the user should be able to subscribe to notifications
       ✓ should have a special title and description
     ✓ when the event is full and te user has subscribed (1)
       ✓ the user should be able to unsubscribe
 ✓ src/domain/event/enrol/__tests__/SuccessToast.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/eventCard/__tests__/EventCard.test.tsx (6) 1259ms
   ✓ <EventCard /> (6) 1256ms
     ✓ should show event name, short description and image 620ms
     ✓ should show primary action by default and it should map to action 332ms
     ✓ should allow for primary action to be toggled off
     ✓ should show a placeholder image if none is provided
     ✓ should gives highest priority to custom imageElement
     ✓ should show focal content
 ✓ src/domain/event/partial/__tests__/InfoItem.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/event/partial/__tests__/OccurrenceInfo.test.tsx (3)
   ✓ renders snapshot correctly
   ✓ renders occurrence snapshot correctly
   ✓ renders childByIdQuery occurrence snapshot correctly
 ✓ src/domain/home/moreInfo/__tests__/HomeMoreInfo.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/home/moreInfo/__tests__/MoreInfoLinkList.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/home/partners/__tests__/HomePartners.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/home/partners/__tests__/PartnersLogoList.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/home/video/__tests__/HomeVideo.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/profile/events/__tests__/ProfileEvents.test.tsx (5)
   ✓ Renders "No events" when no events"
   ✓ Renders events list when events of any type
   ✓ Renders events list when only upcomingEventsAndEventGroups
   ✓ Renders events list when only enrolments
   ✓ Renders events list when only past events
 ✓ src/domain/profile/events/__tests__/ProfileEventsList.test.tsx (6) 1131ms
   ✓ Renders snapshot correctly
   ✓ Renders only upcoming events and event groups when no other inputs 750ms
   ✓ Renders only enrolments when no other inputs
   ✓ Renders Ticketmaster enrolment
   ✓ Renders Lippupiste enrolment
   ✓ Renders Tixly enrolment
 ✓ src/domain/profile/modal/__tests__/EditProfileModal.test.tsx (2) 2805ms
   ✓ renders snapshot correctly
   ✓ should allow all fields to be filled 2554ms
 ✓ src/domain/registration/form/__tests__/RegistrationForm.test.tsx (3) 1502ms
   ✓ renders snapshot correctly 323ms
   ✓ email field is disabled
   ✓ hasAcceptedCommunication is checked by default 1039ms
 ✓ src/domain/registration/modal/__tests__/AddNewChildFormModal.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/registration/notEligible/__tests__/NotEligible.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/registration/notEligible/__tests__/NotEligibleUtils.test.ts (9)
   ✓ notEligibleUtils.test.ts (9)
     ✓ A random city should not be eligible
     ✓ A random city should be eligible when editing a child
     ✓ Verify that all cities in VITE_ELIGIBLE_CITIES are eligible
     ✓ Verify that cities are eligible even when user adds whitespace
     ✓ Verify that getEligibleCities returns an array of eligible cities
     ✓ Verify that all cities in VITE_ELIGIBLE_CITIES in uppercase are eligible
     ✓ Verify that a date too far into the past is not eligible
     ✓ Verify that a date after supported start date is eligible
     ✓ Verify that an invalid date is not eligible
 ✓ src/domain/registration/welcome/__tests__/Welcome.test.tsx (1)
   ✓ renders snapshot correctly
 ✓ src/domain/app/layout/utilityComponents/__tests__/Page.test.tsx (5)
   ✓ <Page /> (5)
     ✓ should set title
     ✓ should show loading spinner when isLoading is true
     ✓ should show generic error when error is true
     ✓ should show custom error when error is an object
     ✓ should render children when isReady is true

 Test Files  51 passed (51)
      Tests  121 passed (121)
   Start at  09:39:36
   Duration  121.46s (transform 116.49s, setup 1008.13s, collect 470.36s, tests 14.12s, environment 173.42s, prepare 10.49s)
```

<details>

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-1372](https://helsinkisolutionoffice.atlassian.net/browse/KK-1372)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1372]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ