### PR TITLE
KK-1372 | Fix Dart Sass @import/global built-in function deprecation warnings when building

### DIFF
--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -1,20 +1,22 @@
-@import '~hds-design-tokens/lib/breakpoint/all.scss';
+@use "sass:map";
+@use '~hds-design-tokens/lib/breakpoint/all.scss' as hds;
+@use '~styles/variables';
 
 $breakpoints: (
-  xs: $breakpoint-xs,
-  s: $breakpoint-s,
-  m: $breakpoint-m,
-  l: $breakpoint-l,
-  xl-minus: $container-width-xl,
-  xl: $breakpoint-xl,
-  xxl: 1600px, // $container-width-xl * 4 / 3
+  xs: hds.$breakpoint-xs,
+  s: hds.$breakpoint-s,
+  m: hds.$breakpoint-m,
+  l: hds.$breakpoint-l,
+  xl-minus: hds.$container-width-xl,
+  xl: hds.$breakpoint-xl,
+  xxl: 1600px, // hds.$container-width-xl * 4 / 3
 );
 
 @mixin respond-above($breakpoint) {
   // If the breakpoint exists in the map.
-  @if map-has-key($breakpoints, $breakpoint) {
+  @if map.has-key($breakpoints, $breakpoint) {
     // Get the breakpoint value.
-    $breakpoint-value: map-get($breakpoints, $breakpoint);
+    $breakpoint-value: map.get($breakpoints, $breakpoint);
 
     // Write the media query.
     @media (min-width: $breakpoint-value) {
@@ -30,9 +32,9 @@ $breakpoints: (
 
 @mixin respond-below($breakpoint) {
   // If the breakpoint exists in the map.
-  @if map-has-key($breakpoints, $breakpoint) {
+  @if map.has-key($breakpoints, $breakpoint) {
     // Get the breakpoint value.
-    $breakpoint-value: map-get($breakpoints, $breakpoint);
+    $breakpoint-value: map.get($breakpoints, $breakpoint);
 
     // Write the media query.
     @media (max-width: ($breakpoint-value - 1)) {
@@ -53,10 +55,10 @@ $breakpoints: (
 // @include respond-between(s, m) {}
 @mixin respond-between($lower, $upper) {
   // If both the lower and upper breakpoints exist in the map.
-  @if map-has-key($breakpoints, $lower) and map-has-key($breakpoints, $upper) {
+  @if map.has-key($breakpoints, $lower) and map.has-key($breakpoints, $upper) {
     // Get the lower and upper breakpoints.
-    $lower-breakpoint: map-get($breakpoints, $lower);
-    $upper-breakpoint: map-get($breakpoints, $upper);
+    $lower-breakpoint: map.get($breakpoints, $lower);
+    $upper-breakpoint: map.get($breakpoints, $upper);
 
     // Write the media query.
     @media (min-width: $lower-breakpoint) and (max-width: ($upper-breakpoint - 1)) {
@@ -66,13 +68,13 @@ $breakpoints: (
     // If one or both of the breakpoints don't exist.
   } @else {
     // If lower breakpoint is invalid.
-    @if (map-has-key($breakpoints, $lower) == false) {
+    @if (map.has-key($breakpoints, $lower) == false) {
       // Log a warning.
       @warn 'Your lower breakpoint was invalid: #{$lower}.';
     }
 
     // If upper breakpoint is invalid.
-    @if (map-has-key($breakpoints, $upper) == false) {
+    @if (map.has-key($breakpoints, $upper) == false) {
       // Log a warning.
       @warn 'Your upper breakpoint was invalid: #{$upper}.';
     }
@@ -82,7 +84,7 @@ $breakpoints: (
 @mixin formContainer() {
   @include respond-above(m) {
     display: grid;
-    grid-template-columns: 1fr minmax(auto, $containerFormMaxWidth) 1fr;
+    grid-template-columns: 1fr minmax(auto, variables.$containerFormMaxWidth) 1fr;
 
     > * {
       grid-column: 2;
@@ -97,6 +99,6 @@ $breakpoints: (
     grid-column: 2;
   }
   @include respond-above(l) {
-    grid-template-columns: 1fr minmax(auto, $containerFormMaxWidth) 1fr;
+    grid-template-columns: 1fr minmax(auto, variables.$containerFormMaxWidth) 1fr;
   }
 }

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,16 +1,16 @@
-@import '~styles/fonts';
-@import '~styles/variables';
+@use '~styles/fonts';
+@use '~styles/variables';
 
 // Override globally all text to use Helsinki font.
 
 * {
-  font-family: $font-family-base;
+  font-family: fonts.$font-family-base;
 }
 
 p,
 span,
 li {
-  line-height: $baseLineHeight;
+  line-height: variables.$baseLineHeight;
 }
 
 #cookie-consent-language-selector-button {

--- a/src/assets/styles/mixins.scss
+++ b/src/assets/styles/mixins.scss
@@ -1,5 +1,5 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 /*
  * Pure CSS spinner, taken from:
@@ -17,7 +17,7 @@
 * You should use it in pseudo element, see sample below
 */
 @mixin add_spinner(
-  $size: $spinnerHeight,
+  $size: variables.$spinnerHeight,
   $main-color: var(--color-black-30),
   $alt-color: var(--color-black-90),
   $thickness: 2px

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -1,4 +1,5 @@
-@import '~hds-design-tokens/lib/all.scss';
+@use '~hds-design-tokens/lib/all.scss' as hds;
+@forward '~hds-design-tokens/lib/all.scss';
 
 $basePadding: 1rem;
 $largePadding: 3rem;
@@ -18,7 +19,7 @@ $imgHeight: 1.5rem;
 
 // Layout
 // (Designer proposal)
-$containerMaxWidth: $container-width-xl;
+$containerMaxWidth: hds.$container-width-xl;
 $containerFormMaxWidth: 800px;
 
 // Line height

--- a/src/common/components/alert/alertModal.module.scss
+++ b/src/common/components/alert/alertModal.module.scss
@@ -1,9 +1,9 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .modal {
   text-align: center;
 }
 
 .okButton {
-  margin: $largeMargin 0;
+  margin: variables.$largeMargin 0;
 }

--- a/src/common/components/button/buttonOverrides.module.scss
+++ b/src/common/components/button/buttonOverrides.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .button {
   --color: var(--color-black);

--- a/src/common/components/card/card.module.scss
+++ b/src/common/components/card/card.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .wrapper {
   display: flex;
@@ -7,7 +7,7 @@
   column-gap: var(--spacing-xl);
   background: var(--color-white);
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     display: grid;
     grid-template-columns: 2fr 10fr 1fr;
     align-items: center;
@@ -20,7 +20,7 @@
 .image {
   margin-bottom: unset;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     width: 20vw;
     height: 20vw;
     min-width: 200px;
@@ -62,7 +62,7 @@
 .cta {
   display: none;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     display: block;
     justify-self: center;
   }

--- a/src/common/components/confirm/confirmModal.module.scss
+++ b/src/common/components/confirm/confirmModal.module.scss
@@ -1,24 +1,24 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .modal {
   text-align: center;
 }
 
 .buttonGroup {
-  margin: $largeMargin 0;
+  margin: variables.$largeMargin 0;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     display: grid;
-    grid-gap: $baseMargin;
+    grid-gap: variables.$baseMargin;
     grid-auto-flow: column;
   }
 
-  @include respond-below(m) {
+  @include layout.respond-below(m) {
     display: flex;
     flex-direction: column-reverse;
     .okButton {
-      margin-bottom: $baseMargin;
+      margin-bottom: variables.$baseMargin;
     }
   }
 }

--- a/src/common/components/error/error.module.scss
+++ b/src/common/components/error/error.module.scss
@@ -1,10 +1,10 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .error {
-  margin: $baseMargin;
-  @include respond-above(m) {
+  margin: variables.$baseMargin;
+  @include layout.respond-above(m) {
     grid-column: 2;
-    margin: $baseMargin 0;
+    margin: variables.$baseMargin 0;
   }
 }

--- a/src/common/components/formikWrappers/formikInputs.module.scss
+++ b/src/common/components/formikWrappers/formikInputs.module.scss
@@ -1,7 +1,7 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .formField {
-  padding-bottom: $basePadding;
+  padding-bottom: variables.$basePadding;
 }
 
 /* Hide number input spinners */

--- a/src/common/components/giveFeedbackButton/giveFeedbackButton.module.scss
+++ b/src/common/components/giveFeedbackButton/giveFeedbackButton.module.scss
@@ -1,10 +1,10 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .container {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-top: $spacing-layout-l;
+  margin-top: variables.$spacing-layout-l;
 }
 
 .buttonLink {

--- a/src/common/components/icon/icon.module.scss
+++ b/src/common/components/icon/icon.module.scss
@@ -1,8 +1,8 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .imgWrapper {
-  height: $imgHeight;
-  width: $imgHeight;
+  height: variables.$imgHeight;
+  width: variables.$imgHeight;
   display: flex;
   justify-items: center;
   align-items: center;

--- a/src/common/components/modal/modal.module.scss
+++ b/src/common/components/modal/modal.module.scss
@@ -1,6 +1,6 @@
-@import '~styles/fonts';
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/fonts';
+@use '~styles/layout';
+@use '~styles/variables';
 
 $modalPadding: 2rem;
 $modalWidthLg: 800px;
@@ -8,7 +8,7 @@ $modalWidthLg: 800px;
 .modal {
   position: relative;
 
-  background-color: var(--color-white);
+  background-color: variables.$color-white;
   margin: auto;
 
   &:focus {
@@ -16,14 +16,14 @@ $modalWidthLg: 800px;
   }
 
   // Make tab-key jump between fields
-  @include respond-below(l) {
+  @include layout.respond-below(l) {
     position: fixed;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
   }
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     width: $modalWidthLg;
   }
 }
@@ -49,7 +49,7 @@ $modalWidthLg: 800px;
   display: flex;
   justify-content: flex-end;
 
-  @include respond-below(l) {
+  @include layout.respond-below(l) {
     z-index: 1;
     position: relative;
   }
@@ -57,23 +57,23 @@ $modalWidthLg: 800px;
   button {
     padding: 0;
     border: none;
-    height: $largeMargin;
-    width: $largeMargin;
+    height: variables.$largeMargin;
+    width: variables.$largeMargin;
   }
 }
 
 .modalContent {
-  background-color: var(--color-white);
-  padding: $basePadding $largePadding;
+  background-color: variables.$color-white;
+  padding: variables.$basePadding variables.$largePadding;
 
-  @include respond-below(l) {
+  @include layout.respond-below(l) {
     // Ensure that modal is vertically scrollable on mobile
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    padding: $largePadding 0;
+    padding: variables.$largePadding 0;
     overflow: auto;
   }
 }
@@ -81,7 +81,7 @@ $modalWidthLg: 800px;
 .modalChildren {
   padding: 0 $modalPadding;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     padding: 0 $modalPadding;
   }
 }
@@ -90,13 +90,13 @@ $modalWidthLg: 800px;
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin: 0 0 $largeMargin 0;
+  margin: 0 0 variables.$largeMargin 0;
   padding: 0 $modalPadding;
 
   .icon {
-    height: $largeMargin;
-    width: $largeMargin;
-    margin-right: $baseMargin;
+    height: variables.$largeMargin;
+    width: variables.$largeMargin;
+    margin-right: variables.$baseMargin;
   }
 
   h1 {

--- a/src/common/components/placeholderImage/placeholderImage.module.scss
+++ b/src/common/components/placeholderImage/placeholderImage.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .placeholderImage {
   display: flex;
@@ -7,7 +7,7 @@
   width: 100%;
   height: 100%;
 
-  background-color: $color-summer;
+  background-color: variables.$color-summer;
 
   & > img {
     max-width: 9rem;

--- a/src/common/components/spinner/loadingSpinner.module.scss
+++ b/src/common/components/spinner/loadingSpinner.module.scss
@@ -1,4 +1,5 @@
-@import '~styles/mixins';
+@use '~styles/variables';
+@use '~styles/mixins';
 
 .spinnerWrapper {
   display: flex;
@@ -11,10 +12,10 @@
 
 .spinner {
   position: relative;
-  height: $spinnerHeight;
-  width: $spinnerHeight;
+  height: variables.$spinnerHeight;
+  width: variables.$spinnerHeight;
 
   &::before {
-    @include add_spinner();
+    @include mixins.add_spinner();
   }
 }

--- a/src/common/components/text/text.module.scss
+++ b/src/common/components/text/text.module.scss
@@ -1,64 +1,64 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .text {
-  color: $color-black-90;
+  color: variables.$color-black-90;
 }
 .text:last-child {
   margin-bottom: 0;
 }
 
 .h1 {
-  margin: 0 0 $spacing-s 0;
+  margin: 0 0 variables.$spacing-s 0;
 
-  font-size: $fontsize-heading-l;
-  line-height: $lineheight-l;
+  font-size: variables.$fontsize-heading-l;
+  line-height: variables.$lineheight-l;
 
-  @include respond-above(s) {
-    font-size: $fontsize-heading-xl;
+  @include layout.respond-above(s) {
+    font-size: variables.$fontsize-heading-xl;
   }
 }
 
 .h2 {
-  margin: 0 0 $spacing-s 0;
+  margin: 0 0 variables.$spacing-s 0;
 
-  font-size: $fontsize-heading-l;
+  font-size: variables.$fontsize-heading-l;
 }
 
 .h3 {
-  margin: 0 0 $spacing-s 0;
+  margin: 0 0 variables.$spacing-s 0;
 
-  font-size: $fontsize-heading-m;
+  font-size: variables.$fontsize-heading-m;
   font-weight: 600;
 }
 
 .h4 {
-  margin: 0 0 $spacing-s 0;
+  margin: 0 0 variables.$spacing-s 0;
 
-  font-size: $fontsize-heading-s;
+  font-size: variables.$fontsize-heading-s;
 }
 
 .h5 {
-  margin: 0 0 $spacing-s 0;
+  margin: 0 0 variables.$spacing-s 0;
 
-  font-size: $fontsize-heading-xs;
+  font-size: variables.$fontsize-heading-xs;
 }
 
 .body-l {
-  margin: 0 0 $spacing-l 0;
+  margin: 0 0 variables.$spacing-l 0;
 
-  font-size: $fontsize-body-l;
-  line-height: $lineheight-l;
+  font-size: variables.$fontsize-body-l;
+  line-height: variables.$lineheight-l;
   white-space: pre-wrap;
 }
 
 .body {
-  font-size: $fontsize-body-m;
+  font-size: variables.$fontsize-body-m;
   white-space: pre-wrap;
 }
 
 .body-xl {
-  font-size: $fontsize-body-xl;
+  font-size: variables.$fontsize-body-xl;
   font-weight: 400;
   white-space: pre-wrap;
 }

--- a/src/domain/app/footer/footer.module.scss
+++ b/src/domain/app/footer/footer.module.scss
@@ -1,7 +1,7 @@
-@import '~styles/mixins';
-@import '~styles/variables';
-@import '~styles/fonts';
-@import '~styles/layout';
+@use '~styles/mixins';
+@use '~styles/variables';
+@use '~styles/fonts';
+@use '~styles/layout';
 
 .footer {
   overflow: hidden;

--- a/src/domain/app/layout/container.module.scss
+++ b/src/domain/app/layout/container.module.scss
@@ -1,11 +1,11 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .container {
   display: grid;
 }
 
-@include respond-between(m, xxl) {
+@include layout.respond-between(m, xxl) {
   .container {
     grid-template-columns: 1fr 10fr 1fr;
 
@@ -15,9 +15,9 @@
   }
 }
 
-@include respond-above(xxl) {
+@include layout.respond-above(xxl) {
   .container {
-    grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
+    grid-template-columns: 1fr minmax(auto, variables.$containerMaxWidth) 1fr;
 
     & > * {
       grid-column: 2;

--- a/src/domain/app/layout/listPageLayout.module.scss
+++ b/src/domain/app/layout/listPageLayout.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~hds-design-tokens/lib/all.scss';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .wrapper {
   display: flex;
@@ -13,25 +13,23 @@
 .container {
   display: flex;
   flex-direction: column;
-  row-gap: var(--spacing-layout-s);
+  row-gap: variables.$spacing-layout-s;
 
-  padding: 0 var(--spacing-2-xs) 0 var(--spacing-s);
+  padding: 0 variables.$spacing-2-xs 0 variables.$spacing-s;
   margin: 0 auto;
-  max-width: var(--breakpoint-xl);
+  max-width: variables.$breakpoint-xl;
 
-  @include respond-above(m) {
-    row-gap: var(--spacing-layout-m);
+  @include layout.respond-above(m) {
+    row-gap: variables.$spacing-layout-m;
 
-    padding: 0 var(--spacing-m);
+    padding: 0 variables.$spacing-m;
   }
 }
 
 $backButtonWidth: 5 * 16px;
-$backButtonAsideBreakpoint: calc($backButtonWidth + $breakpoint-xl);
+$backButtonAsideBreakpoint: $backButtonWidth + variables.$breakpoint-xl;
 
 .header {
-  --back-button-width: #{$backButtonWidth};
-
   display: grid;
   grid-template-columns: 1fr auto;
   grid-template-rows: auto auto auto auto;
@@ -40,10 +38,10 @@ $backButtonAsideBreakpoint: calc($backButtonWidth + $breakpoint-xl);
     'title title'
     'content content'
     'actions actions';
-  row-gap: var(--spacing-layout-xs);
+  row-gap: variables.$spacing-layout-xs;
   align-items: center;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     grid-template-rows: auto auto;
     grid-template-areas:
       'backButton backButton'
@@ -52,12 +50,12 @@ $backButtonAsideBreakpoint: calc($backButtonWidth + $breakpoint-xl);
   }
 
   @media screen and (min-width: $backButtonAsideBreakpoint) {
-    grid-template-columns: var(--back-button-width) 1fr auto;
+    grid-template-columns: $backButtonWidth 1fr auto;
     grid-template-areas:
       'backButton title actions'
       'empty content content';
 
-    margin-left: calc(#{var(--back-button-width)} * -1);
+    margin-left: $backButtonWidth * -1;
   }
 
   & .headerBackButtonContainer {
@@ -73,7 +71,7 @@ $backButtonAsideBreakpoint: calc($backButtonWidth + $breakpoint-xl);
     grid-area: actions;
   }
 
-  margin-top: var(--spacing-layout-s);
+  margin-top: variables.$spacing-layout-s;
 
   // Remove margin from text elements so that we can control them with
   // gaps.
@@ -85,7 +83,7 @@ $backButtonAsideBreakpoint: calc($backButtonWidth + $breakpoint-xl);
 .headerActions {
   display: flex;
   align-items: center;
-  column-gap: var(--spacing-l);
+  column-gap: variables.$spacing-l;
 }
 
 .headerBackButton {
@@ -93,10 +91,10 @@ $backButtonAsideBreakpoint: calc($backButtonWidth + $breakpoint-xl);
   align-items: center;
   justify-content: center;
 
-  padding: var(--spacing-s);
+  padding: variables.$spacing-s;
 
-  color: var(--color-text);
+  color: variables.$color-black-90;
 
-  background: var(--color-white);
+  background: variables.$color-white;
   border-radius: 100%;
 }

--- a/src/domain/app/layout/pageLayout.module.scss
+++ b/src/domain/app/layout/pageLayout.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 body {
   margin: 0;

--- a/src/domain/app/layout/utilityComponents/heroLayout.module.scss
+++ b/src/domain/app/layout/utilityComponents/heroLayout.module.scss
@@ -1,6 +1,5 @@
-@import '~styles/variables';
-@import '~styles/fonts';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .wrapper {
   width: 100%;
@@ -8,9 +7,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-bottom: $spacing-layout-2-xl;
+  padding-bottom: variables.$spacing-layout-2-xl;
 
-  background-color: $color-black-5;
+  background-color: variables.$color-black-5;
 }
 
 .heroBackground {
@@ -21,13 +20,13 @@
   height: 26rem;
   min-height: 20%;
 
-  background-color: $color-summer;
+  background-color: variables.$color-summer;
 }
 
 .backButtonInnerWrapper {
   grid-column: 1;
   padding-top: 2rem;
-  width: $logoWidth;
+  width: variables.$logoWidth;
   display: flex;
   justify-content: center;
 
@@ -46,11 +45,11 @@
 
 .main {
   width: 100%;
-  max-width: $containerMaxWidth;
+  max-width: variables.$containerMaxWidth;
   display: grid;
   position: relative;
 
-  @include respond-above(xl-minus) {
+  @include layout.respond-above(xl-minus) {
     grid-template-columns: 1fr 10fr 1fr;
 
     & > .content {

--- a/src/domain/app/layout/utilityComponents/infoTemplate.module.scss
+++ b/src/domain/app/layout/utilityComponents/infoTemplate.module.scss
@@ -1,9 +1,9 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .infoPageLayout {
-  @include respond-below(l) {
-    margin: 0 $baseMargin $largeMargin $baseMargin;
+  @include layout.respond-below(l) {
+    margin: 0 variables.$baseMargin variables.$largeMargin variables.$baseMargin;
   }
 
   display: flex;
@@ -11,30 +11,30 @@
   align-items: center;
   justify-content: center;
 
-  color: $color-black-90;
+  color: variables.$color-black-90;
 
   .infoPageLayoutFace {
-    height: $spacing-5-xl;
-    width: $spacing-5-xl;
-    margin: 0 0 $spacing-m 0;
+    height: variables.$spacing-5-xl;
+    width: variables.$spacing-5-xl;
+    margin: 0 0 variables.$spacing-m 0;
   }
 
   .infoPageLayoutTitle {
-    font-size: $fontsize-heading-xl;
+    font-size: variables.$fontsize-heading-xl;
   }
 
   .infoPageLayoutDescription {
-    max-width: $container-width-m;
+    max-width: variables.$container-width-m;
     margin-top: 0;
-    margin-bottom: $spacing-xl;
+    margin-bottom: variables.$spacing-xl;
 
-    font-size: $fontsize-body-l;
+    font-size: variables.$fontsize-body-l;
     text-align: center;
   }
 }
 
 .callToActionButton {
-  margin: 2 * $baseMargin;
+  margin: 2 * variables.$baseMargin;
   width: min-content;
-  max-width: $container-width-s;
+  max-width: variables.$container-width-s;
 }

--- a/src/domain/app/layout/utilityComponents/simpleFormTemplate.module.scss
+++ b/src/domain/app/layout/utilityComponents/simpleFormTemplate.module.scss
@@ -1,9 +1,9 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .simpleFormPageLayout {
-  @include respond-below(l) {
-    margin: 0 $baseMargin $largeMargin $baseMargin;
+  @include layout.respond-below(l) {
+    margin: 0 variables.$baseMargin variables.$largeMargin variables.$baseMargin;
   }
 
   display: flex;
@@ -11,29 +11,29 @@
   align-items: center;
   justify-content: center;
 
-  color: $color-black-90;
+  color: variables.$color-black-90;
 
   .simpleFormPageLayoutFace {
-    height: $spacing-5-xl;
-    width: $spacing-5-xl;
-    margin: 0 0 $spacing-m 0;
+    height: variables.$spacing-5-xl;
+    width: variables.$spacing-5-xl;
+    margin: 0 0 variables.$spacing-m 0;
   }
 
   .simpleFormPageLayoutTitle {
-    font-size: $fontsize-heading-xl;
+    font-size: variables.$fontsize-heading-xl;
   }
 
   .simpleFormPageLayoutDescription {
-    max-width: $container-width-m;
+    max-width: variables.$container-width-m;
     margin-top: 0;
-    margin-bottom: $spacing-xl;
+    margin-bottom: variables.$spacing-xl;
 
-    font-size: $fontsize-body-l;
+    font-size: variables.$fontsize-body-l;
     text-align: center;
   }
   button[type='submit'] {
-    margin: 2 * $baseMargin;
+    margin: 2 * variables.$baseMargin;
     width: min-content;
-    max-width: $container-width-s;
+    max-width: variables.$container-width-s;
   }
 }

--- a/src/domain/app/navigation/userNavigation.module.scss
+++ b/src/domain/app/navigation/userNavigation.module.scss
@@ -1,7 +1,7 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .hideBelowSmall {
-  @include respond-below(s) {
+  @include layout.respond-below(s) {
     display: none;
   }
 }

--- a/src/domain/app/notFound/notFound.module.scss
+++ b/src/domain/app/notFound/notFound.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .notFound {
   text-align: center;
@@ -7,23 +7,23 @@
 
   .returnLink {
     width: 50%;
-    @include respond-below(m) {
+    @include layout.respond-below(m) {
       width: 80%;
     }
 
     display: block;
-    margin: $largeMargin auto auto auto;
-    background: var(--color-summer);
+    margin: variables.$largeMargin auto auto auto;
+    background: variables.$color-summer;
     box-sizing: border-box;
     text-decoration: none;
-    padding: $basePadding;
-    color: var(--color-black);
+    padding: variables.$basePadding;
+    color: variables.$color-black;
   }
 }
 
 .icon {
   display: block;
   margin: 0 auto;
-  height: $largeMargin;
-  width: $largeMargin;
+  height: variables.$largeMargin;
+  width: variables.$largeMargin;
 }

--- a/src/domain/child/form/childForm.module.scss
+++ b/src/domain/child/form/childForm.module.scss
@@ -1,13 +1,13 @@
-@import '~styles/variables';
-@import '~styles/layout';
-@import '~styles/fonts';
+@use '~styles/variables';
+@use '~styles/layout';
+@use '~styles/fonts';
 
 .childName,
 .childInfo {
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     display: grid;
     grid-template-columns: 1fr;
-    grid-gap: $baseMargin;
+    grid-gap: variables.$baseMargin;
   }
 }
 
@@ -16,9 +16,9 @@
   flex-direction: column;
 
   label {
-    font-size: $font-size-sm;
-    margin-bottom: $baseMargin * 0.25;
-    font-weight: $font-weight-bold;
+    font-size: fonts.$font-size-sm;
+    margin-bottom: variables.$baseMargin * 0.25;
+    font-weight: fonts.$font-weight-bold;
   }
 
   p {
@@ -28,7 +28,7 @@
 }
 
 .deleteChildButton {
-  margin-bottom: $largeMargin;
+  margin-bottom: variables.$largeMargin;
   // Ensure that text is correctly left aligned despite HDS
   // extra whitespace
   transform: translateX(calc(var(--spacing-m) * -1));
@@ -40,37 +40,37 @@
 }
 
 .formField {
-  padding-bottom: $basePadding;
+  padding-bottom: variables.$basePadding;
 }
 
 .buttonGroup {
-  margin: $largeMargin 0;
+  margin: variables.$largeMargin 0;
 }
 
 .editChildButtons {
   display: grid;
-  grid-gap: $baseMargin;
+  grid-gap: variables.$baseMargin;
 
   button {
     width: 100% !important;
   }
   .submitButton {
-    @include respond-below(m) {
+    @include layout.respond-below(m) {
       grid-row: 1;
     }
   }
 
   .cancelButton {
-    @include respond-below(m) {
+    @include layout.respond-below(m) {
       grid-row: 2;
     }
   }
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     grid-auto-flow: column;
   }
 
-  @include respond-below(m) {
+  @include layout.respond-below(m) {
     grid-auto-flow: row;
   }
 }
@@ -83,7 +83,7 @@
 
 .submitButton {
   width: 80%;
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     width: 60%;
   }
 }

--- a/src/domain/child/modal/alert/nonEligible/childAlertNonEligibleModal.module.scss
+++ b/src/domain/child/modal/alert/nonEligible/childAlertNonEligibleModal.module.scss
@@ -1,8 +1,8 @@
-@import '~styles/variables';
+@use '~styles/variables';
 
 .icon {
   display: block;
-  margin: $largeMargin auto;
-  height: $largeMargin;
-  width: $largeMargin;
+  margin: variables.$largeMargin auto;
+  height: variables.$largeMargin;
+  width: variables.$largeMargin;
 }

--- a/src/domain/event/enrol/enrol.module.scss
+++ b/src/domain/event/enrol/enrol.module.scss
@@ -1,8 +1,8 @@
-@import '~styles/variables';
-@import '~styles/fonts';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/fonts';
+@use '~styles/layout';
 
-$max-text-width: $container-width-s;
+$max-text-width: variables.$container-width-s;
 
 .wrapper {
   background: var(--color-black-5);
@@ -10,13 +10,13 @@ $max-text-width: $container-width-s;
   justify-items: center;
   grid-template-rows: min-content;
 
-  @include respond-above(m) {
-    padding: $largePadding;
+  @include layout.respond-above(m) {
+    padding: variables.$largePadding;
   }
 }
 
 .enrolContainer {
-  max-width: $container-width-m;
+  max-width: variables.$container-width-m;
   padding-bottom: 0;
 
   background: var(--color-white);
@@ -24,7 +24,7 @@ $max-text-width: $container-width-s;
 
 .enrolWrapper {
   background: var(--color-white);
-  padding: $spacing-3-xl $spacing-l;
+  padding: variables.$spacing-3-xl variables.$spacing-l;
   display: grid;
   justify-items: center;
 }
@@ -33,38 +33,38 @@ $max-text-width: $container-width-s;
   margin: 0;
   max-width: $max-text-width;
 
-  font-size: $fontsize-heading-l;
+  font-size: variables.$fontsize-heading-l;
   text-align: center;
 }
 
 .text {
   margin: 2rem 0;
   max-width: $max-text-width;
-  line-height: $lineheight-l;
+  line-height: variables.$lineheight-l;
 
-  font-size: $fontsize-body-l;
+  font-size: variables.$fontsize-body-l;
   text-align: center;
 }
 
 .occurrenceInfo {
   box-sizing: border-box;
-  background: $color-fog-medium-light;
-  padding: $spacing-xs;
+  background: variables.$color-fog-medium-light;
+  padding: variables.$spacing-xs;
   width: 100%;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     width: unset;
   }
 }
 
 .actions {
-  margin-top: $spacing-s;
+  margin-top: variables.$spacing-s;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     max-width: 55%;
   }
   button {
-    margin-top: $baseMargin;
+    margin-top: variables.$baseMargin;
     width: 100%;
   }
 }

--- a/src/domain/event/enrol/successToast.module.scss
+++ b/src/domain/event/enrol/successToast.module.scss
@@ -1,6 +1,6 @@
-@import '~styles/fonts';
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/fonts';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .successToast {
   background-color: var(--color-white);
@@ -14,7 +14,7 @@
   top: -25rem;
   text-align: center;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     position: inherit;
 
     justify-self: center;

--- a/src/domain/event/event.module.scss
+++ b/src/domain/event/event.module.scss
@@ -1,16 +1,16 @@
-@import '~styles/variables';
-@import '~styles/fonts';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/fonts';
+@use '~styles/layout';
 
-@include respond-between(l, xxl) {
+@include layout.respond-between(l, xxl) {
   .heroWrapper {
     grid-template-columns: 1fr 10fr 1fr;
   }
 }
 
-@include respond-above(xxl) {
+@include layout.respond-above(xxl) {
   .heroWrapper {
-    grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
+    grid-template-columns: 1fr minmax(auto, variables.$containerMaxWidth) 1fr;
   }
 }
 
@@ -23,7 +23,7 @@
 .backButtonInnerWrapper {
   grid-column: 1;
   padding-top: 2rem;
-  width: $logoWidth;
+  width: variables.$logoWidth;
   display: flex;
   justify-content: center;
 
@@ -44,7 +44,7 @@
   background: var(--color-black-5);
 
   margin-top: 20rem;
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     margin-top: 12rem;
   }
 }
@@ -59,46 +59,46 @@
 }
 
 .signup {
-  margin: $baseMargin 0;
+  margin: variables.$baseMargin 0;
   form {
     display: grid;
-    grid-gap: $baseMargin;
+    grid-gap: variables.$baseMargin;
     grid-template-columns: auto;
-    @include respond-above(s) {
+    @include layout.respond-above(s) {
       grid-template-columns: auto auto;
     }
-    @include respond-above(l) {
+    @include layout.respond-above(l) {
       grid-template-columns: 3fr minmax(170px, 2fr) 40%;
     }
   }
 }
 
 .dateField {
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     min-width: 15rem;
   }
 }
 
 .eventWrapper {
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     z-index: 1;
   }
   display: grid;
   .event {
-    @include respond-above(l) {
-      padding: $largePadding;
+    @include layout.respond-above(l) {
+      padding: variables.$largePadding;
       h1 {
         margin-top: 0;
       }
     }
     background-color: var(--color-white);
   }
-  @include respond-below(l) {
-    padding: 0 $basePadding;
+  @include layout.respond-below(l) {
+    padding: 0 variables.$basePadding;
     background: var(--color-white);
     padding-bottom: 5rem;
   }
-  @include respond-above(xl-minus) {
+  @include layout.respond-above(xl-minus) {
     grid-template-columns: 1fr 10fr 1fr;
 
     .event {
@@ -108,19 +108,19 @@
 }
 
 .occurrenceInfo {
-  background: $color-fog-medium-light;
+  background: variables.$color-fog-medium-light;
   box-sizing: border-box;
-  padding: $spacing-2-xs;
+  padding: variables.$spacing-2-xs;
 
   width: 100%;
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     width: auto;
   }
   display: block;
   .label {
     display: inline-flex;
     width: min-content;
-    @include respond-above(m) {
+    @include layout.respond-above(m) {
       > * {
         margin-left: 0;
       }
@@ -128,13 +128,13 @@
   }
   & > * {
     margin-left: 0;
-    margin-right: $baseMargin;
+    margin-right: variables.$baseMargin;
   }
 }
 
 .participantsPerInvite {
-  font-weight: $font-weight-bold;
-  margin: $baseMargin 0;
+  font-weight: fonts.$font-weight-bold;
+  margin: variables.$baseMargin 0;
 }
 
 .cancelButtonWrapper {
@@ -146,14 +146,14 @@
     width: 100%;
   }
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     justify-content: normal;
   }
 }
 
 .divider {
-  margin-top: $spacing-m;
-  margin-bottom: $spacing-l;
+  margin-top: variables.$spacing-m;
+  margin-bottom: variables.$spacing-l;
 }
 
 .externalTicketSystemButtons {
@@ -166,10 +166,10 @@
   }
 
   & > *:not(:last-child) {
-    margin-bottom: $spacing-s;
+    margin-bottom: variables.$spacing-s;
   }
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     flex-direction: row;
 
     & > * {
@@ -178,7 +178,7 @@
 
     & > *:not(:last-child) {
       margin-bottom: 0;
-      margin-right: $spacing-s;
+      margin-right: variables.$spacing-s;
     }
   }
 }

--- a/src/domain/event/eventOccurrence.module.scss
+++ b/src/domain/event/eventOccurrence.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .linkButton {
   text-decoration: none;
@@ -16,7 +16,7 @@ tr {
   display: none;
 
   & {
-    @include respond-above(l) {
+    @include layout.respond-above(l) {
       display: table-row;
     }
   }
@@ -30,19 +30,19 @@ tr {
       grid-column: 1 / -1;
     }
 
-    @include respond-above(l) {
+    @include layout.respond-above(l) {
       display: none;
     }
   }
 }
 
-@include respond-above(l) {
+@include layout.respond-above(l) {
   table {
     border-collapse: collapse;
   }
   th,
   td {
-    padding: $basePadding 0;
+    padding: variables.$basePadding 0;
     &.occurrenceSubmit {
       // Needs to be wide enough to facilitate the widest possible,
       // button label in each language
@@ -55,7 +55,7 @@ tr {
     }
   }
 }
-@include respond-below(l) {
+@include layout.respond-below(l) {
   tr {
     padding: 1rem 0;
   }

--- a/src/domain/event/eventOccurrenceList.module.scss
+++ b/src/domain/event/eventOccurrenceList.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .eventOccurrenceList {
   width: 100%;
@@ -10,10 +10,10 @@
 
   tr.mobileHeader,
   tr.desktopHeader {
-    border-bottom: 4px solid $color-summer;
+    border-bottom: 4px solid variables.$color-summer;
   }
 
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     tr.mobileHeader {
       display: none;
     }
@@ -21,7 +21,7 @@
       text-align: center;
     }
   }
-  @include respond-below(l) {
+  @include layout.respond-below(l) {
     padding: 0 0.2rem;
     table,
     thead,

--- a/src/domain/event/eventParticipantsPerInvite.module.scss
+++ b/src/domain/event/eventParticipantsPerInvite.module.scss
@@ -1,16 +1,15 @@
-@import '~styles/variables';
-@import '~styles/variables';
+@use '~styles/variables';
 
 .participantsPerInvite {
-  padding: $spacing-s;
+  padding: variables.$spacing-s;
   display: flex;
   align-items: center;
 
   font-weight: 500;
 
-  background: $color-fog-medium-light;
+  background: variables.$color-fog-medium-light;
 
   & > * {
-    margin-right: $spacing-2-xs;
+    margin-right: variables.$spacing-2-xs;
   }
 }

--- a/src/domain/event/eventRedirect.module.scss
+++ b/src/domain/event/eventRedirect.module.scss
@@ -1,21 +1,21 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .wrapper {
   align-self: flex-start;
-  padding: $spacing-layout-s $spacing-layout-xs;
-  margin: $spacing-layout-s auto;
+  padding: variables.$spacing-layout-s variables.$spacing-layout-xs;
+  margin: variables.$spacing-layout-s auto;
   max-width: 44.5rem;
 
-  background-color: $color-white;
+  background-color: variables.$color-white;
 
   h1,
   h2 {
-    margin-bottom: $spacing-l;
+    margin-bottom: variables.$spacing-l;
   }
 
-  @include respond-above(m) {
-    padding: $spacing-layout-m $spacing-layout-l;
+  @include layout.respond-above(m) {
+    padding: variables.$spacing-layout-m variables.$spacing-layout-l;
   }
 
   .acquireButtonRow {
@@ -24,7 +24,7 @@
     flex-direction: column;
 
     &:not(:last-child) {
-      margin-bottom: $spacing-3-xl;
+      margin-bottom: variables.$spacing-3-xl;
     }
 
     & > * {
@@ -32,10 +32,10 @@
     }
 
     & > *:not(:last-child) {
-      margin-bottom: $spacing-s;
+      margin-bottom: variables.$spacing-s;
     }
 
-    @include respond-above(m) {
+    @include layout.respond-above(m) {
       flex-direction: row;
 
       & > * {
@@ -44,30 +44,30 @@
 
       & > *:not(:last-child) {
         margin-bottom: 0;
-        margin-right: $spacing-s;
+        margin-right: variables.$spacing-s;
       }
     }
   }
 
   .passwordWrapper {
     & > * {
-      margin-bottom: $spacing-m;
+      margin-bottom: variables.$spacing-m;
     }
   }
 
   .continueButton {
     width: 100%;
-    margin-top: $spacing-s;
-    margin-bottom: $spacing-l;
+    margin-top: variables.$spacing-s;
+    margin-bottom: variables.$spacing-l;
 
-    @include respond-above(m) {
+    @include layout.respond-above(m) {
       width: initial;
     }
   }
 }
 
 .grey {
-  background-color: $color-black-5;
+  background-color: variables.$color-black-5;
 }
 
 hr {
@@ -75,5 +75,5 @@ hr {
 }
 
 .noFreeTicketSystemPasswordsLeftLabel {
-  color: $color-error;
+  color: variables.$color-error;
 }

--- a/src/domain/event/externalTicketSystemEventIsEnrolled.module.scss
+++ b/src/domain/event/externalTicketSystemEventIsEnrolled.module.scss
@@ -1,30 +1,29 @@
-@import '~styles/variables';
-@import '~styles/fonts';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .passwordRow {
   display: flex;
   align-items: center;
   flex-direction: column;
-  margin-top: $spacing-l;
-  margin-bottom: $spacing-l;
+  margin-top: variables.$spacing-l;
+  margin-bottom: variables.$spacing-l;
 
   & > *:not(:last-child) {
-    margin-bottom: $spacing-s;
+    margin-bottom: variables.$spacing-s;
   }
 
   & > *:last-child {
-    margin-top: $spacing-m;
+    margin-top: variables.$spacing-m;
     width: 100%;
   }
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     flex-direction: row;
     flex-wrap: wrap;
-    row-gap: $spacing-m;
+    row-gap: variables.$spacing-m;
 
     & > *:not(:last-child) {
-      margin-right: $spacing-s;
+      margin-right: variables.$spacing-s;
       margin-bottom: 0;
     }
 

--- a/src/domain/event/externalTicketSystemPassword.module.scss
+++ b/src/domain/event/externalTicketSystemPassword.module.scss
@@ -1,32 +1,32 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-xs;
+  gap: variables.$spacing-xs;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     flex-direction: row;
   }
 
   .password {
-    padding: $spacing-s;
+    padding: variables.$spacing-s;
     width: min-content;
 
-    font-size: $fontsize-body-xl;
+    font-size: variables.$fontsize-body-xl;
     text-transform: uppercase;
     letter-spacing: 6px;
 
-    background-color: $color-black-5;
+    background-color: variables.$color-black-5;
   }
 
   .copyButton {
     padding: 0;
 
     text-decoration: underline;
-    color: $color-black-90;
+    color: variables.$color-black-90;
 
     background: none;
     border: none;
@@ -35,13 +35,13 @@
 
   .copyButtonWrapper {
     position: relative;
-    @include respond-above(m) {
+    @include layout.respond-above(m) {
       margin-right: 42px;
     }
   }
 
   .successCheckMark {
-    color: $color-success;
+    color: variables.$color-success;
     position: absolute;
     bottom: -2px;
     right: -32px;

--- a/src/domain/event/partial/occurrenceInfo.module.scss
+++ b/src/domain/event/partial/occurrenceInfo.module.scss
@@ -1,33 +1,33 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 $labelIconMargin: 0.5rem;
-$labelColumnMargin: $spacing-2-xs;
-$labelRowMargin: $spacing-s;
+$labelColumnMargin: variables.$spacing-2-xs;
+$labelRowMargin: variables.$spacing-s;
 
 .row {
   display: flex;
   flex-direction: column;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
   }
 
   & > div {
-    margin-bottom: $spacing-2-xs;
+    margin-bottom: variables.$spacing-2-xs;
   }
 
   .label {
     text-transform: capitalize;
     font-weight: 500;
-    @include respond-above(m) {
+    @include layout.respond-above(m) {
       > * {
         margin-right: $labelColumnMargin;
       }
     }
-    @include respond-below(m) {
+    @include layout.respond-below(m) {
       & + & {
         margin-top: $labelRowMargin;
       }
@@ -49,7 +49,7 @@ $labelRowMargin: $spacing-s;
   margin: 0;
   white-space: pre-wrap;
 
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     white-space: nowrap;
   }
 }

--- a/src/domain/eventGroup/eventGroup.module.scss
+++ b/src/domain/eventGroup/eventGroup.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .container {
   display: flex;
@@ -8,50 +8,50 @@
 
 .eventGroupDecoration {
   max-width: 100%;
-  margin-top: $spacing-xs;
+  margin-top: variables.$spacing-xs;
   z-index: 10;
   align-self: center;
   margin-bottom: -8%;
 
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     max-height: 18rem;
     margin-bottom: -67px;
   }
 }
 
 .eventGroupDetails {
-  padding: $spacing-layout-s $spacing-layout-xs;
-  margin-bottom: $spacing-layout-s;
+  padding: variables.$spacing-layout-s variables.$spacing-layout-xs;
+  margin-bottom: variables.$spacing-layout-s;
 
-  background: $color-white;
+  background: variables.$color-white;
 
-  @include respond-above(l) {
-    padding: $spacing-layout-m $spacing-layout-xl;
+  @include layout.respond-above(l) {
+    padding: variables.$spacing-layout-m variables.$spacing-layout-xl;
   }
 
   .title {
     margin-top: 0;
 
-    font-size: $fontsize-heading-l;
+    font-size: variables.$fontsize-heading-l;
 
-    @include respond-above(l) {
-      font-size: $fontsize-heading-xl;
+    @include layout.respond-above(l) {
+      font-size: variables.$fontsize-heading-xl;
     }
   }
 
   & > p {
     margin-bottom: 0;
 
-    font-size: $fontsize-body-l;
+    font-size: variables.$fontsize-body-l;
     font-weight: 300;
-    line-height: $lineheight-l;
+    line-height: variables.$lineheight-l;
   }
 }
 
 .eventList {
-  margin: 0 $spacing-xs;
+  margin: 0 variables.$spacing-xs;
 
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     margin: 0;
   }
 }

--- a/src/domain/headlessCms/headlessCmsPage.module.scss
+++ b/src/domain/headlessCms/headlessCmsPage.module.scss
@@ -1,13 +1,14 @@
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .cmsPageContainer {
-  padding-bottom: $spacing-xl;
+  padding-bottom: variables.$spacing-xl;
   h1 {
     overflow-wrap: break-word;
     -ms-word-break: break-all;
     word-break: break-word;
     -webkit-hyphens: manual;
     hyphens: manual;
-    font-size: $fontsize-heading-xl !important;
+    font-size: variables.$fontsize-heading-xl !important;
   }
 }

--- a/src/domain/home/contact/homeContact.module.scss
+++ b/src/domain/home/contact/homeContact.module.scss
@@ -1,14 +1,14 @@
-@import '~styles/variables';
-@import '~styles/layout';
-@import '~styles/fonts';
+@use '~styles/variables';
+@use '~styles/layout';
+@use '~styles/fonts';
 
 $korosIncludedPadding: 7rem;
 
 .wrapper {
-  padding: 2 * $largeMargin 0;
+  padding: 2 * variables.$largeMargin 0;
   //
   display: grid;
-  grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
+  grid-template-columns: 1fr minmax(auto, variables.$containerMaxWidth) 1fr;
 }
 
 .contact {
@@ -25,7 +25,7 @@ $korosIncludedPadding: 7rem;
 
     p {
       &:first-child {
-        font-size: $font-size-lg;
+        font-size: fonts.$font-size-lg;
       }
     }
   }

--- a/src/domain/home/form/homePreliminaryForm.module.scss
+++ b/src/domain/home/form/homePreliminaryForm.module.scss
@@ -1,35 +1,35 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .homeForm {
-  padding: 2 * $largeMargin 0;
+  padding: 2 * variables.$largeMargin 0;
 
   form {
     display: grid;
-    gap: $baseMargin 0;
+    gap: variables.$baseMargin 0;
   }
 
   .inputWrapper {
     display: grid;
     align-items: baseline;
-    @include respond-above(l) {
+    @include layout.respond-above(l) {
       grid-template-columns: 1fr 1fr;
-      gap: 0 $baseMargin;
+      gap: 0 variables.$baseMargin;
     }
   }
 }
 
 .wrapper {
-  @include formContainer();
+  @include layout.formContainer();
 
-  @include respond-below(l) {
-    padding: 0 $baseMargin;
+  @include layout.respond-below(l) {
+    padding: 0 variables.$baseMargin;
   }
 }
 
 .submitButton {
   width: 80%;
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     width: 60%;
   }
   justify-self: center;
@@ -41,6 +41,6 @@
     margin-top: 0;
   }
   p {
-    margin-bottom: $largeMargin;
+    margin-bottom: variables.$largeMargin;
   }
 }

--- a/src/domain/home/hero/hero.module.scss
+++ b/src/domain/home/hero/hero.module.scss
@@ -1,5 +1,6 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use "sass:map";
+@use '~styles/layout';
+@use '~styles/variables';
 
 .heroWrapper {
   background-color: var(--color-summer);
@@ -9,9 +10,9 @@
 }
 
 .kidsImageContainer {
-  grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
+  grid-template-columns: 1fr minmax(auto, variables.$containerMaxWidth) 1fr;
   display: grid;
-  @include respond-above(xl-minus) {
+  @include layout.respond-above(xl-minus) {
     background-image:
       linear-gradient(to bottom, var(--color-summer) 276px, var(--color-black-5) 0),
       url('/images/Culture_kids_background@2x.png');
@@ -24,8 +25,8 @@
 .kidsImage {
   grid-column: 2;
   min-height: calc(0.265 * 100vw);
-  @media (min-width: map-get($breakpoints, xl-minus)) {
-    min-height: calc(0.265 * #{$containerMaxWidth});
+  @media (min-width: map.get(layout.$breakpoints, xl-minus)) {
+    min-height: 0.265 * variables.$containerMaxWidth;
   }
   background-image: url('/images/Culture_kids@2x.jpg');
   background-repeat: no-repeat;
@@ -37,33 +38,33 @@
   display: grid;
   text-align: center;
 
-  @include heroContainer();
+  @include layout.heroContainer();
 }
 
 .hero {
   h1 {
-    margin: $spacing-layout-l 0 $spacing-l;
+    margin: variables.$spacing-layout-l 0 variables.$spacing-l;
 
-    font-size: $fontsize-heading-l;
+    font-size: variables.$fontsize-heading-l;
 
-    @include respond-above(m) {
-      font-size: $fontsize-heading-xl;
+    @include layout.respond-above(m) {
+      font-size: variables.$fontsize-heading-xl;
     }
   }
   p {
-    margin: 0 0 $spacing-s;
+    margin: 0 0 variables.$spacing-s;
   }
 
   .bodyXl {
-    font-size: $fontsize-body-xl;
-    line-height: $lineheight-l;
+    font-size: variables.$fontsize-body-xl;
+    line-height: variables.$lineheight-l;
   }
 
   .buttonGroup {
-    margin: $spacing-2-xl auto 0;
+    margin: variables.$spacing-2-xl auto 0;
     button {
       width: 80%;
-      @include respond-above(m) {
+      @include layout.respond-above(m) {
         width: 60%;
       }
     }
@@ -86,7 +87,7 @@
       }
 
       background-color: var(--color-white);
-      margin-bottom: $baseMargin;
+      margin-bottom: variables.$baseMargin;
     }
   }
 

--- a/src/domain/home/instructions/homeInstructions.module.scss
+++ b/src/domain/home/instructions/homeInstructions.module.scss
@@ -1,35 +1,35 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .wrapper {
   text-align: center;
-  padding-bottom: 2 * $largeMargin;
+  padding-bottom: 2 * variables.$largeMargin;
 
   display: grid;
-  grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
+  grid-template-columns: 1fr minmax(auto, variables.$containerMaxWidth) 1fr;
 
   .instructions {
     grid-column: 2;
 
     h2 {
       margin: 0;
-      padding: $largeMargin 0;
+      padding: variables.$largeMargin 0;
     }
 
     .icon {
-      height: $xlargeMargin;
-      width: $xlargeMargin;
+      height: variables.$xlargeMargin;
+      width: variables.$xlargeMargin;
       display: block;
       margin: 0 auto;
     }
 
     .iconContainer {
       display: grid;
-      padding: 0 $basePadding;
+      padding: 0 variables.$basePadding;
 
-      @include respond-above(m) {
+      @include layout.respond-above(m) {
         grid-template-columns: 1fr 1fr 1fr;
-        gap: $baseMargin;
+        gap: variables.$baseMargin;
       }
     }
   }

--- a/src/domain/home/moreInfo/homeMoreInfo.module.scss
+++ b/src/domain/home/moreInfo/homeMoreInfo.module.scss
@@ -1,12 +1,11 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/variables';
 
 .wrapper {
-  background: var(--color-black-5);
-  padding: 2rem 0 2 * $largeMargin 0;
+  background: variables.$color-black-5;
+  padding: 2rem 0 2 * variables.$largeMargin 0;
 
   display: grid;
-  grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
+  grid-template-columns: 1fr minmax(auto, variables.$containerMaxWidth) 1fr;
 }
 
 .innerwrapper {
@@ -14,7 +13,7 @@
     margin-top: 0;
   }
   p {
-    margin-bottom: $largeMargin;
+    margin-bottom: variables.$largeMargin;
   }
 
   text-align: center;

--- a/src/domain/home/moreInfo/moreInfoLinkList.module.scss
+++ b/src/domain/home/moreInfo/moreInfoLinkList.module.scss
@@ -1,15 +1,15 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .link {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   justify-items: center;
   width: 100vw;
-  max-width: $containerMaxWidth;
+  max-width: variables.$containerMaxWidth;
   a {
     color: var(--color-black-90);
-    margin: $baseMargin;
+    margin: variables.$baseMargin;
     text-decoration: none;
     font-weight: 500;
     &:hover {

--- a/src/domain/home/partners/homePartners.module.scss
+++ b/src/domain/home/partners/homePartners.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .wrapper {
   h2 {
@@ -7,10 +7,10 @@
     margin-top: 0;
   }
 
-  padding: 2 * $largeMargin 0;
+  padding: 2 * variables.$largeMargin 0;
 
   display: grid;
-  grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
+  grid-template-columns: 1fr minmax(auto, variables.$containerMaxWidth) 1fr;
 }
 
 .innerwrapper {
@@ -18,6 +18,6 @@
 }
 
 .partners {
-  padding: 0 $baseMargin;
+  padding: 0 variables.$baseMargin;
   display: grid;
 }

--- a/src/domain/home/partners/partnerLogoList.module.scss
+++ b/src/domain/home/partners/partnerLogoList.module.scss
@@ -1,20 +1,20 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .big {
   display: grid;
-  @include respond-below(l) {
+  @include layout.respond-below(l) {
     justify-content: center;
     gap: 2em;
   }
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     grid-template-columns: repeat(2, 1fr);
-    gap: $xlargeMargin;
+    gap: variables.$xlargeMargin;
   }
-  margin-bottom: $largeMargin;
+  margin-bottom: variables.$largeMargin;
 
   .container {
-    @include respond-above(m) {
+    @include layout.respond-above(m) {
       &:first-child {
         justify-self: end;
       }
@@ -26,8 +26,8 @@
   }
 
   .icon {
-    width: 2 * $xlargeMargin;
-    height: $xlargeMargin;
+    width: 2 * variables.$xlargeMargin;
+    height: variables.$xlargeMargin;
 
     img {
       width: 100%;
@@ -39,7 +39,7 @@
     // Enlarge JAES logo to give it prominence as one of the main partners
     img {
       width: 180%;
-      @include respond-below(m) {
+      @include layout.respond-below(m) {
         margin-left: -40%;  // To center the icon horizontally in width 180%
       }
     }
@@ -50,10 +50,10 @@
   display: grid;
   gap: 2rem;
   grid-template-columns: repeat(2, 1fr);
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     grid-template-columns: repeat(4, 1fr);
   }
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     grid-template-columns: repeat(5, 1fr);
   }
   .icon {
@@ -65,13 +65,13 @@
       width: 100%;
       height: auto;
     }
-    @include respond-above(m) {
-      width: $xlargeMargin;
-      height: 0.67 * $xlargeMargin;
+    @include layout.respond-above(m) {
+      width: variables.$xlargeMargin;
+      height: 0.67 * variables.$xlargeMargin;
     }
-    @include respond-above(l) {
-      width: 1.5 * $xlargeMargin;
-      height: $xlargeMargin;
+    @include layout.respond-above(l) {
+      width: 1.5 * variables.$xlargeMargin;
+      height: variables.$xlargeMargin;
     }
   }
 }

--- a/src/domain/home/video/homeVideo.module.scss
+++ b/src/domain/home/video/homeVideo.module.scss
@@ -1,18 +1,18 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .wrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(auto, $containerFormMaxWidth) 1fr;
+  grid-template-columns: 1fr minmax(auto, variables.$containerFormMaxWidth) 1fr;
 
-  @include respond-below(l) {
-    padding: 0 $baseMargin;
+  @include layout.respond-below(l) {
+    padding: 0 variables.$baseMargin;
   }
 }
 
 .innerwrapper {
   grid-column: 2;
-  padding: 2 * $largeMargin 0;
+  padding: 2 * variables.$largeMargin 0;
 }
 
 .embedContainer {

--- a/src/domain/profile/children/child/profileChild.module.scss
+++ b/src/domain/profile/children/child/profileChild.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .container {
   --container-padding: var(--spacing-s);
@@ -16,7 +16,7 @@
   background: var(--color-white);
   cursor: pointer;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     --container-padding: var(--spacing-s);
     --icon-dimension: 4rem;
 
@@ -39,7 +39,7 @@
   height: var(--icon-dimension);
   width: var(--icon-dimension);
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     position: unset;
     top: unset;
     left: unset;
@@ -57,7 +57,7 @@
     margin: 0;
   }
 
-  @include respond-above(xl-minus) {
+  @include layout.respond-above(xl-minus) {
     display: grid;
     grid-template-columns: 1fr auto;
     grid-template-rows: auto auto;
@@ -84,7 +84,7 @@
   min-height: var(--icon-dimension);
   padding-left: calc(var(--icon-dimension) + var(--spacing-xs));
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     min-height: unset;
     padding-left: unset;
   }
@@ -99,7 +99,7 @@
     margin: 0;
   }
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     order: unset;
   }
 }
@@ -115,7 +115,7 @@
   column-gap: var(--spacing-l);
   row-gap: var(--spacing-xs);
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     flex-direction: row;
     align-items: center;
     flex-shrink: 0;
@@ -136,7 +136,7 @@
   display: flex;
   align-items: center;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     position: unset;
     top: unset;
     left: unset;

--- a/src/domain/profile/children/child/profileChildDetail.module.scss
+++ b/src/domain/profile/children/child/profileChildDetail.module.scss
@@ -1,46 +1,46 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 $childHeadingMargin: 0.65rem;
 
 .childDetailWrapper {
   display: grid;
-  padding: 0 $basePadding;
-  @include respond-above(m) {
+  padding: 0 variables.$basePadding;
+  @include layout.respond-above(m) {
     padding: 0;
     grid-template-columns: 1fr 10fr 1fr;
   }
-  @include respond-below(m) {
+  @include layout.respond-below(m) {
     grid-auto-rows: min-content;
   }
 }
 
 .childIcon {
-  height: $largeMargin;
-  width: $largeMargin;
+  height: variables.$largeMargin;
+  width: variables.$largeMargin;
 }
 
 .childInfo {
   display: grid;
   grid-auto-flow: row;
-  margin-bottom: $baseMargin;
+  margin-bottom: variables.$baseMargin;
   .childInfoHeadingRow {
     display: inline-flex;
     justify-content: space-between;
-    margin: $baseMargin 0;
+    margin: variables.$baseMargin 0;
 
     .childName {
       display: grid;
 
-      @include respond-below(m) {
+      @include layout.respond-below(m) {
         > div {
           display: none;
         }
         flex-grow: 1;
       }
-      @include respond-above(m) {
-        grid-template-columns: $largeMargin 1fr;
-        gap: $baseMargin;
+      @include layout.respond-above(m) {
+        grid-template-columns: variables.$largeMargin 1fr;
+        gap: variables.$baseMargin;
         > div {
           align-self: baseline;
           margin-top: $childHeadingMargin;
@@ -56,14 +56,14 @@ $childHeadingMargin: 0.65rem;
       border: none;
       padding: 0;
       background: transparent;
-      height: $buttonHeight;
+      height: variables.$buttonHeight;
       // HDS adds unwanted margin to icon
       div {
         margin-right: 0;
       }
       span {
         display: none;
-        @include respond-above(l) {
+        @include layout.respond-above(l) {
           display: inline;
           white-space: nowrap;
         }
@@ -72,17 +72,17 @@ $childHeadingMargin: 0.65rem;
   }
 
   .childInfoRow {
-    padding-bottom: $baseMargin;
+    padding-bottom: variables.$baseMargin;
     display: grid;
-    grid-template-columns: $largeMargin 1fr;
-    gap: $baseMargin;
-    @include respond-above(m) {
+    grid-template-columns: variables.$largeMargin 1fr;
+    gap: variables.$baseMargin;
+    @include layout.respond-above(m) {
       > span {
         align-self: center;
       }
     }
 
-    @include respond-below(m) {
+    @include layout.respond-below(m) {
       > span {
         align-self: start;
       }

--- a/src/domain/profile/children/child/profileChildEnrolment.module.scss
+++ b/src/domain/profile/children/child/profileChildEnrolment.module.scss
@@ -1,4 +1,4 @@
-@import '~styles/layout';
+@use '~styles/layout';
 
 .container {
   display: flex;
@@ -24,7 +24,7 @@
 
   list-style-type: none;
 
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     flex-direction: row;
   }
 }

--- a/src/domain/profile/events/profileNoEvent.module.scss
+++ b/src/domain/profile/events/profileNoEvent.module.scss
@@ -1,20 +1,20 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
-$iconSize: 2 * $xlargeMargin;
+$iconSize: 2 * variables.$xlargeMargin;
 
 .noEvent {
-  padding: $largeMargin;
+  padding: variables.$largeMargin;
   display: grid;
-  background: var(--color-white);
-  @include respond-above(m) {
+  background: variables.$color-white;
+  @include layout.respond-above(m) {
     grid-template-columns: $iconSize 1fr;
-    grid-gap: $baseMargin;
+    grid-gap: variables.$baseMargin;
   }
   p {
     align-self: center;
 
-    @include respond-below(m) {
+    @include layout.respond-below(m) {
       text-align: center;
     }
   }
@@ -22,7 +22,7 @@ $iconSize: 2 * $xlargeMargin;
     height: $iconSize;
     width: $iconSize;
 
-    @include respond-below(m) {
+    @include layout.respond-below(m) {
       justify-self: center;
     }
   }

--- a/src/domain/profile/modal/editProfileModal.module.scss
+++ b/src/domain/profile/modal/editProfileModal.module.scss
@@ -1,8 +1,8 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .formField {
-  padding-bottom: $basePadding;
+  padding-bottom: variables.$basePadding;
 }
 
 .email {
@@ -10,7 +10,7 @@
     font-weight: bold;
   }
   p {
-    margin-top: $baseMargin * 0.25;
+    margin-top: variables.$baseMargin * 0.25;
   }
 }
 
@@ -35,18 +35,18 @@
 
 .buttonsWrapper {
   display: grid;
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     grid-template-columns: 1fr 1fr;
   }
-  grid-gap: $baseMargin;
-  margin: $largeMargin 0;
+  grid-gap: variables.$baseMargin;
+  margin: variables.$largeMargin 0;
   button: {
     width: 100%;
   }
 }
 
 .cancelButton {
-  @include respond-below(m) {
+  @include layout.respond-below(m) {
     grid-row: 2;
   }
 
@@ -54,7 +54,7 @@
 }
 
 .submitButton {
-  @include respond-below(m) {
+  @include layout.respond-below(m) {
     grid-row: 1;
   }
 
@@ -62,16 +62,16 @@
 }
 
 .profileName {
-  @include respond-above(m) {
+  @include layout.respond-above(m) {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-gap: $baseMargin;
+    grid-gap: variables.$baseMargin;
   }
 }
 
 .icon {
   display: block;
-  margin: $largeMargin auto;
-  height: $largeMargin;
-  width: $largeMargin;
+  margin: variables.$largeMargin auto;
+  height: variables.$largeMargin;
+  width: variables.$largeMargin;
 }

--- a/src/domain/registration/form/partial/childFormFields.module.scss
+++ b/src/domain/registration/form/partial/childFormFields.module.scss
@@ -1,28 +1,28 @@
-@import '~styles/variables';
-@import '~styles/layout';
-@import '~styles/fonts';
+@use '~styles/variables';
+@use '~styles/layout';
+@use '~styles/fonts';
 
 $childIconHeight: 4rem;
 
 .childImage {
   height: $childIconHeight;
   width: $childIconHeight;
-  margin-right: $baseMargin;
+  margin-right: variables.$baseMargin;
 }
 
 .childFields {
-  margin-top: $baseMargin;
-  margin-bottom: $largeMargin;
+  margin-top: variables.$baseMargin;
+  margin-bottom: variables.$largeMargin;
 }
 
 .childName,
 .childFixedInfo {
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-gap: $baseMargin;
+    grid-gap: variables.$baseMargin;
   }
-  padding: $baseMargin 0;
+  padding: variables.$baseMargin 0;
 }
 
 .childBirthyear,
@@ -31,9 +31,9 @@ $childIconHeight: 4rem;
   flex-direction: column;
 
   label {
-    font-size: $font-size-sm;
-    margin-bottom: $baseMargin * 0.25;
-    font-weight: $font-weight-bold;
+    font-size: fonts.$font-size-sm;
+    margin-bottom: variables.$baseMargin * 0.25;
+    font-weight: fonts.$font-weight-bold;
   }
 
   p {
@@ -46,7 +46,7 @@ $childIconHeight: 4rem;
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: $baseMargin 0;
+  padding: variables.$baseMargin 0;
 
   h2 {
     flex-grow: 1;
@@ -59,7 +59,7 @@ $childIconHeight: 4rem;
 
     transform: translateX(calc(var(--spacing-m) * 0.5));
     span {
-      font-weight: $font-weight-bold;
+      font-weight: fonts.$font-weight-bold;
       padding: 0;
     }
     > div {

--- a/src/domain/registration/form/registrationForm.module.scss
+++ b/src/domain/registration/form/registrationForm.module.scss
@@ -1,6 +1,6 @@
-@import '~styles/variables';
-@import '~styles/layout';
-@import './partial/childFormFields.module.scss';
+@use '~styles/variables';
+@use '~styles/layout';
+@use './partial/childFormFields.module.scss';
 
 $plusIconHeight: 2rem;
 
@@ -14,30 +14,30 @@ $plusIconHeight: 2rem;
   h1 {
     margin-bottom: auto;
   }
-  @include respond-above(l) {
-    grid-template-columns: 1fr minmax(auto, $containerFormMaxWidth) 1fr;
+  @include layout.respond-above(l) {
+    grid-template-columns: 1fr minmax(auto, variables.$containerFormMaxWidth) 1fr;
   }
 
-  @include respond-below(l) {
+  @include layout.respond-below(l) {
     grid-template-columns: 1fr 10fr 1fr;
   }
 }
 
 .guardianName {
-  @include respond-above(l) {
+  @include layout.respond-above(l) {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-gap: $baseMargin;
+    grid-gap: variables.$baseMargin;
   }
 }
 
 .submitButton {
-  margin: $largeMargin 0 !important;
+  margin: variables.$largeMargin 0 !important;
 }
 
 .addNewChildButton {
   display: flex;
-  margin: $baseMargin 0;
+  margin: variables.$baseMargin 0;
   flex-direction: row;
   align-items: center;
   justify-content: flex-start !important;
@@ -62,11 +62,11 @@ $plusIconHeight: 2rem;
   > * {
     grid-column: 2;
   }
-  margin: $baseMargin;
+  margin: variables.$baseMargin;
 }
 
 .guardianInfo {
-  padding-top: $baseMargin;
+  padding-top: variables.$baseMargin;
 }
 
 .plusIcon {
@@ -75,7 +75,7 @@ $plusIconHeight: 2rem;
 }
 
 .heading {
-  padding: $baseMargin;
+  padding: variables.$baseMargin;
 }
 
 .required {

--- a/src/domain/registration/notEligible/notEligible.module.scss
+++ b/src/domain/registration/notEligible/notEligible.module.scss
@@ -1,9 +1,9 @@
-@import '~styles/layout';
-@import '~styles/variables';
+@use '~styles/layout';
+@use '~styles/variables';
 
 .notEligible {
-  @include respond-below(l) {
-    margin: 0 $baseMargin $largeMargin $baseMargin;
+  @include layout.respond-below(l) {
+    margin: 0 variables.$baseMargin variables.$largeMargin variables.$baseMargin;
   }
 
   font-weight: bold;
@@ -15,10 +15,10 @@
   .notEligibleFace {
     height: 4rem;
     width: 4rem;
-    margin: $baseMargin 0;
+    margin: variables.$baseMargin 0;
   }
 }
 
 .goBackButton {
-  margin: 2 * $baseMargin;
+  margin: 2 * variables.$baseMargin;
 }

--- a/src/domain/registration/welcome/welcome.module.scss
+++ b/src/domain/registration/welcome/welcome.module.scss
@@ -1,5 +1,5 @@
-@import '~styles/variables';
-@import '~styles/layout';
+@use '~styles/variables';
+@use '~styles/layout';
 
 .welcome {
   display: flex;
@@ -7,21 +7,21 @@
   align-items: center;
   align-self: center;
   text-align: center;
-  @include respond-below(l) {
-    padding: 0 $basePadding;
+  @include layout.respond-below(l) {
+    padding: 0 variables.$basePadding;
   }
 }
 
 .tada {
   display: block;
-  height: 4 * $imgHeight;
-  width: 4 * $imgHeight;
-  margin: $baseMargin auto;
+  height: 4 * variables.$imgHeight;
+  width: 4 * variables.$imgHeight;
+  margin: variables.$baseMargin auto;
 }
 
 .submitButton {
-  margin-top: $largeMargin;
-  @include respond-above(l) {
+  margin-top: variables.$largeMargin;
+  @include layout.respond-above(l) {
     width: 50%;
   }
 }


### PR DESCRIPTION
## Description

### fix: Dart Sass @import/global built-in function deprecation warnings

remove Dart Sass 3.0.0 deprecation warnings when building:
 - Sass @import rules are deprecated
 - Global built-in functions are deprecated

done:
- `@import` → `@use` + namespacing functions and variables, e.g.
  `$breakpoint-m` → `hds.$breakpoint-m`
- exporting variables from .scss file to another by `@forward`, e.g. all
  `hds-design-tokens`'s variables are now explicitly exported from
  `variables.scss`
- `map-has-key` → `@use "sass:map"` + `map.has-key`
- `map-get` → `@use "sass:map"` + `map.get`
- changed some constants from CSS style to SASS style:
  - var(--breakpoint-xl) → variables.$breakpoint-xl
  - var(--color-black) → variables.$color-black
  - var(--color-black-5) → variables.$color-black-5
  - var(--color-summer) → variables.$color-summer
  - var(--color-white) → variables.$color-white
  - var(--spacing-2-xs) → variables.$spacing-2-xs
  - var(--spacing-l) → variables.$spacing-l
  - var(--spacing-layout-m) → variables.$spacing-layout-m
  - var(--spacing-layout-s) → variables.$spacing-layout-s
  - var(--spacing-layout-s) → variables.$spacing-layout-s
  - var(--spacing-layout-xs) → variables.$spacing-layout-xs
  - var(--spacing-m) → variables.$spacing-m
  - var(--spacing-s) → variables.$spacing-s
  - var(--spacing-s) → variables.$spacing-s
- Specifically in listPageLayout.module.scss:
  - removed unnecessary calc() use from `$backButtonAsideBreakpoint`:
	- `calc($backButtonWidth + $breakpoint-xl);` →
	  `$backButtonWidth + variables.$breakpoint-xl;`
  - removed unnecessary SASS → CSS variable mapping by removing
	`--back-button-width: #{$backButtonWidth};`
  - simplified calculation
	`margin-left: calc(#{var(--back-button-width)} * -1);` →
	`margin-left: $backButtonWidth * -1;`
  - **NOTE**: Replaced `var(--color-text)` with
	`variables.$color-black-90` as there was no variable `color-text`
	i.e. **it had no value at all**
- Specifically in hero.module.scss:
  - Changed from using min-height calculation using CSS and
	interpolation to using SASS calculations directly i.e.
	`min-height: calc(0.265 * #{$containerMaxWidth});` →
	`min-height: 0.265 * variables.$containerMaxWidth;`

refs KK-1372

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-1372](https://helsinkisolutionoffice.atlassian.net/browse/KK-1372)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1372]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ