### PR TITLE
fix(docker): dev compose uses polling to detect code changes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,9 @@ export default ({ mode }) => {
       outDir: 'build',
     },
     server: {
+      watch: {
+        usePolling: Boolean(process.env.NODE_ENV === 'development'),
+      },
       port: parseInt(process.env.PORT) || 3000,
       open: true,
     },


### PR DESCRIPTION
KK-1367 KK-1393.

For server reload on code changes, enable server watch with polling when NODE_ENV is set to development.

See more from Vite: https://vite.dev/config/server-options#server-watch.
