### PR TITLE
KK-1356 | Fix dependabot issue #140 i.e. cookie <0.7.0 security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,24 @@
       "last 1 safari version"
     ]
   },
+  "//": {
+    "Why are packages in resolutions?": {
+      "hds-react/cookie": [
+        "To fix https://github.com/City-of-Helsinki/kukkuu-ui/security/dependabot/140",
+        "NOTE: This can be removed if hds-react starts to depend on >=v1 cookie"
+      ],
+      "@types/cookie": [
+        "To use the last known @types/cookie version, only for <v1 cookie",
+        "",
+        "NOTE: This can be removed if all dependencies start to depend on >=v1 cookie ",
+        "which provides the types itself"
+      ]
+    }
+  },
+  "resolutions": {
+    "hds-react/cookie": "^0.7.2",
+    "@types/cookie": "^0.6.0"
+  },
   "dependencies": {
     "@apollo/client": "^3.12.4",
     "@faker-js/faker": "^9.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3797,12 +3797,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
-  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
-
-"@types/cookie@^0.6.0":
+"@types/cookie@^0.4.1", "@types/cookie@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
@@ -5834,12 +5829,7 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
-  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
-
-cookie@^0.7.2:
+cookie@^0.4.1, cookie@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==


### PR DESCRIPTION
## Description

### fix: dependabot issue #140 i.e. cookie <0.7.0 security vulnerability

resolve cookie & @types/cookie for <v1 versions to latest v0.*,
fix dependabot issue #140:
https://github.com/City-of-Helsinki/kukkuu-ui/security/dependabot/140
"cookie accepts cookie name, path, and domain with out of bounds
characters"

> Dependabot cannot update cookie to a non-vulnerable version
> The latest possible version that can be installed is 0.4.2 because of
> the following conflicting dependencies:
>
> hds-react@3.11.0 requires cookie@^0.4.1
> msw@2.7.0 requires cookie@^0.7.2 via @bundled-es-modules/cookie@2.0.1
> react-router@7.1.1 requires cookie@^1.0.1
> react-router-dom@7.1.1 requires cookie@^1.0.1 via a transitive
> dependency on react-router@7.1.1
> The earliest fixed version is 0.7.0.

refs KK-1356

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

- [KK-1356](https://helsinkisolutionoffice.atlassian.net/browse/KK-1356)
- https://github.com/City-of-Helsinki/kukkuu-ui/security/dependabot/140

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1356]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ