### PR TITLE
refactor(time-utils): replace moment with date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "cross-env": "^7.0.3",
     "css-what": "^6.1.0",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "dompurify": "^3.2.3",
     "dotenv": "^16.4.7",
     "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "jsdom": "^25.0.1",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
-    "moment": "^2.30.1",
     "msw": "^2.7.0",
     "oidc-client": "^1.11.5",
     "prettier": "^3.4.2",

--- a/src/common/localization/setLocale.tsx
+++ b/src/common/localization/setLocale.tsx
@@ -1,15 +1,16 @@
-import moment from 'moment';
-// FIXME: Moment with Vite not working properly.
-// See: https://github.com/moment/moment/issues/5926
-// "Hi, moment is working fine, with vite. Unfortunately moment.locale() is not working..."
-// "...Instead of import 'moment/locale/cs', use import 'moment/dist/locale/cs'..."
-import 'moment/dist/locale/fi';
-import 'moment/dist/locale/sv';
+import { setDefaultOptions } from 'date-fns';
+import { fi, sv, enUS } from 'date-fns/locale';
 
 export type Locale = 'fi' | 'sv' | 'en';
 
+const locales = {
+  fi,
+  sv,
+  en: enUS,
+};
+
 function setLocale(locale: Locale) {
-  moment.locale(locale);
+  setDefaultOptions({ locale: locales[locale] });
 }
 
 export default setLocale;

--- a/src/common/time/TimeConstants.ts
+++ b/src/common/time/TimeConstants.ts
@@ -9,3 +9,5 @@ export const BACKEND_DATE_FORMAT = 'yyyy-MM-dd';
 
 // HH.MM
 export const DEFAULT_TIME_FORMAT = 'HH:mm';
+
+export const DEFAULT_TIME_ZONE = 'Europe/Helsinki';

--- a/src/common/time/TimeConstants.ts
+++ b/src/common/time/TimeConstants.ts
@@ -2,10 +2,10 @@
 export const SUPPORTED_START_BIRTH_YEAR = 2020;
 
 // Finnish display time format
-export const DEFAULT_DATE_FORMAT = 'D.M.YYYY';
+export const DEFAULT_DATE_FORMAT = 'd.M.yyyy';
 
 // Backend allowed time format
-export const BACKEND_DATE_FORMAT = 'YYYY-MM-DD';
+export const BACKEND_DATE_FORMAT = 'yyyy-MM-dd';
 
 // HH.MM
 export const DEFAULT_TIME_FORMAT = 'HH:mm';

--- a/src/common/time/utils.tsx
+++ b/src/common/time/utils.tsx
@@ -1,30 +1,33 @@
-import moment from 'moment';
+import { format, parse } from 'date-fns';
 
 import { BACKEND_DATE_FORMAT } from './TimeConstants';
 
 /**
- * Return new instance of moment, same with moment()
- * Use this util function to keep all moment import in single place.
+ * Return new instance of Date, same with new Date()
+ * Use this util function to keep all date-fns import in single place.
  * @param inp
- * @param format
- * @param strict
+ * @param formatStr
  */
-export const newMoment = (
-  inp?: moment.MomentInput,
-  format?: moment.MomentFormatSpecification,
-  strict?: boolean
-) => moment(inp, format, strict);
+export const newDate = (
+  inp?: string | number | Date | null,
+  formatStr?: string
+) => {
+  if (formatStr) {
+    return parse(inp as string, formatStr, new Date());
+  }
+  return inp ? new Date(inp) : new Date();
+};
 
 /**
- * Format input moment to backend time format by default. Can use custom format as 2nd params
- * @param inputMoment
- * @param format
+ * Format input date to backend time format by default. Can use custom format as 2nd params
+ * @param inputDate
+ * @param formatStr
  */
-export const formatTime = (inputMoment: moment.Moment, format?: string) =>
-  inputMoment.format(format || BACKEND_DATE_FORMAT);
+export const formatTime = (inputDate: Date, formatStr?: string) =>
+  format(inputDate, formatStr || BACKEND_DATE_FORMAT);
 
 /**
- * Format month to zero indexed for Moment
+ * Format month to zero indexed for date-fns
  * @param input
  */
 export const toZeroBasedMonth = (input: number | string) => {

--- a/src/common/time/utils.tsx
+++ b/src/common/time/utils.tsx
@@ -1,4 +1,3 @@
-import { parse } from 'date-fns';
 import { format, toZonedTime } from 'date-fns-tz';
 
 import { BACKEND_DATE_FORMAT, DEFAULT_TIME_ZONE } from './TimeConstants';
@@ -7,17 +6,9 @@ import { BACKEND_DATE_FORMAT, DEFAULT_TIME_ZONE } from './TimeConstants';
  * Return new instance of Date, same with new Date()
  * Use this util function to keep all date-fns import in single place.
  * @param inp
- * @param formatStr
  */
-export const newDate = (
-  inp?: string | number | Date | null,
-  formatStr?: string
-) => {
-  if (formatStr) {
-    return parse(inp as string, formatStr, new Date());
-  }
-  return toZonedTime(inp ? new Date(inp) : new Date(), DEFAULT_TIME_ZONE);
-};
+export const newDate = (inp?: string | number | Date | null) =>
+  toZonedTime(inp ? new Date(inp) : new Date(), DEFAULT_TIME_ZONE);
 
 /**
  * Format input date to backend time format by default. Can use custom format as 2nd params

--- a/src/common/time/utils.tsx
+++ b/src/common/time/utils.tsx
@@ -1,6 +1,7 @@
-import { format, parse } from 'date-fns';
+import { parse } from 'date-fns';
+import { format, toZonedTime } from 'date-fns-tz';
 
-import { BACKEND_DATE_FORMAT } from './TimeConstants';
+import { BACKEND_DATE_FORMAT, DEFAULT_TIME_ZONE } from './TimeConstants';
 
 /**
  * Return new instance of Date, same with new Date()
@@ -15,7 +16,7 @@ export const newDate = (
   if (formatStr) {
     return parse(inp as string, formatStr, new Date());
   }
-  return inp ? new Date(inp) : new Date();
+  return toZonedTime(inp ? new Date(inp) : new Date(), DEFAULT_TIME_ZONE);
 };
 
 /**
@@ -24,7 +25,9 @@ export const newDate = (
  * @param formatStr
  */
 export const formatTime = (inputDate: Date, formatStr?: string) =>
-  format(inputDate, formatStr || BACKEND_DATE_FORMAT);
+  format(inputDate, formatStr || BACKEND_DATE_FORMAT, {
+    timeZone: DEFAULT_TIME_ZONE,
+  });
 
 /**
  * Format month to zero indexed for date-fns

--- a/src/domain/event/Event.tsx
+++ b/src/domain/event/Event.tsx
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/browser';
 import uniqBy from 'lodash/uniqBy';
 
 import LoadingSpinner from '../../common/components/spinner/LoadingSpinner';
-import { formatTime, newMoment } from '../../common/time/utils';
+import { formatTime, newDate } from '../../common/time/utils';
 import {
   BACKEND_DATE_FORMAT,
   DEFAULT_DATE_FORMAT,
@@ -40,8 +40,8 @@ const OccurrenceList = RelayList<OccurrenceNode>();
 
 export function getDateOptions(occurrences?: Occurrences) {
   const options = OccurrenceList(occurrences).items.map(({ id, time }) => ({
-    value: formatTime(newMoment(time), BACKEND_DATE_FORMAT),
-    label: formatTime(newMoment(time), DEFAULT_DATE_FORMAT),
+    value: formatTime(newDate(time), BACKEND_DATE_FORMAT),
+    label: formatTime(newDate(time), DEFAULT_DATE_FORMAT),
     key: id,
   }));
 
@@ -51,7 +51,7 @@ export function getDateOptions(occurrences?: Occurrences) {
 export function getTimeOptions(occurrences?: Occurrences) {
   const options = OccurrenceList(occurrences).items.map(
     ({ id, time, event }) => ({
-      value: formatTime(newMoment(time), DEFAULT_TIME_FORMAT),
+      value: formatTime(newDate(time), DEFAULT_TIME_FORMAT),
       label: formatOccurrenceTime(time, event.duration || null),
       key: id,
     })

--- a/src/domain/event/EventNotificationSubscriptionModal.tsx
+++ b/src/domain/event/EventNotificationSubscriptionModal.tsx
@@ -1,6 +1,6 @@
 import { useTranslation, Trans } from 'react-i18next';
 
-import { formatTime, newMoment } from '../../common/time/utils';
+import { formatTime, newDate } from '../../common/time/utils';
 import {
   DEFAULT_DATE_FORMAT,
   DEFAULT_TIME_FORMAT,
@@ -58,7 +58,7 @@ const EventNotificationSubscriptionModal = ({
     }
   };
 
-  const occurrenceTime = newMoment(eventOccurrence.time);
+  const occurrenceTime = newDate(eventOccurrence.time);
 
   return (
     <ConfirmModal

--- a/src/domain/event/EventOccurrence.tsx
+++ b/src/domain/event/EventOccurrence.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
 import { TicketSystem } from '../api/generatedTypes/graphql';
-import { formatTime, newMoment } from '../../common/time/utils';
+import { formatTime, newDate } from '../../common/time/utils';
 import LinkButton from '../../common/components/button/LinkButton';
 import {
   DEFAULT_TIME_FORMAT,
@@ -56,13 +56,13 @@ const EventOccurrence = ({
   const { childId, eventId } = useParams<UrlParams>();
 
   const date = formatTime(
-    newMoment(occurrence.time),
-    `ddd ${DEFAULT_DATE_FORMAT}`
+    newDate(occurrence.time),
+    `iiiiii ${DEFAULT_DATE_FORMAT}`
   );
-  const time = formatTime(newMoment(occurrence.time), DEFAULT_TIME_FORMAT);
-  const machineReadableDate = formatTime(newMoment(occurrence.time));
+  const time = formatTime(newDate(occurrence.time), DEFAULT_TIME_FORMAT);
+  const machineReadableDate = formatTime(newDate(occurrence.time));
   const machineReadableTime = formatTime(
-    newMoment(occurrence.time),
+    newDate(occurrence.time),
     'HH:mm:ss.SSS'
   );
   const machineReadableDateTime = `${machineReadableDate} ${machineReadableTime}`;

--- a/src/domain/event/EventUtils.tsx
+++ b/src/domain/event/EventUtils.tsx
@@ -14,7 +14,7 @@ export const formatOccurrenceTime = (
 
   if (durationMinutes) {
     const endTimeRaw = addMinutes(newDate(startTimeRaw), durationMinutes);
-    const endTime = formatTime(newDate(endTimeRaw), DEFAULT_TIME_FORMAT);
+    const endTime = formatTime(endTimeRaw, DEFAULT_TIME_FORMAT);
     occurrenceTime = `${startTime} - ${endTime}`;
   } else {
     occurrenceTime = startTime;

--- a/src/domain/event/EventUtils.tsx
+++ b/src/domain/event/EventUtils.tsx
@@ -1,6 +1,7 @@
 import { IconGroup } from 'hds-react';
+import { addMinutes } from 'date-fns/addMinutes';
 
-import { formatTime, newMoment } from '../../common/time/utils';
+import { formatTime, newDate } from '../../common/time/utils';
 import { DEFAULT_TIME_FORMAT } from '../../common/time/TimeConstants';
 import { EventParticipantsPerInvite as EventParticipantsPerInviteEnum } from '../api/generatedTypes/graphql';
 
@@ -9,11 +10,11 @@ export const formatOccurrenceTime = (
   durationMinutes: number | null
 ) => {
   let occurrenceTime;
-  const startTime = formatTime(newMoment(startTimeRaw), DEFAULT_TIME_FORMAT);
+  const startTime = formatTime(newDate(startTimeRaw), DEFAULT_TIME_FORMAT);
 
   if (durationMinutes) {
-    const endTimeRaw = newMoment(startTimeRaw).add(durationMinutes, 'minutes');
-    const endTime = formatTime(newMoment(endTimeRaw), DEFAULT_TIME_FORMAT);
+    const endTimeRaw = addMinutes(newDate(startTimeRaw), durationMinutes);
+    const endTime = formatTime(newDate(endTimeRaw), DEFAULT_TIME_FORMAT);
     occurrenceTime = `${startTime} - ${endTime}`;
   } else {
     occurrenceTime = startTime;

--- a/src/domain/event/partial/OccurrenceInfo.tsx
+++ b/src/domain/event/partial/OccurrenceInfo.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import joinClassNames from 'classnames';
 import { IconCalendar, IconLocation, IconClock } from 'hds-react';
 
-import { formatTime, newMoment } from '../../../common/time/utils';
+import { formatTime, newDate } from '../../../common/time/utils';
 import { DEFAULT_DATE_FORMAT } from '../../../common/time/TimeConstants';
 import { formatOccurrenceTime, getParticipantsIcon } from '../EventUtils';
 import InfoItem, { InfoItemProps } from './InfoItem';
@@ -34,7 +34,7 @@ const OccurrenceInfo = ({
     {
       id: 'time',
       icon: <IconCalendar />,
-      label: formatTime(newMoment(occurrence.time), DEFAULT_DATE_FORMAT),
+      label: formatTime(newDate(occurrence.time), DEFAULT_DATE_FORMAT),
     },
     {
       id: 'duration',

--- a/src/domain/profile/children/child/ProfileChild.tsx
+++ b/src/domain/profile/children/child/ProfileChild.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { IconAngleRight } from 'hds-react';
+import { differenceInMilliseconds } from 'date-fns';
 
 import Icon from '../../../../common/components/icon/Icon';
 import Text from '../../../../common/components/text/Text';
-import { newMoment } from '../../../../common/time/utils';
+import { newDate } from '../../../../common/time/utils';
 import useGetPathname from '../../../../common/route/utils/useGetPathname';
 import ChildEnrolmentCount from '../../../child/ChildEnrolmentCount';
 import useChildEnrolmentCount from '../../../child/useChildEnrolmentCount';
@@ -178,9 +179,15 @@ function findNextEnrolment(enrolments: MyProfileEnrolment[]) {
         return enrolment;
       }
 
-      const now = newMoment(new Date());
-      const untilIncumbent = now.diff(newMoment(incumbent.occurrence.time));
-      const untilEnrolment = now.diff(newMoment(enrolment.occurrence.time));
+      const now = newDate();
+      const untilIncumbent = differenceInMilliseconds(
+        newDate(incumbent.occurrence.time),
+        now
+      );
+      const untilEnrolment = differenceInMilliseconds(
+        newDate(enrolment.occurrence.time),
+        now
+      );
 
       return untilIncumbent < untilEnrolment ? enrolment : incumbent;
     },

--- a/src/domain/profile/children/child/ProfileChildEnrolment.tsx
+++ b/src/domain/profile/children/child/ProfileChildEnrolment.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { IconCalendar, IconClock, IconLocation } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import { addMinutes } from 'date-fns/addMinutes';
 
-import { formatTime, newMoment } from '../../../../common/time/utils';
+import { formatTime, newDate } from '../../../../common/time/utils';
 import {
   DEFAULT_DATE_FORMAT,
   DEFAULT_TIME_FORMAT,
@@ -22,20 +23,22 @@ export default function Enrolment({ enrolment, childId }: EnrolmentProps) {
   } = useTranslation();
 
   const date = formatTime(
-    newMoment(enrolment.occurrence.time),
+    newDate(enrolment.occurrence.time),
     DEFAULT_DATE_FORMAT
   );
   const startTime = formatTime(
-    newMoment(enrolment.occurrence.time),
+    newDate(enrolment.occurrence.time),
     DEFAULT_TIME_FORMAT
   );
-  const endTime = formatTime(
-    newMoment(enrolment.occurrence.time).add(
-      enrolment.occurrence.event.duration,
-      'minutes'
-    ),
-    DEFAULT_TIME_FORMAT
-  );
+  const endTime = enrolment.occurrence.event.duration
+    ? formatTime(
+        addMinutes(
+          newDate(enrolment.occurrence.time),
+          enrolment.occurrence.event.duration
+        ),
+        DEFAULT_TIME_FORMAT
+      )
+    : '';
   const occurrencePath =
     '/:lang/profile/child/:childId/occurrence/:occurrenceId'
       .replace(':lang', language)

--- a/src/domain/profile/children/child/ProfileChildEnrolment.tsx
+++ b/src/domain/profile/children/child/ProfileChildEnrolment.tsx
@@ -38,7 +38,7 @@ export default function Enrolment({ enrolment, childId }: EnrolmentProps) {
         ),
         DEFAULT_TIME_FORMAT
       )
-    : '';
+    : startTime;
   const occurrencePath =
     '/:lang/profile/child/:childId/occurrence/:occurrenceId'
       .replace(':lang', language)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9173,7 +9173,7 @@ moment-duration-format-commonjs@^1.0.0:
   resolved "https://registry.yarnpkg.com/moment-duration-format-commonjs/-/moment-duration-format-commonjs-1.0.1.tgz#ca8776466dba736a30cb7cda4e07026b5aec8cf1"
   integrity sha512-KhKZRH21/+ihNRWrmdNFOyBptFi7nAWZFeFsRRpXkzgk/Yublb4fxyP0jU6EY1VDxUL/VUPdCmm/wAnpbfXdfw==
 
-moment@^2.14.1, moment@^2.29.4, moment@^2.30.1:
+moment@^2.14.1, moment@^2.29.4:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4940,6 +4940,11 @@ dataloader@^2.2.3:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.3.tgz#42d10b4913515f5b37c6acedcb4960d6ae1b1517"
   integrity sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==
 
+date-fns-tz@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-3.2.0.tgz#647dc56d38ac33a3e37b65e9d5c4cda5af5e58e6"
+  integrity sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==
+
 date-fns@2.16.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"


### PR DESCRIPTION
KK-1253.

With minimum effort, replace the old unsupported momentjs library usage
with date-fns implementations.
