### PR TITLE
KK-1411 | Fix browser tests in CI/CD pipeline by fixing polling interval/timeout

### DIFF
--- a/src/domain/app/AppConfig.ts
+++ b/src/domain/app/AppConfig.ts
@@ -200,7 +200,9 @@ class AppConfig {
    * Defaults to 1 minute.
    * */
   static get oidcSessionPollerIntervalInMs(): number {
-    return import.meta.env.VITE_OIDC_SESSION_POLLING_INTERVAL_MS ?? 60_000;
+    return (
+      Number(import.meta.env.VITE_OIDC_SESSION_POLLING_INTERVAL_MS) || 60_000
+    );
   }
 
   /**
@@ -208,7 +210,7 @@ class AppConfig {
    * Defaults to 60 minutes.
    * */
   static get userIdleTimeoutInMs(): number {
-    return import.meta.env.VITE_IDLE_TIMEOUT_IN_MS ?? 3_600_000;
+    return Number(import.meta.env.VITE_IDLE_TIMEOUT_IN_MS) || 3_600_000;
   }
 
   /**


### PR DESCRIPTION
<!-- DOCTOC SKIP -->

## Description

### fix: browser tests in CI/CD pipeline by fixing polling interval/timeout

Probable hypothesis at the moment is that in the CI/CD pipeline `VITE_OIDC_SESSION_POLLING_INTERVAL_MS` environment variable got the value "" i.e. an empty string, and that got handled like a zero i.e. it tried to poll repeatedly, and made the browser tests pop up a window saying your session has expired.

Now `VITE_OIDC_SESSION_POLLING_INTERVAL_MS` and
`VITE_IDLE_TIMEOUT_IN_MS` neither use empty string as a value, but use their fallback values if given one.

refs KK-1411

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-1411](https://helsinkisolutionoffice.atlassian.net/browse/KK-1411)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1411]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ