### PR TITLE
KK-1406 | Hardcode CMS languages for faster language rendering in header

### DIFF
--- a/src/domain/app/footer/__mocks__/languagesMock.ts
+++ b/src/domain/app/footer/__mocks__/languagesMock.ts
@@ -1,45 +1,11 @@
 import { LanguagesDocument } from 'react-helsinki-headless-cms/apollo';
-import { LanguageCodeEnum } from 'react-helsinki-headless-cms';
 import { MockedResponse } from '@apollo/client/testing';
 
-/**
- * This is a mock of the response from the languages query.
- * Data taken from production CMS query response.
- */
-export const languagesQueryResponse = {
-  data: {
-    languages: [
-      {
-        code: LanguageCodeEnum.Fi,
-        id: 'TGFuZ3VhZ2U6Zmk=',
-        locale: 'fi',
-        name: 'Suomi',
-        slug: 'fi',
-        __typename: 'Language',
-      },
-      {
-        code: LanguageCodeEnum.En,
-        id: 'TGFuZ3VhZ2U6ZW4=',
-        locale: 'en_US',
-        name: 'English',
-        slug: 'en',
-        __typename: 'Language',
-      },
-      {
-        code: LanguageCodeEnum.Sv,
-        id: 'TGFuZ3VhZ2U6c3Y=',
-        locale: 'sv_SE',
-        name: 'Svenska',
-        slug: 'sv',
-        __typename: 'Language',
-      },
-    ],
-  },
-} as const;
+import { HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE } from '../../../languages/constants';
 
 export const languagesMock: MockedResponse = {
   request: {
     query: LanguagesDocument,
   },
-  result: languagesQueryResponse,
+  result: { ...HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE },
 };

--- a/src/domain/headlessCms/client.ts
+++ b/src/domain/headlessCms/client.ts
@@ -6,8 +6,10 @@ import {
 } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
 import * as Sentry from '@sentry/browser';
+import { LanguagesDocument } from 'react-helsinki-headless-cms/apollo';
 
 import AppConfig from '../app/AppConfig';
+import { HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE } from '../languages/constants';
 
 const httpLink = createHttpLink({
   uri: import.meta.env.VITE_CMS_URI,
@@ -38,6 +40,13 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
 const client = new ApolloClient({
   link: ApolloLink.from([errorLink, httpLink]),
   cache: new InMemoryCache(),
+});
+
+// Make sure the hardcoded CMS languages response is always in cache
+client.writeQuery({
+  query: LanguagesDocument,
+  data: { ...HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE },
+  variables: {},
 });
 
 export default client;

--- a/src/domain/languages/constants.ts
+++ b/src/domain/languages/constants.ts
@@ -1,0 +1,41 @@
+import { type Language, LanguageCodeEnum } from 'react-helsinki-headless-cms';
+
+export const CMS_FINNISH_LANGUAGE_ENTRY = {
+  code: LanguageCodeEnum.Fi,
+  id: 'TGFuZ3VhZ2U6Zmk=',
+  locale: 'fi',
+  name: 'Suomi',
+  slug: 'fi',
+  __typename: 'Language',
+} as const satisfies Language;
+
+export const CMS_ENGLISH_LANGUAGE_ENTRY = {
+  code: LanguageCodeEnum.En,
+  id: 'TGFuZ3VhZ2U6ZW4=',
+  locale: 'en_US',
+  name: 'English',
+  slug: 'en',
+  __typename: 'Language',
+} as const satisfies Language;
+
+export const CMS_SWEDISH_LANGUAGE_ENTRY = {
+  code: LanguageCodeEnum.Sv,
+  id: 'TGFuZ3VhZ2U6c3Y=',
+  locale: 'sv_SE',
+  name: 'Svenska',
+  slug: 'sv',
+  __typename: 'Language',
+} as const satisfies Language;
+
+export const HARDCODED_CMS_LANGUAGES = [
+  { ...CMS_FINNISH_LANGUAGE_ENTRY },
+  { ...CMS_ENGLISH_LANGUAGE_ENTRY },
+  { ...CMS_SWEDISH_LANGUAGE_ENTRY },
+] as const;
+
+/** Data taken from production CMS languages query response. */
+export const HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE = {
+  data: {
+    languages: [...HARDCODED_CMS_LANGUAGES],
+  },
+} as const;

--- a/src/domain/profile/modal/__tests__/EditProfileModal.test.tsx
+++ b/src/domain/profile/modal/__tests__/EditProfileModal.test.tsx
@@ -12,8 +12,8 @@ import {
   waitFor,
 } from '../../../../common/test/testingLibraryUtils';
 import initModal from '../../../../common/test/initModal';
-import { languagesQueryResponse } from '../../../app/footer/__mocks__/languagesMock';
 import { languagesQuery } from '../../../languages/queries/LanguageQueries';
+import { HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE } from '../../../languages/constants';
 
 const initialValues: MyProfile = {
   id: 'yuiop',
@@ -48,7 +48,7 @@ const languagesMock: MockedResponse = {
     query: languagesQuery,
     variables: {},
   },
-  result: { ...languagesQueryResponse },
+  result: { ...HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE },
 };
 
 const mocks: MockedResponse[] = [languagesMock];

--- a/src/domain/registration/form/__tests__/RegistrationForm.test.tsx
+++ b/src/domain/registration/form/__tests__/RegistrationForm.test.tsx
@@ -6,8 +6,8 @@ import RegistrationForm, {
 } from '../RegistrationForm';
 import { render, screen } from '../../../../common/test/testingLibraryUtils';
 import { languagesQuery } from '../../../languages/queries/LanguageQueries';
-import { languagesQueryResponse } from '../../../app/footer/__mocks__/languagesMock';
 import profileQuery from '../../../profile/queries/ProfileQuery';
+import { HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE } from '../../../languages/constants';
 
 const emptyProfileMock: MockedResponse = {
   request: {
@@ -24,7 +24,7 @@ const languagesMock: MockedResponse = {
     query: languagesQuery,
     variables: {},
   },
-  result: { ...languagesQueryResponse },
+  result: { ...HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE },
 };
 
 const mocks: MockedResponse[] = [emptyProfileMock, languagesMock];


### PR DESCRIPTION
## Description

### feat: hardcode CMS languages for faster language rendering in header

to ameliorate the current CMS query speed issues hardcode the CMS
languages query response to apollo client's cache, this is acceptable
as the CMS language query's data is practically constant

CMS languages query could even be replaced with a language enumeration
(i.e. 'fi' | 'sv' | 'en' basically) use if `react-helsinki-headless-cms`
would be updated to use such

refs KK-1406

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-1406](https://helsinkisolutionoffice.atlassian.net/browse/KK-1406)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1406]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ