### PR TITLE
feat: use apollo client local storage cache persister

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@vitejs/plugin-react-swc": "^3.7.2",
     "@vitest/coverage-v8": "^3.0.4",
     "@vitest/eslint-plugin": "^1.1.25",
+    "apollo3-cache-persist": "^0.15.0",
     "browserslist": "^4.24.4",
     "classnames": "^2.5.1",
     "codecov": "^3.8.3",

--- a/src/domain/app/AppConfig.ts
+++ b/src/domain/app/AppConfig.ts
@@ -275,6 +275,18 @@ class AppConfig {
   }
 
   /**
+   * How long should the Apollo peristed cache be kept in local storage.
+   * Read env variable `VITE_APOLLO_PERSISTED_CACHE_TIME_TO_LIVE_MS`.
+   * Time in milliseconds. Defaults to 10 minutes.
+   */
+  static get apolloPersistedCacheTimeToLiveMs() {
+    return (
+      Number(import.meta.env.VITE_APOLLO_PERSISTED_CACHE_TIME_TO_LIVE_MS) ||
+      1000 * 60 * 10
+    ); // 10 minutes by default;
+  }
+
+  /**
    * An array of supported locale codes (e.g., ['fi', 'en']).
    */
   static get locales(): readonly string[] {

--- a/src/domain/headlessCms/__tests__/client.test.ts
+++ b/src/domain/headlessCms/__tests__/client.test.ts
@@ -1,13 +1,21 @@
 import { graphql, HttpResponse } from 'msw';
 import { PageDocument } from 'react-helsinki-headless-cms/apollo';
+import {
+  ApolloClient,
+  InMemoryCache,
+  NormalizedCacheObject,
+} from '@apollo/client';
 
 import { server } from '../../../test/msw/server';
 import { fakePage } from '../../../utils/cmsMockDataUtils';
-import client from '../client';
+import { createCmsApolloClient } from '../client';
+import { LogLevel, TimedApolloCachePersistor } from '../persistor';
 
+let client: ApolloClient<NormalizedCacheObject>;
 const page = fakePage();
 
 beforeEach(() => {
+  client = createCmsApolloClient();
   const link =
     process.env.VITE_CMS_URI ||
     'https://kukkuu.app-staging.hkih.hion.dev/graphql';
@@ -22,7 +30,7 @@ describe('Headless CMS Client', () => {
     const { data } = await client.query({
       query: PageDocument,
       variables: {
-        id: '/en/slug',
+        id: page!.id,
         language: 'EN',
       },
       // NOTE: The React-helsinki-headless-cms library sets a cache here by default
@@ -30,5 +38,172 @@ describe('Headless CMS Client', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(data.page.id).toEqual(page!.id);
+  });
+
+  it('returns a page from the cache when a page query is requested', async () => {
+    const variables = {
+      id: page!.id,
+      language: 'EN',
+    };
+    // First query to populate the cache
+    await client.query({
+      query: PageDocument,
+      variables,
+      fetchPolicy: 'cache-first',
+    });
+
+    // Second query to test cache retrieval
+    const { data } = await client.query({
+      query: PageDocument,
+      variables,
+      fetchPolicy: 'cache-only',
+    });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(data.page.id).toEqual(page!.id);
+  });
+
+  describe('persisted cache', () => {
+    afterEach(() => {
+      localStorage.clear();
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+      client.cache.reset(); // Reset the cache after each test.
+    });
+
+    it('clears the local storage on initialization when the persisted cache has expired', async () => {
+      const hasPersistedCacheExpiredSpy = vi
+        .spyOn(TimedApolloCachePersistor.prototype, 'hasPersistedCacheExpired')
+        .mockImplementation(() => true);
+      const clearLocalStorageSpy = vi.spyOn(
+        TimedApolloCachePersistor.prototype,
+        'clearLocalStorage'
+      );
+      const cachePersistor = new TimedApolloCachePersistor(
+        client.cache as InMemoryCache,
+        {
+          logLevel: LogLevel.WARN,
+          persistedCacheTimeToLiveMs: 0, // Set TTL to 0 to simulate expiration
+        }
+      );
+      expect(cachePersistor.hasPersistedCacheExpired()).toBe(true);
+      expect(hasPersistedCacheExpiredSpy).toHaveBeenCalledTimes(2);
+      expect(clearLocalStorageSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not clear the local storage when the persisted cache has not expired', async () => {
+      const hasPersistedCacheExpiredSpy = vi
+        .spyOn(TimedApolloCachePersistor.prototype, 'hasPersistedCacheExpired')
+        .mockReturnValue(false);
+      const clearLocalStorageSpy = vi.spyOn(
+        TimedApolloCachePersistor.prototype,
+        'clearLocalStorage'
+      );
+      const cachePersistor = new TimedApolloCachePersistor(
+        client.cache as InMemoryCache,
+        {
+          logLevel: LogLevel.WARN,
+          persistedCacheTimeToLiveMs: 10000,
+        }
+      );
+      expect(cachePersistor.hasPersistedCacheExpired()).toBe(false);
+      expect(hasPersistedCacheExpiredSpy).toHaveBeenCalledTimes(2);
+      expect(clearLocalStorageSpy).not.toHaveBeenCalled();
+    });
+
+    it('persists the cache to localStorage', async () => {
+      const cachePersistor = new TimedApolloCachePersistor(
+        client.cache as InMemoryCache,
+        {
+          logLevel: LogLevel.WARN,
+          persistedCacheTimeToLiveMs: 10000,
+        }
+      );
+
+      await cachePersistor.persist();
+      const persistedData = localStorage.getItem(
+        cachePersistor.persistorLocalStorageKey
+      );
+      expect(persistedData).not.toBeNull();
+      const persistedTimestamp = localStorage.getItem(
+        cachePersistor.timePersistedLocalStorageKey
+      );
+      expect(persistedTimestamp).not.toBeNull();
+    });
+
+    it('restores the cache from localStorage', async () => {
+      // Make a query to write cache
+      await client.query({
+        query: PageDocument,
+        variables: {
+          id: page!.id,
+          language: 'EN',
+        },
+        fetchPolicy: 'network-only',
+      });
+
+      // Create a persistor
+      const cachePersistor = new TimedApolloCachePersistor(
+        client.cache as InMemoryCache,
+        {
+          logLevel: LogLevel.WARN,
+          persistedCacheTimeToLiveMs: 10000,
+        }
+      );
+
+      // Persist to localStorage
+      cachePersistor.persist();
+
+      // reset the client cache
+      client.cache.reset();
+
+      // Test that the cache is empty
+      const { data: dataBeforeRestore } = await client.query({
+        query: PageDocument,
+        variables: {
+          id: page!.id,
+          language: 'EN',
+        },
+        fetchPolicy: 'cache-only',
+      });
+      expect(dataBeforeRestore).toEqual({});
+
+      // Restore the cache from locaStorage
+      await cachePersistor.restore();
+
+      // Test that the cache is restored
+      const { data: dataAfterRestore } = await client.query({
+        query: PageDocument,
+        variables: {
+          id: page!.id,
+          language: 'EN',
+        },
+        fetchPolicy: 'cache-only',
+      });
+      expect(dataAfterRestore.page.id).toEqual(page!.id);
+    });
+
+    it.each([600000, 10000])(
+      'expires the persisted cache in set time (%i ms)',
+      async (persistedCacheTimeToLiveMs) => {
+        vi.useFakeTimers();
+        const cachePersistor = new TimedApolloCachePersistor(
+          client.cache as InMemoryCache,
+          {
+            persistedCacheTimeToLiveMs,
+          }
+        );
+
+        const persistedAt = Date.now();
+        localStorage.setItem(
+          cachePersistor.timePersistedLocalStorageKey,
+          persistedAt.toString()
+        );
+
+        expect(cachePersistor.hasPersistedCacheExpired()).toBe(false);
+
+        vi.advanceTimersByTime(persistedCacheTimeToLiveMs + 1);
+        expect(cachePersistor.hasPersistedCacheExpired()).toBe(true);
+      }
+    );
   });
 });

--- a/src/domain/headlessCms/cache.ts
+++ b/src/domain/headlessCms/cache.ts
@@ -1,0 +1,46 @@
+import { InMemoryCache } from '@apollo/client/cache/inmemory/inMemoryCache';
+
+import { HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE } from '../languages/constants';
+
+export const queryPolicies = {
+  languages: 'cache-only',
+  language: 'cache-only',
+  menu: 'cache-and-network',
+} as const;
+
+export function isConfiguredQueryPolicy(
+  policy?: string
+): policy is keyof typeof queryPolicies {
+  if (!policy) {
+    return false;
+  }
+  return policy in queryPolicies;
+}
+
+/**
+ * Create a Apollo cache.
+ */
+export function createApolloCache() {
+  return new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          // Hardcode the languages query response, so we don't need to ever fetch it from the CMS.
+          languages: {
+            read() {
+              return HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE['data']['languages'];
+            },
+          },
+          // Hardcode the language query response, so we don't need to ever fetch it from the CMS.
+          language: {
+            read(id: string) {
+              return HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE['data'][
+                'languages'
+              ].find((language) => language.id === id);
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/src/domain/headlessCms/client.ts
+++ b/src/domain/headlessCms/client.ts
@@ -1,52 +1,103 @@
-import {
-  ApolloClient,
-  createHttpLink,
-  InMemoryCache,
-  ApolloLink,
-} from '@apollo/client';
+import { ApolloClient, createHttpLink, ApolloLink } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
 import * as Sentry from '@sentry/browser';
-import { LanguagesDocument } from 'react-helsinki-headless-cms/apollo';
 
 import AppConfig from '../app/AppConfig';
-import { HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE } from '../languages/constants';
+import {
+  createApolloCache,
+  isConfiguredQueryPolicy,
+  queryPolicies,
+} from './cache';
+import { LogLevel, TimedApolloCachePersistor } from './persistor';
 
-const httpLink = createHttpLink({
-  uri: import.meta.env.VITE_CMS_URI,
-});
+export function createCmsApolloClient() {
+  const httpLink = createHttpLink({
+    uri: import.meta.env.VITE_CMS_URI,
+  });
 
-const errorLink = onError(({ graphQLErrors, networkError }) => {
-  if (graphQLErrors) {
-    graphQLErrors.forEach(({ message, locations, path, extensions }) => {
-      const errorCode = extensions?.code;
+  const errorLink = onError(({ graphQLErrors, networkError }) => {
+    if (graphQLErrors) {
+      graphQLErrors.forEach(({ message, locations, path, extensions }) => {
+        const errorCode = extensions?.code;
 
-      // eslint-disable-next-line max-len
-      const errorMessage = `[GraphQL error]: Message: ${message}, Code: ${errorCode}, Location: ${locations}, Path: ${path}`;
+        // eslint-disable-next-line max-len
+        const errorMessage = `[GraphQL error]: Message: ${message}, Code: ${errorCode}, Location: ${locations}, Path: ${path}`;
 
-      Sentry.captureMessage(errorMessage);
+        Sentry.captureMessage(errorMessage);
 
-      if (!AppConfig.isAppInProductionMode) {
-        // eslint-disable-next-line no-console
-        console.error(errorMessage);
-      }
-    });
-  }
+        if (!AppConfig.isAppInProductionMode) {
+          // eslint-disable-next-line no-console
+          console.error(errorMessage);
+        }
+      });
+    }
 
-  if (networkError) {
-    Sentry.captureMessage('Network error');
-  }
-});
+    if (networkError) {
+      Sentry.captureMessage('Network error');
+    }
+  });
 
-const client = new ApolloClient({
-  link: ApolloLink.from([errorLink, httpLink]),
-  cache: new InMemoryCache(),
-});
+  const cache = createApolloCache();
+  const kukkuuApolloCachePersistor = new TimedApolloCachePersistor(cache, {
+    logLevel: LogLevel.WARN,
+    persistedCacheTimeToLiveMs: AppConfig.apolloPersistedCacheTimeToLiveMs,
+  });
 
-// Make sure the hardcoded CMS languages response is always in cache
-client.writeQuery({
-  query: LanguagesDocument,
-  data: { ...HARDCODED_CMS_LANGUAGE_QUERY_RESPONSE },
-  variables: {},
-});
+  (async () => {
+    if (kukkuuApolloCachePersistor.hasPersistedCacheExpired()) {
+      // eslint-disable-next-line no-console
+      console.info('Persisted cache has expired.');
+      await kukkuuApolloCachePersistor.purge();
+    } else {
+      await kukkuuApolloCachePersistor.restore();
+      // eslint-disable-next-line no-console
+      console.info('Persisted cache has been restored.');
+    }
+  })();
+
+  const client = new ApolloClient({
+    link: ApolloLink.from([errorLink, httpLink]),
+    cache,
+    defaultOptions: {
+      watchQuery: {
+        nextFetchPolicy(
+          currentFetchPolicy,
+          {
+            // Either "after-fetch" or "variables-changed", indicating why the
+            // nextFetchPolicy function was invoked.
+            reason,
+            // The rest of the options (currentFetchPolicy === options.fetchPolicy).
+            // The original value of options.fetchPolicy, before nextFetchPolicy was
+            // applied for the first time.
+            initialFetchPolicy,
+            // The ObservableQuery associated with this client.watchQuery call.
+            observable,
+          }
+        ) {
+          // When variables change, the default behavior is to reset
+          // options.fetchPolicy to context.initialFetchPolicy. If you omit this logic,
+          // your nextFetchPolicy function can override this default behavior to
+          // prevent options.fetchPolicy from changing in this case.
+          if (reason === 'variables-changed') {
+            return initialFetchPolicy;
+          }
+          // The languages are hardcoded in the cache, so we can always return cache-only,
+          // because the languages never changes. Also, flashing on menus should be avoided,
+          // so the menu query should first try from cache, but could still update cache
+          // on background.
+          if (isConfiguredQueryPolicy(observable.queryName)) {
+            return queryPolicies[observable.queryName];
+          }
+          // Leave all other fetch policies unchanged.
+          return currentFetchPolicy;
+        },
+      },
+    },
+  });
+
+  return client;
+}
+
+const client = createCmsApolloClient();
 
 export default client;

--- a/src/domain/headlessCms/persistor.ts
+++ b/src/domain/headlessCms/persistor.ts
@@ -1,0 +1,206 @@
+import { InMemoryCache } from '@apollo/client/cache/inmemory/inMemoryCache';
+import { CachePersistor, LocalStorageWrapper } from 'apollo3-cache-persist';
+import { NormalizedCacheObject } from '@apollo/client';
+
+import AppConfig from '../app/AppConfig';
+
+// Using console for logging for simplicity, consider a logging library
+export enum LogLevel {
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+}
+
+class TimedApolloCachePersistorLogger {
+  private readonly logLevel: LogLevel;
+
+  constructor(logLevel: LogLevel = LogLevel.INFO) {
+    this.logLevel = logLevel;
+  }
+
+  debug(message: string, ...optionalParams: unknown[]) {
+    if (this.logLevel <= LogLevel.DEBUG) {
+      // eslint-disable-next-line no-console
+      console.debug(message, ...optionalParams);
+    }
+  }
+
+  info(message: string, ...optionalParams: unknown[]) {
+    if (this.logLevel <= LogLevel.INFO) {
+      // eslint-disable-next-line no-console
+      console.info(message, ...optionalParams);
+    }
+  }
+
+  warn(message: string, ...optionalParams: unknown[]) {
+    if (this.logLevel <= LogLevel.WARN) {
+      // eslint-disable-next-line no-console
+      console.warn(message, ...optionalParams);
+    }
+  }
+
+  error(message: string, ...optionalParams: unknown[]) {
+    if (this.logLevel <= LogLevel.ERROR) {
+      // eslint-disable-next-line no-console
+      console.error(message, ...optionalParams);
+    }
+  }
+}
+
+export interface TimedApolloCachePersistorOptions {
+  /**
+   * The time-to-live for the persisted cache in milliseconds.
+   * Defaults to 10 minutes (600000 milliseconds).
+   */
+  persistedCacheTimeToLiveMs?: number;
+  /**
+   * The logging level to use. Defaults to LogLevel.INFO.
+   */
+  logLevel?: LogLevel;
+}
+
+export class TimedApolloCachePersistor {
+  persistorLocalStorageKey: string;
+  timePersistedLocalStorageKey: string;
+  persistedCacheTimeToLiveMs: number;
+  persistor: CachePersistor<NormalizedCacheObject>;
+  private readonly logger: TimedApolloCachePersistorLogger;
+
+  /**
+   * Creates a new TimedApolloCachePersistor instance to manage the Apollo cache
+   * with an expiration time. This class automatically clears expired caches
+   * and provides methods for persisting and restoring the cache to/from localStorage.
+   *
+   * @param cache The Apollo InMemoryCache instance to be managed.
+   * @param options Options for configuring the persistor.
+   *
+   * @example
+   * const cache = new InMemoryCache();
+   * const persistor = new TimedApolloCachePersistor(cache, {
+   * persistedCacheTimeToLiveMs: 1000 * 60 * 5, // 5 minute expiry
+   * logLevel: LogLevel.DEBUG
+   * });
+   */
+  constructor(
+    cache: InMemoryCache,
+    options: TimedApolloCachePersistorOptions = {}
+  ) {
+    const {
+      persistedCacheTimeToLiveMs = 1000 * 60 * 10, // 10 minutes
+      logLevel = LogLevel.INFO,
+    } = options;
+    this.logger = new TimedApolloCachePersistorLogger(logLevel);
+    this.persistorLocalStorageKey = `kukkuu-ui-cms-${AppConfig.environment}-apollo-cache`;
+    this.timePersistedLocalStorageKey = `kukkuu-ui-cms-${AppConfig.environment}-apollo-cache-persisted-at`;
+    this.persistedCacheTimeToLiveMs = persistedCacheTimeToLiveMs;
+    this.persistor = this.createApolloCachePersistor(cache);
+  }
+
+  /**
+   * @private
+   * Creates and configures the Apollo CachePersistor instance.
+   * This method also handles clearing expired caches from localStorage.
+   * * @param cache The Apollo InMemoryCache instance.
+   * @returns The configured CachePersistor instance.
+   */
+  private createApolloCachePersistor(cache: InMemoryCache) {
+    if (this.hasPersistedCacheExpired()) {
+      try {
+        this.clearLocalStorage();
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          this.logger.error(
+            'Failed to clear local storage:',
+            e.message,
+            e.stack
+          );
+        } else {
+          this.logger.error('Failed to clear local storage:', e); //log the unknown error.
+        }
+      }
+
+      localStorage.setItem(
+        this.timePersistedLocalStorageKey,
+        Date.now().toString()
+      );
+
+      this.logger.debug(
+        'timePersistedLocalStorageKey has been set to',
+        this.timePersistedLocalStorageKey
+      );
+    }
+    return new CachePersistor({
+      cache,
+      storage: new LocalStorageWrapper(localStorage),
+      key: this.persistorLocalStorageKey,
+    });
+  }
+
+  /**
+   * Checks if the persisted Apollo cache has expired based on the
+   * `persistedCacheTimeToLiveMs` value.
+   *
+   * @returns `true` if the cache has expired, `false` otherwise.
+   */
+  hasPersistedCacheExpired() {
+    const persistedAt = parseInt(
+      localStorage.getItem(this.timePersistedLocalStorageKey) ?? ''
+    );
+
+    if (isNaN(persistedAt)) {
+      this.logger.debug('Persisted cache has not been set.');
+      return true;
+    }
+
+    const millisecondsLeft =
+      persistedAt + this.persistedCacheTimeToLiveMs - Date.now();
+
+    // eslint-disable-next-line no-console
+    this.logger.debug(
+      'Persisted cache expires in',
+      millisecondsLeft / 1000,
+      'seconds.'
+    );
+
+    return millisecondsLeft <= 0;
+  }
+
+  /**
+   * A synchronous way to clear the persisted Apollo cache data from localStorage.
+   * Note: This does not clear the cache from the Apollo cache itself.
+   * `this.purge()` should be used to clear the cache from the Apollo cache,
+   * but it should be noted that it is an async function.
+   * @returns void
+   **/
+  clearLocalStorage() {
+    localStorage.removeItem(this.timePersistedLocalStorageKey);
+    localStorage.removeItem(this.persistorLocalStorageKey);
+    this.logger.info('Persisted cache localStorage has been cleared.');
+  }
+
+  /**
+   * Clears the persisted Apollo cache from both the Apollo cache and localStorage.
+   */
+  async purge() {
+    await this.persistor.purge();
+    this.clearLocalStorage();
+    this.logger.info('Persisted cache has been purged.');
+  }
+
+  /**
+   * Persists the current Apollo cache to localStorage.
+   */
+  async persist() {
+    await this.persistor.persist();
+    this.logger.info('Cache has been persisted.');
+  }
+
+  /**
+   * Restores the Apollo cache from localStorage.
+   */
+  async restore() {
+    await this.persistor.restore();
+    this.logger.info('Persisted cache has been restored.');
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,6 +3756,11 @@ ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
+apollo3-cache-persist@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/apollo3-cache-persist/-/apollo3-cache-persist-0.15.0.tgz#aee23062bc811f3bc15369b850002f54195a6572"
+  integrity sha512-asxhPOHGddgXYvY4/Wa+XLODYpjci/kPB4zdy82D0tVGzVmvO4lqp3k06NtzHvd//gd9kCnTaG8iziwAcXZYjw==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"


### PR DESCRIPTION
KK-1406.

Installed apollo3-cache-persist.

Refactored code by spitting the CMS client code to multiple files.

Implemented `TimedApolloCachePersistor` that creates a new persisted Apollo cache persistor with an expiration time. This class automatically clears expired caches and provides methods for persisting and restoring the cache to/from localStorage.

The language(s) queries are now hard coded to the Apollo client's in memory cache in the apollo client's initialization, so there is no need to handle cache or queries related those anymore.
