### PR TITLE
feat: use react-router Link in scope of RHHC

### DIFF
--- a/src/hooks/useRHHCConfig.tsx
+++ b/src/hooks/useRHHCConfig.tsx
@@ -6,6 +6,7 @@ import {
   ModuleItemTypeEnum,
 } from 'react-helsinki-headless-cms';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
 
 import headlessCmsClient from '../domain/headlessCms/client';
 import AppConfig from '../domain/app/AppConfig';
@@ -39,6 +40,8 @@ export default function useRHHCConfig(): Config {
         appLanguageToRHHCLanguageMap[language] ?? LanguageCodeEnum.Fi,
       components: {
         ...rhhcDefaultConfig.components,
+        A: ({ href, ...props }) => <Link to={href ?? ''} {...props} />,
+        Link: ({ href, ...props }) => <Link to={href ?? ''} {...props} />,
         Img: rhhcDefaultConfig.components.Img,
         // Extend the Kukkuu PageMeta with the RHHC PageMeta
         // to get the CMS Page SEO Meta to work properly.


### PR DESCRIPTION
KK-1406.

NOTE: This works best together with the #662, that brings the cached menu.
