### PR TITLE
KK-1424 | Fix routing of internal hrefs in Notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",
-    "react-helsinki-headless-cms": "1.0.0",
+    "react-helsinki-headless-cms": "1.0.1",
     "react-i18next": "^15.4.0",
     "react-idle-timer": "^5.7.2",
     "react-modal": "^3.16.3",

--- a/src/hooks/useRHHCConfig.tsx
+++ b/src/hooks/useRHHCConfig.tsx
@@ -84,11 +84,11 @@ export default function useRHHCConfig(): Config {
           if (!link) {
             return '#';
           }
-          internalHrefOrigins.forEach((origin) => {
+          for (const origin of internalHrefOrigins) {
             if (link.includes(origin)) {
               return link.replace(origin, '');
             }
-          });
+          }
           return link;
         },
         getShowAllUrl: () => '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9974,10 +9974,10 @@ react-helmet-async@^2.0.5:
     react-fast-compare "^3.2.2"
     shallowequal "^1.1.0"
 
-react-helsinki-headless-cms@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.0.tgz#3c3b409ca307a04bdbb1ab9032751a1d3dad39de"
-  integrity sha512-ZmLd5lCxmjccW8Nk6pQ9EV2cfeI+UHauTAQFRppWCNlBZ6J1bv4/pm0SlxNef11KMeM5/MWlruAhIXcqFxOLEg==
+react-helsinki-headless-cms@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.1.tgz#8e92845755f78d8aedf9f0cfffd7a0220ff3adf3"
+  integrity sha512-jhgiRLSV+OKqW9gmAhNBBkwBnEO0IBqjDSU5e9+XmfQXYwtx58tIfK1ysLgTSGBfJXGCR1KvfrE8ZyG+qL8mwg==
   dependencies:
     hds-design-tokens "^3.11.0"
     html-entities "^2.5.2"


### PR DESCRIPTION
<!-- DOCTOC SKIP -->

## Description

### Fix routing of internal hrefs in Notification

Depends on RHHC PR #203's changes that started mapping the linkUrl in
Notification component through getRoutedInternalHref:
https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/203

These RHHC changes were published to npm as
react-helsinki-headless-cms v1.0.1.

At kukkuu-ui side the getRoutedInternalHref function was bugged because
forEach doesn't return anything else but undefined:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
> forEach() always returns undefined and is not chainable. The typical
> use case is to execute side effects at the end of a chain.

Switching from forEach to a for loop made the getRoutedInternalHref work

refs KK-1424

<!-- Describe your changes in detail -->

## Context

- [KK-1424](https://helsinkisolutionoffice.atlassian.net/browse/KK-1424)
- https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/203

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

### Finnish

- ![image](https://github.com/user-attachments/assets/37a143c8-26f0-424b-aaac-00e55b2f0655)
- Clicking on "Lue lisää" takes to "Ajankohtaista"-page:
- ![image](https://github.com/user-attachments/assets/10667c20-d5da-420b-a343-bd99009b906f)

At Headless CMS side:
- ![image](https://github.com/user-attachments/assets/fb80bc66-10d8-4d1e-90a5-3557f8c7c792)

### Swedish

- ![image](https://github.com/user-attachments/assets/a2afbb6a-523f-4f84-a8db-aa1214ec68dc)
- Clicking on "Lue lisää" takes to "Ajankohtaista"-page (Checked CMS that the Swedish version is pointing to a Finnish page, so this is a data problem):
- ![image](https://github.com/user-attachments/assets/fd802c53-513f-4c45-b4f3-6a6762425a37)

At Headless CMS side:
- ![image](https://github.com/user-attachments/assets/f3d7a130-bdef-4f7d-a1a2-26cf23751fc3)

### English

- ![image](https://github.com/user-attachments/assets/0c89b777-072a-4cb0-bee0-b2fb4183e37e)
- Clicking on "Read mode" takes to "News"-page
- ![image](https://github.com/user-attachments/assets/2f583357-ae6f-48ff-bb11-04fda9356d78)

At Headless CMS side:
- ![image](https://github.com/user-attachments/assets/b30af51b-199c-4d3a-a92d-c2d666c79776)

<!-- Add screenshots if appropriate -->


[KK-1424]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ