### PR TITLE
Try to fix Layout.test.tsx by using MemoryRouter, not BrowserRouter

### DIFF
--- a/src/common/test/TestProviders.tsx
+++ b/src/common/test/TestProviders.tsx
@@ -2,7 +2,7 @@ import { ReactElement, ReactNode } from 'react';
 import { Provider } from 'react-redux';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { HelmetProvider } from 'react-helmet-async';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import {
   ConfigProvider as RHHCConfigProvider,
   defaultConfig as rhhcDefaultConfig,
@@ -11,6 +11,7 @@ import {
 import { ApolloClient } from '@apollo/client/core/ApolloClient';
 import { useApolloClient } from '@apollo/client/react/hooks/useApolloClient';
 
+import type { RouterType } from './types';
 import { store } from '../../domain/app/state/AppStore';
 import ProfileProvider from '../../domain/profile/ProfileProvider';
 import KukkuuHDSLoginProvider from '../../domain/auth/KukkuuHDSLoginProvider';
@@ -20,10 +21,12 @@ type Props = {
   children: ReactElement | ReactNode;
   // eslint-disable-next-line react/no-unused-prop-types
   mocks?: MockedResponse[];
+  // eslint-disable-next-line react/no-unused-prop-types
+  router?: RouterType;
 };
 
 const TestProviders = (props: Props) => {
-  const { children, mocks } = props;
+  const { children, mocks, router = 'BrowserRouter' } = props;
   return (
     <Provider store={store}>
       <MockedProvider mocks={mocks}>
@@ -32,7 +35,11 @@ const TestProviders = (props: Props) => {
             <ProfileProvider>
               <RHHCConfigProviderWithMockedApolloClient {...props}>
                 <HelmetProvider>
-                  <BrowserRouter>{children}</BrowserRouter>
+                  {router === 'MemoryRouter' ? (
+                    <MemoryRouter>{children}</MemoryRouter>
+                  ) : (
+                    <BrowserRouter>{children}</BrowserRouter>
+                  )}
                 </HelmetProvider>
               </RHHCConfigProviderWithMockedApolloClient>
             </ProfileProvider>

--- a/src/common/test/customRender.tsx
+++ b/src/common/test/customRender.tsx
@@ -2,16 +2,20 @@ import type { ReactElement } from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
 import type { MockedResponse } from '@apollo/client/testing';
 
+import type { RouterType } from './types';
 import TestProviders from './TestProviders';
 
 export const customRender = (
   ui: ReactElement,
   mocks?: MockedResponse[],
-  options?: RenderOptions
+  options?: RenderOptions,
+  router?: RouterType
 ) =>
   render(ui, {
     wrapper: ({ children }) => (
-      <TestProviders mocks={mocks}>{children}</TestProviders>
+      <TestProviders mocks={mocks} router={router}>
+        {children}
+      </TestProviders>
     ),
     ...options,
   });

--- a/src/common/test/types.ts
+++ b/src/common/test/types.ts
@@ -1,0 +1,1 @@
+export type RouterType = 'BrowserRouter' | 'MemoryRouter';

--- a/src/domain/app/__tests__/Layout.test.tsx
+++ b/src/domain/app/__tests__/Layout.test.tsx
@@ -26,6 +26,6 @@ beforeEach(() => {
 });
 
 it('renders without crashing', () => {
-  const { container } = render(<Layout />, mocks);
+  const { container } = render(<Layout />, mocks, undefined, 'MemoryRouter');
   expect(container).toMatchSnapshot();
 });


### PR DESCRIPTION
<!-- DOCTOC SKIP -->

## Description

Try to fix Layout.test.tsx by using MemoryRouter, not BrowserRouter

The Layout.test.tsx broke in github run tests with:
```
 FAIL  src/domain/app/__tests__/Layout.test.tsx > renders without crashing
Error: useLocation() may be used only in the context of a <Router> component.
 ❯ invariant node_modules/react-router/dist/development/index.js:327:11
    325| function invariant(value, message) {
    326|   if (value === false || value === null || typeof value === "undefined…
    327|     throw new Error(message);
       |           ^
    328|   }
    329| }
 ❯ useLocation node_modules/react-router/dist/development/index.js:4229:3
 ❯ useCmsLanguageOptions src/hooks/useCmsLanguageOptions.ts:11:20
 ❯ Navigation src/domain/app/navigation/Navigation.tsx:21:30
 ❯ renderWithHooks node_modules/react-dom/cjs/react-dom.development.js:15486:18
 ❯ mountIndeterminateComponent node_modules/react-dom/cjs/react-dom.development.js:20103:13
 ❯ beginWork node_modules/react-dom/cjs/react-dom.development.js:21626:16
 ❯ beginWork$1 node_modules/react-dom/cjs/react-dom.development.js:27465:14
 ❯ performUnitOfWork node_modules/react-dom/cjs/react-dom.development.js:26599:12
 ❯ workLoopSync node_modules/react-dom/cjs/react-dom.development.js:26505:5
```

Using MemoryRouter instead of BrowserRouter for the
Layout.test.tsx's test case to see if that fixes the test when
run in github environment, as the test did pass when run
locally with Node 20.

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

Example of failing test when ran in github environment:
 - https://github.com/City-of-Helsinki/kukkuu-ui/actions/runs/14060698150/job/39370479476

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

Failing test in github environment:
![image](https://github.com/user-attachments/assets/ba667573-fe51-4d83-88d4-e4251076d55a)

<!-- Add screenshots if appropriate -->
