### PR TITLE
fix: improve child notes explanation text in means of privacy policy

### DIFF
--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -244,7 +244,7 @@
       "heading": "My diary of events",
       "edit": "Edit",
       "save": "Save",
-      "noNotes": "Attach information about past Culture Kids events here and write notes about future ones as well.",
+      "noNotes": "Do not enter personal information such as names, health information, or other sensitive information.",
       "titlegroup": "Title",
       "titleAction": "Insert title",
       "errorMessage": "An error occurred while saving the data. Please try again later."

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -244,7 +244,7 @@
       "heading": "Päiväkirjamerkintäni tapahtumista",
       "edit": "Muokkaa",
       "save": "Tallenna",
-      "noNotes": "Voit liittää tähän tiedot menneistä kummitapahtumista ja kirjoittaa muistiinpanoja myös tulevista.",
+      "noNotes": "Älä kirjoita tähän henkilötietoja kuten nimiä, terveystietoja tai muita arkaluonteisia tietoja.",
       "titlegroup": "Otsikko",
       "titleAction": "Lisää otsikko",
       "errorMessage": "Tapahtui virhe tietojen tallennuksessa. Yritä myöhemmin uudestaan."

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -244,7 +244,7 @@
       "heading": "Min dagbok om evenemang",
       "edit": "Redigera",
       "save": "Spara",
-      "noNotes": "Bifoga information om tidigare fadderevenemang här och skriva anteckningar om framtida också.",
+      "noNotes": "Skriv inte personuppgifter såsom namn, hälsouppgifter eller andra känsliga uppgifter.",
       "titlegroup": "Titel",
       "titleAction": "Infoga titel",
       "errorMessage": "Ett fel uppstod när data sparades. Försök igen senare."


### PR DESCRIPTION
KK-1432.

Be more clear that users should not include any sensitive information in the child notes.