### PR TITLE
fix: define default locale for external authentication process

### DIFF
--- a/src/domain/auth/KukkuuHDSLoginProvider.tsx
+++ b/src/domain/auth/KukkuuHDSLoginProvider.tsx
@@ -11,14 +11,24 @@ import AppConfig from '../app/AppConfig';
 type KukkuuHDSLoginProviderProps = { children: React.ReactNode };
 
 function KukkuuHDSLoginProvider({ children }: KukkuuHDSLoginProviderProps) {
-  const { t } = useTranslation();
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
   const providerProperties =
     AppConfig.oidcServerType === 'TUNNISTAMO'
       ? tunnistamoPoviderProperties
       : keycloakPoviderProperties;
 
   return (
-    <LoginProvider {...providerProperties}>
+    <LoginProvider
+      {...providerProperties}
+      userManagerSettings={{
+        ...providerProperties.userManagerSettings,
+        // Define what language to use in the (external) login page
+        ui_locales: language,
+      }}
+    >
       {children}
       <SessionEndedHandler
         content={{


### PR DESCRIPTION
KK-1437.

By defining `ui_locales` to the user manager settings, we should be able to set the default locale for external (Helsinki Profile Keycloak) authentication screen. Since the locale can be dynamically changed in Kukkuu UI, also the User manager settings should react and set the locale dynamically. For this we need I18Next translation context and a React login provider that supports hooks and initializes the HDS LoginProvider -- KukkuuHDSLoginProvider is our option for that.
