### PR TITLE
Add missing error elements to Nginx and React-Router implementation

### DIFF
--- a/.prod/nginx.conf.template
+++ b/.prod/nginx.conf.template
@@ -45,11 +45,7 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
-        error_page   500 502 503 504  /50x.html;
-        location = /50x.html {
-            root   /usr/share/nginx/html;
-        }
-
+        error_page 500 502 503 504 /50x.html;
     }
 
 }

--- a/public/50x.html
+++ b/public/50x.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kulttuurin kummilapset - Culture Kids</title>
+
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+      block-all-mixed-content;
+      default-src 'self';
+      script-src 'self' https://m.youtube.com https://www.youtube.com https://webanalytics.digiaiiris.com;
+      style-src 'self' 'unsafe-inline';
+      object-src 'none';
+      frame-src 'self' *.hel.fi *.hel.ninja *.youtube.com www.youtube-nocookie.com *.vimeo.com;
+      img-src 'self' data: *.hel.fi *.hel.ninja *.ytimg.com *.youtube.com *.vimeo.com *.vimeocdn.com *.blob.core.windows.net *.hkih.hion.dev;
+      font-src 'self' *.hel.fi *.hel.ninja;
+      connect-src 'self' localhost:* 127.0.0.1:* *.hel.fi *.hel.ninja *.hkih.hion.dev *.digiaiiris.com;
+      manifest-src 'self';
+      base-uri 'self';
+      form-action 'self';
+      media-src 'self' *.hel.fi *.hel.ninja *.hkih.hion.dev;
+      worker-src 'self';
+    "
+    />
+    <link rel="icon" href="/hds-favicon-kit/favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/hds-favicon-kit/apple-touch-icon.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <style type="text/css">
+      .error {
+        text-align: center;
+        align-self: center;
+      }
+      .error .returnLink {
+        display: block;
+        margin: 3rem auto auto auto;
+        background: #ffc61e;
+        box-sizing: border-box;
+        text-decoration: none;
+        padding: 1rem;
+        color: #000000;
+        width: 50%;
+      }
+      @media (max-width: 767px) {
+        .error .returnLink {
+          width: 80%;
+        }
+      }
+      .icon {
+        display: block;
+        margin: 0 auto;
+        height: 8rem;
+        width: 8rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="main_content">
+      <div class="container">
+        <div class="error">
+          <h1>
+            <span lang="fi">Virhe</span> / <span lang="en">Error</span> /
+            <span lang="sv">Fel</span>
+          </h1>
+          <div class="icon">
+            <img src="/icons/svg/adultFace.svg" alt="Icon of sad face" />
+          </div>
+          <p lang="fi">Jokin meni pieleen. Yritä myöhemmin uudelleen.</p>
+          <p lang="en">Something went wrong. Try again later.</p>
+          <p lang="sv">Något gick fel. Försök igen senare.</p>
+          <a class="returnLink" href="/"
+            ><span lang="fi">Etusivulle</span> /
+            <span lang="en">To front page</span> /
+            <span lang="sv">Till framsidan</span></a
+          >
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -563,6 +563,13 @@
     },
     "text": "The page you are looking for couldn't be found"
   },
+  "applicationError": {
+    "return": {
+      "text": "To front page"
+    },
+    "text": "Something went wrong. Try again later.",
+    "title": "An error occurred"
+  },
   "partners": {
     "2020": "Children born in 2020"
   },

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -563,6 +563,13 @@
     },
     "text": "Etsimääsi sivua ei löytynyt"
   },
+  "applicationError": {
+    "return": {
+      "text": "Etusivulle"
+    },
+    "text": "Jokin meni pieleen. Yritä myöhemmin uudelleen.",
+    "title": "Virhe tapahtui"
+  },
   "partners": {
     "2020": "2020 syntyneet"
   },

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -563,6 +563,13 @@
     },
     "text": "Sidan du söker kunde inte hittas"
   },
+  "applicationError": {
+    "return": {
+      "text": "Tillbaka till framsidan"
+    },
+    "text": "Något gick fel. Försök igen senare.",
+    "title": "Ett fel uppstod"
+  },
   "partners": {
     "2020": "Födda 2020"
   },

--- a/src/domain/app/errorElement/ApplicationError.module.scss
+++ b/src/domain/app/errorElement/ApplicationError.module.scss
@@ -1,7 +1,7 @@
 @use '~styles/variables';
 @use '~styles/layout';
 
-.notFound {
+.applicationError {
   text-align: center;
   align-self: center;
 

--- a/src/domain/app/errorElement/ApplicationError.tsx
+++ b/src/domain/app/errorElement/ApplicationError.tsx
@@ -1,0 +1,30 @@
+import { FunctionComponent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+import styles from './ApplicationError.module.scss';
+import Container from '../layout/Container';
+import Icon from '../../../common/components/icon/Icon';
+import useGetPathname from '../../../common/route/utils/useGetPathname';
+import { publicSvgIconPaths } from '../../../public_files';
+
+const ApplicationError: FunctionComponent = () => {
+  const { t } = useTranslation();
+  const getPathname = useGetPathname();
+
+  return (
+    <Container>
+      <div className={styles.applicationError}>
+        <h2>{t('applicationError.title')}</h2>
+        <Icon src={publicSvgIconPaths['adultFace']} className={styles.icon} />
+        <p>{t('applicationError.text')}</p>
+
+        <Link className={styles.returnLink} to={getPathname('/')}>
+          {t('applicationError.return.text')}
+        </Link>
+      </div>
+    </Container>
+  );
+};
+
+export default ApplicationError;

--- a/src/domain/app/routes/browserRouter.tsx
+++ b/src/domain/app/routes/browserRouter.tsx
@@ -25,9 +25,13 @@ import ManageCommunicationSubscriptions from '../../profile/subscriptions/Manage
 import NotFound from '../notFound/NotFound';
 import KukkuuHDSLoginCallbackHandler from '../../auth/KukkuuHDSLoginCallbackHandler';
 import SilentRenewRedirect from './SilentRenewRedirect';
+import ApplicationError from '../errorElement/ApplicationError';
 
 const browserRouter = createBrowserRouter([
-  { path: '/', element: <NavigateToLocalePath /> },
+  {
+    path: '/',
+    element: <NavigateToLocalePath />,
+  },
   {
     path: '/callback',
     Component: KukkuuHDSLoginCallbackHandler,
@@ -42,6 +46,7 @@ const browserRouter = createBrowserRouter([
   {
     path: '/:locale/*',
     Component: WithProfileChildRouteAuthorization(WithLocaleRoute(Layout)),
+    errorElement: <ApplicationError />,
     children: [
       {
         index: true,


### PR DESCRIPTION
KK-1438.

1. When a route does not have an errorElement, errors will bubble up
through parent routes. See more: https://reactrouter.com/6.30.0/route/error-element#default-error-element
    The easies way to test is to add an error to a router loader: 
    ```typescript
      {
        path: '/:locale/*',
        Component: WithProfileChildRouteAuthorization(WithLocaleRoute(Layout)),
        loader: async ({ params }) => {
          return undefined();
        },
        errorElement: <ApplicationError />,
    ```
    <img width="945" alt="image" src="https://github.com/user-attachments/assets/5a72ee86-c219-4ae9-8a45-83b08695b833" />

2. Add a custom Kukkuu themed error page to Nginx.
      
      The easiest way to test Nginx error page is to provide a location that
      throws an error:
      ```
      server {
          listen 80;
      
          location /throw503 {
              return 503;
          }
      }
      ```

      <img width="829" alt="image" src="https://github.com/user-attachments/assets/fb7ab875-80a5-4342-830e-5cc6fac4ef1f" />
