### PR TITLE
KEH-281 | Update React tooling and fix dependency vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,15 @@
       "hds-react/cookie": [
         "To fix https://github.com/City-of-Helsinki/palvelutarjotin-ui/security/dependabot/101",
         "NOTE: This can be removed if hds-react starts to depend on >=v1 cookie"
+      ],
+      "lodash": [
+        "To fix security vulnerabilities in lodash dependency through @graphql-codegen packages",
+        "Fixes:",
+        "  - CVE-1115806: Code Injection via _.template imports with unsafe key names",
+        "  - CVE-1115810: Prototype Pollution via array path bypass in _.unset and _.omit",
+        "Forces lodash to use version >=4.18.0 which includes security patches",
+        "",
+        "NOTE: This can be removed when @graphql-codegen and other dependencies require patched lodash versions"
       ]
     }
   },
@@ -161,7 +170,8 @@
     "**/testcafe-hammerhead/httpntlm/underscore": "1.13.8",
     "**/@ardatan/relay-compiler/immutable": ">=3.8.3",
     "**/external-editor/tmp": ">=0.2.4",
-    "hds-react/cookie": "^0.7.2"
+    "hds-react/cookie": "^0.7.2",
+    "lodash": ">=4.18.0"
   },
   "msw": {
     "workerDirectory": "public"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.15.3",
   "private": true,
   "license": "MIT",
+  "packageManager": "yarn@1.22.22",
   "type": "module",
   "engines": {
     "node": ">=22.13.1"
@@ -69,9 +70,9 @@
     "@typescript-eslint/parser": "^8.57.1",
     "@uiw/react-markdown-preview": "^5.1.5",
     "@uiw/react-md-editor": "^4.0.11",
-    "@vitejs/plugin-react-swc": "^3.7.2",
-    "@vitest/coverage-v8": "^3.0.7",
-    "@vitest/eslint-plugin": "^1.6.13",
+    "@vitejs/plugin-react": "^5.0.0",
+    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/eslint-plugin": "^1.6.14",
     "apollo3-cache-persist": "^0.15.0",
     "browserslist": "^4.24.4",
     "classnames": "^2.5.1",
@@ -118,10 +119,9 @@
     "typescript": "^5.7.3",
     "validator": "^13.15.22",
     "vite": "^8.0.5",
-    "vite-plugin-svgr": "^5.0.0",
-    "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.7",
-    "vitest-sonar-reporter": "^2.0.0",
+    "vite-plugin-svgr": "^5.2.0",
+    "vitest": "4.1.2",
+    "vitest-sonar-reporter": "^3.0.0",
     "yup": "^1.6.1"
   },
   "//": {

--- a/src/common/AriaLive/__tests__/AriaLive.test.tsx
+++ b/src/common/AriaLive/__tests__/AriaLive.test.tsx
@@ -35,7 +35,7 @@ describe('AriaLive', () => {
       >
         <div
           aria-live="polite"
-          class="_visuallyHidden_936ef7"
+          class="_visuallyHidden_b54c46"
         />
       </div>
     `);
@@ -49,7 +49,7 @@ describe('AriaLive', () => {
       >
         <div
           aria-live="polite"
-          class="_visuallyHidden_936ef7"
+          class="_visuallyHidden_b54c46"
         >
           message
         </div>

--- a/src/common/components/card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/common/components/card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -3,32 +3,32 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_wrapper_f3c708"
+    class="_wrapper_2a19a2"
     role="button"
     tabindex="0"
   >
     <div
-      class="_image_f3c708 _fullHeight_f3c708"
+      class="_image_2a19a2 _fullHeight_2a19a2"
     />
     <div
-      class="_content_f3c708"
+      class="_content_2a19a2"
     >
       <h3
-        class="_text_e4e173 _h3_e4e173 _title_f3c708"
+        class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
       />
       foo
       <div
-        class="_focalPoint_f3c708"
+        class="_focalPoint_2a19a2"
       >
         <span />
       </div>
     </div>
     <div
-      class="_cta_f3c708"
+      class="_cta_2a19a2"
     >
       <button
         aria-label=""
-        class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+        class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
         style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
         type="button"
       >

--- a/src/common/components/formikWrappers/__tests__/__snapshots__/FormikDropdown.test.tsx.snap
+++ b/src/common/components/formikWrappers/__tests__/__snapshots__/FormikDropdown.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_formField_b4a938 Select-module_root__-GjU5"
+    class="_formField_69b114 Select-module_root__-GjU5"
     id="fooSelect"
     name="fooSelect"
     tabindex="-1"

--- a/src/common/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/src/common/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_modalWrapper_7e0fff"
+    class="_modalWrapper_b8f964"
   />
 </div>
 `;

--- a/src/domain/app/__tests__/__snapshots__/Layout.test.tsx.snap
+++ b/src/domain/app/__tests__/__snapshots__/Layout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders without crashing 1`] = `
 <div>
   <div
-    class="_pageWrapper_87a801"
+    class="_pageWrapper_953203"
   >
     <div>
       <header
@@ -66,7 +66,7 @@ exports[`renders without crashing 1`] = `
                   />
                 </div>
                 <div
-                  class="HeaderActionBarItem-module_container__1uq2m _list_0e6fe3 HeaderActionBarItem-module_hasContent__YJfOU"
+                  class="HeaderActionBarItem-module_container__1uq2m _list_074ea4 HeaderActionBarItem-module_hasContent__YJfOU"
                   id="signinButton"
                 >
                   <button
@@ -103,7 +103,7 @@ exports[`renders without crashing 1`] = `
                           class="HeaderActionBarItemButton-module_actionBarItemButtonLabel__12Iec"
                         >
                           <span
-                            class="_hideBelowSmall_0e6fe3"
+                            class="_hideBelowSmall_074ea4"
                           >
                             Kirjaudu
                           </span>
@@ -136,7 +136,7 @@ exports[`renders without crashing 1`] = `
                           class="HeaderActionBarItemButton-module_actionBarItemButtonLabel__12Iec"
                         >
                           <span
-                            class="_hideBelowSmall_0e6fe3"
+                            class="_hideBelowSmall_074ea4"
                           >
                             Kirjaudu
                           </span>
@@ -163,11 +163,11 @@ exports[`renders without crashing 1`] = `
       </header>
     </div>
     <div
-      class="_pageBody_87a801"
+      class="_pageBody_953203"
       id="main_content"
     />
     <footer
-      class="Footer-module_footer__1aD3T _footer_ca2122"
+      class="Footer-module_footer__1aD3T _footer_21cae1"
     >
       <div
         class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"

--- a/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Footer matches snapshot 1`] = `
 <footer
-  class="Footer-module_footer__1aD3T _footer_ca2122"
+  class="Footer-module_footer__1aD3T _footer_21cae1"
 >
   <div
     class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"

--- a/src/domain/child/modal/__tests__/__snapshots__/ChildFormModal.test.tsx.snap
+++ b/src/domain/child/modal/__tests__/__snapshots__/ChildFormModal.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`renders snapshot correctly 1`] = `
 <div>
   <div>
     <div
-      class="_modalWrapper_7e0fff"
+      class="_modalWrapper_b8f964"
     />
   </div>
 </div>

--- a/src/domain/cookieConsent/__tests__/__snapshots__/CookieConsentPage.test.tsx.snap
+++ b/src/domain/cookieConsent/__tests__/__snapshots__/CookieConsentPage.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_pageWrapper_e42bcd"
+    class="_pageWrapper_4ba3e3"
   >
     <div
-      class="_container_533ff0"
+      class="_container_996049"
     />
   </div>
 </div>

--- a/src/domain/event/__tests__/__snapshots__/EventIsEnrolled.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventIsEnrolled.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`renders snapshot correctly 1`] = `
 <div>
   <div
     aria-label="Lataa"
-    class="_spinnerWrapper_ce417a"
+    class="_spinnerWrapper_13766e"
   >
     <div
-      class="_spinner_ce417a"
+      class="_spinner_13766e"
     />
   </div>
 </div>

--- a/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventOccurrence.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`renders snapshot correctly 1`] = `
   <table>
     <tbody>
       <tr
-        class="_occurrence_cdc216 _isMobile_cdc216"
+        class="_occurrence_010ac1 _isMobile_010ac1"
       >
         <td>
           Musiikkitalo
@@ -19,15 +19,15 @@ exports[`renders snapshot correctly 1`] = `
           </time>
         </td>
         <td
-          class="_remainingCapacity_cdc216"
+          class="_remainingCapacity_010ac1"
         >
           99
         </td>
         <td
-          class="_occurrenceSubmit_cdc216"
+          class="_occurrenceSubmit_010ac1"
         >
           <a
-            class="hds-button _button_f33f10"
+            class="hds-button _button_ed0fc5"
             data-discover="true"
             href="/occurrence/T2NjdXJyZW5jZU5vZGU6Mg==/enrol"
           >
@@ -40,7 +40,7 @@ exports[`renders snapshot correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="_occurrence_cdc216"
+        class="_occurrence_010ac1"
       >
         <td>
           su 8.3.2020
@@ -52,15 +52,15 @@ exports[`renders snapshot correctly 1`] = `
           Musiikkitalo
         </td>
         <td
-          class="_remainingCapacity_cdc216"
+          class="_remainingCapacity_010ac1"
         >
           99
         </td>
         <td
-          class="_occurrenceSubmit_cdc216"
+          class="_occurrenceSubmit_010ac1"
         >
           <a
-            class="hds-button _button_f33f10"
+            class="hds-button _button_ed0fc5"
             data-discover="true"
             href="/occurrence/T2NjdXJyZW5jZU5vZGU6Mg==/enrol"
           >

--- a/src/domain/event/__tests__/__snapshots__/EventOccurrenceList.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventOccurrenceList.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <table
-    class="_eventOccurrenceList_e8d8f8"
+    class="_eventOccurrenceList_11a491"
   >
     <tbody>
       <tr
-        class="_mobileHeader_e8d8f8"
+        class="_mobileHeader_11a491"
       >
         <th>
           Tapahtuman tiedot
@@ -17,7 +17,7 @@ exports[`renders snapshot correctly 1`] = `
         </th>
       </tr>
       <tr
-        class="_desktopHeader_e8d8f8"
+        class="_desktopHeader_11a491"
       >
         <th>
           Päivämäärä
@@ -29,14 +29,14 @@ exports[`renders snapshot correctly 1`] = `
           Tapahtumapaikka
         </th>
         <th
-          class="_freePlaces_e8d8f8"
+          class="_freePlaces_11a491"
         >
           Vapaat paikat
         </th>
         <th />
       </tr>
       <tr
-        class="_occurrence_cdc216 _isMobile_cdc216"
+        class="_occurrence_010ac1 _isMobile_010ac1"
       >
         <td>
           Musiikkitalo
@@ -50,15 +50,15 @@ exports[`renders snapshot correctly 1`] = `
           </time>
         </td>
         <td
-          class="_remainingCapacity_cdc216"
+          class="_remainingCapacity_010ac1"
         >
           99
         </td>
         <td
-          class="_occurrenceSubmit_cdc216"
+          class="_occurrenceSubmit_010ac1"
         >
           <a
-            class="hds-button _button_f33f10"
+            class="hds-button _button_ed0fc5"
             data-discover="true"
             href="/occurrence/T2NjdXJyZW5jZU5vZGU6MQ==/enrol"
           >
@@ -71,7 +71,7 @@ exports[`renders snapshot correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="_occurrence_cdc216"
+        class="_occurrence_010ac1"
       >
         <td>
           su 8.3.2020
@@ -83,15 +83,15 @@ exports[`renders snapshot correctly 1`] = `
           Musiikkitalo
         </td>
         <td
-          class="_remainingCapacity_cdc216"
+          class="_remainingCapacity_010ac1"
         >
           99
         </td>
         <td
-          class="_occurrenceSubmit_cdc216"
+          class="_occurrenceSubmit_010ac1"
         >
           <a
-            class="hds-button _button_f33f10"
+            class="hds-button _button_ed0fc5"
             data-discover="true"
             href="/occurrence/T2NjdXJyZW5jZU5vZGU6MQ==/enrol"
           >
@@ -104,7 +104,7 @@ exports[`renders snapshot correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="_occurrence_cdc216 _isMobile_cdc216"
+        class="_occurrence_010ac1 _isMobile_010ac1"
       >
         <td>
           Somewhere
@@ -118,15 +118,15 @@ exports[`renders snapshot correctly 1`] = `
           </time>
         </td>
         <td
-          class="_remainingCapacity_cdc216"
+          class="_remainingCapacity_010ac1"
         >
           88
         </td>
         <td
-          class="_occurrenceSubmit_cdc216"
+          class="_occurrenceSubmit_010ac1"
         >
           <a
-            class="hds-button _button_f33f10"
+            class="hds-button _button_ed0fc5"
             data-discover="true"
             href="/asdf/redirect"
           >
@@ -139,7 +139,7 @@ exports[`renders snapshot correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="_occurrence_cdc216"
+        class="_occurrence_010ac1"
       >
         <td>
           ke 8.4.2020
@@ -151,15 +151,15 @@ exports[`renders snapshot correctly 1`] = `
           Somewhere
         </td>
         <td
-          class="_remainingCapacity_cdc216"
+          class="_remainingCapacity_010ac1"
         >
           88
         </td>
         <td
-          class="_occurrenceSubmit_cdc216"
+          class="_occurrenceSubmit_010ac1"
         >
           <a
-            class="hds-button _button_f33f10"
+            class="hds-button _button_ed0fc5"
             data-discover="true"
             href="/asdf/redirect"
           >

--- a/src/domain/event/__tests__/__snapshots__/EventPage.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/EventPage.test.tsx.snap
@@ -3,26 +3,26 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_heroWrapper_4ef685"
+    class="_heroWrapper_58ffbb"
     style="background-image: url(a);"
     title="b"
   >
     <div
-      class="_backButtonWrapper_4ef685"
+      class="_backButtonWrapper_58ffbb"
     >
       <div
-        class="_backButtonInnerWrapper_4ef685"
+        class="_backButtonInnerWrapper_58ffbb"
       >
         <a
           aria-label="Palaa"
-          class="_backButton_4ef685"
+          class="_backButton_58ffbb"
           data-discover="true"
           href="/back-to"
         >
           <svg
             aria-hidden="true"
             aria-label="arrow-left"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _backButtonIcon_4ef685"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _backButtonIcon_58ffbb"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -39,20 +39,20 @@ exports[`renders snapshot correctly 1`] = `
     </div>
   </div>
   <div
-    class="_pageWrapper_e42bcd _wrapper_4ef685"
+    class="_pageWrapper_4ba3e3 _wrapper_58ffbb"
   >
     <div
-      class="_container_533ff0"
+      class="_container_996049"
     >
       <div
-        class="_eventWrapper_4ef685"
+        class="_eventWrapper_58ffbb"
         role="main"
       >
         <div
-          class="_event_4ef685"
+          class="_event_58ffbb"
         >
           <div
-            class="_heading_4ef685"
+            class="_heading_58ffbb"
           >
             <h1>
               event name

--- a/src/domain/event/__tests__/__snapshots__/VenueFeatures.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/VenueFeatures.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders snapshot correctly 1`] = `
     <button
       aria-controls="collapsible_1"
       aria-expanded="false"
-      class="_header_b278db"
+      class="_header_e661a8"
     >
       <h3>
         Saapuminen
@@ -16,7 +16,7 @@ exports[`renders snapshot correctly 1`] = `
       <svg
         aria-hidden="true"
         aria-label="angle-down"
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _arrow_b278db"
+        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _arrow_e661a8"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
@@ -31,7 +31,7 @@ exports[`renders snapshot correctly 1`] = `
     </button>
     <div
       aria-hidden="true"
-      class="_content_b278db"
+      class="_content_e661a8"
       id="collapsible_1"
     >
       <p>
@@ -46,7 +46,7 @@ exports[`renders snapshot correctly 1`] = `
     <button
       aria-controls="collapsible_2"
       aria-expanded="false"
-      class="_header_b278db"
+      class="_header_e661a8"
     >
       <h3>
         Esteettömyys
@@ -54,7 +54,7 @@ exports[`renders snapshot correctly 1`] = `
       <svg
         aria-hidden="true"
         aria-label="angle-down"
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _arrow_b278db"
+        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _arrow_e661a8"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
@@ -69,7 +69,7 @@ exports[`renders snapshot correctly 1`] = `
     </button>
     <div
       aria-hidden="true"
-      class="_content_b278db"
+      class="_content_e661a8"
       id="collapsible_2"
     >
       <p>
@@ -84,7 +84,7 @@ exports[`renders snapshot correctly 1`] = `
     <button
       aria-controls="collapsible_3"
       aria-expanded="false"
-      class="_header_b278db"
+      class="_header_e661a8"
     >
       <h3>
         WC-tilat ja lastenhoitohuone
@@ -92,7 +92,7 @@ exports[`renders snapshot correctly 1`] = `
       <svg
         aria-hidden="true"
         aria-label="angle-down"
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _arrow_b278db"
+        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _arrow_e661a8"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
@@ -107,7 +107,7 @@ exports[`renders snapshot correctly 1`] = `
     </button>
     <div
       aria-hidden="true"
-      class="_content_b278db"
+      class="_content_e661a8"
       id="collapsible_3"
     >
       <p>
@@ -122,7 +122,7 @@ exports[`renders snapshot correctly 1`] = `
     <button
       aria-controls="collapsible_4"
       aria-expanded="false"
-      class="_header_b278db"
+      class="_header_e661a8"
     >
       <h3>
         Lisätietoa
@@ -130,7 +130,7 @@ exports[`renders snapshot correctly 1`] = `
       <svg
         aria-hidden="true"
         aria-label="angle-down"
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _arrow_b278db"
+        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _arrow_e661a8"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
@@ -145,7 +145,7 @@ exports[`renders snapshot correctly 1`] = `
     </button>
     <div
       aria-hidden="true"
-      class="_content_b278db"
+      class="_content_e661a8"
       id="collapsible_4"
     >
       <p>

--- a/src/domain/event/partial/__tests__/__snapshots__/InfoItem.test.tsx.snap
+++ b/src/domain/event/partial/__tests__/__snapshots__/InfoItem.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`renders snapshot correctly 1`] = `
     </i>
     <div>
       <p
-        class="_text_e4e173 _body_e4e173 _label_e93b69"
+        class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
       >
         infoItemLabel
       </p>

--- a/src/domain/event/partial/__tests__/__snapshots__/OccurrenceInfo.test.tsx.snap
+++ b/src/domain/event/partial/__tests__/__snapshots__/OccurrenceInfo.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`renders childByIdQuery occurrence snapshot correctly 1`] = `
 <div>
   <div
-    class="_row_e93b69"
+    class="_row_9e1f4e"
   >
     <div
-      class="_label_e93b69 _fullWidth_e93b69"
+      class="_label_9e1f4e _fullWidth_9e1f4e"
       id="venue"
     >
       <svg
@@ -26,19 +26,19 @@ exports[`renders childByIdQuery occurrence snapshot correctly 1`] = `
       </svg>
       <div>
         <p
-          class="_text_e4e173 _body_e4e173 _label_e93b69"
+          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
         >
           Musiikkitalo
         </p>
         <p
-          class="_text_e4e173 _body_e4e173 _description_e93b69"
+          class="_text_f7e7fb _body_f7e7fb _description_9e1f4e"
         >
           Urho Kekkosen katu 12
         </p>
       </div>
     </div>
     <div
-      class="_label_e93b69"
+      class="_label_9e1f4e"
       id="time"
     >
       <svg
@@ -58,14 +58,14 @@ exports[`renders childByIdQuery occurrence snapshot correctly 1`] = `
       </svg>
       <div>
         <p
-          class="_text_e4e173 _body_e4e173 _label_e93b69"
+          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
         >
           8.3.2020
         </p>
       </div>
     </div>
     <div
-      class="_label_e93b69"
+      class="_label_9e1f4e"
       id="duration"
     >
       <svg
@@ -85,14 +85,14 @@ exports[`renders childByIdQuery occurrence snapshot correctly 1`] = `
       </svg>
       <div>
         <p
-          class="_text_e4e173 _body_e4e173 _label_e93b69"
+          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
         >
           06:00 - 06:12
         </p>
       </div>
     </div>
     <div
-      class="_label_e93b69"
+      class="_label_9e1f4e"
       id="participants"
     >
       <svg
@@ -112,7 +112,7 @@ exports[`renders childByIdQuery occurrence snapshot correctly 1`] = `
       </svg>
       <div>
         <p
-          class="_text_e4e173 _body_e4e173 _label_e93b69"
+          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
         >
           Perhe
         </p>
@@ -125,10 +125,10 @@ exports[`renders childByIdQuery occurrence snapshot correctly 1`] = `
 exports[`renders occurrence snapshot correctly 1`] = `
 <div>
   <div
-    class="_row_e93b69"
+    class="_row_9e1f4e"
   >
     <div
-      class="_label_e93b69 _fullWidth_e93b69"
+      class="_label_9e1f4e _fullWidth_9e1f4e"
       id="venue"
     >
       <svg
@@ -148,14 +148,14 @@ exports[`renders occurrence snapshot correctly 1`] = `
       </svg>
       <div>
         <p
-          class="_text_e4e173 _body_e4e173 _label_e93b69"
+          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
         >
           Musiikkitalo
         </p>
       </div>
     </div>
     <div
-      class="_label_e93b69"
+      class="_label_9e1f4e"
       id="time"
     >
       <svg
@@ -175,14 +175,14 @@ exports[`renders occurrence snapshot correctly 1`] = `
       </svg>
       <div>
         <p
-          class="_text_e4e173 _body_e4e173 _label_e93b69"
+          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
         >
           8.3.2020
         </p>
       </div>
     </div>
     <div
-      class="_label_e93b69"
+      class="_label_9e1f4e"
       id="duration"
     >
       <svg
@@ -202,14 +202,14 @@ exports[`renders occurrence snapshot correctly 1`] = `
       </svg>
       <div>
         <p
-          class="_text_e4e173 _body_e4e173 _label_e93b69"
+          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
         >
           06:00 - 06:12
         </p>
       </div>
     </div>
     <div
-      class="_label_e93b69"
+      class="_label_9e1f4e"
       id="participants"
     >
       <svg
@@ -229,7 +229,7 @@ exports[`renders occurrence snapshot correctly 1`] = `
       </svg>
       <div>
         <p
-          class="_text_e4e173 _body_e4e173 _label_e93b69"
+          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
         >
           Perhe
         </p>
@@ -242,26 +242,26 @@ exports[`renders occurrence snapshot correctly 1`] = `
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_heroWrapper_4ef685"
+    class="_heroWrapper_58ffbb"
     style="background-image: url(a);"
     title="b"
   >
     <div
-      class="_backButtonWrapper_4ef685"
+      class="_backButtonWrapper_58ffbb"
     >
       <div
-        class="_backButtonInnerWrapper_4ef685"
+        class="_backButtonInnerWrapper_58ffbb"
       >
         <a
           aria-label="Palaa"
-          class="_backButton_4ef685"
+          class="_backButton_58ffbb"
           data-discover="true"
           href="/back-to"
         >
           <svg
             aria-hidden="true"
             aria-label="arrow-left"
-            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _backButtonIcon_4ef685"
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _backButtonIcon_58ffbb"
             role="img"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -278,20 +278,20 @@ exports[`renders snapshot correctly 1`] = `
     </div>
   </div>
   <div
-    class="_pageWrapper_e42bcd _wrapper_4ef685"
+    class="_pageWrapper_4ba3e3 _wrapper_58ffbb"
   >
     <div
-      class="_container_533ff0"
+      class="_container_996049"
     >
       <div
-        class="_eventWrapper_4ef685"
+        class="_eventWrapper_58ffbb"
         role="main"
       >
         <div
-          class="_event_4ef685"
+          class="_event_58ffbb"
         >
           <div
-            class="_heading_4ef685"
+            class="_heading_58ffbb"
           >
             <h1>
               event name

--- a/src/domain/home/__tests__/__snapshots__/Home.test.tsx.snap
+++ b/src/domain/home/__tests__/__snapshots__/Home.test.tsx.snap
@@ -3,36 +3,36 @@
 exports[`<Home /> > renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_pageWrapper_e42bcd"
+    class="_pageWrapper_4ba3e3"
   >
     <div
-      class="_container_533ff0 _gridLayoutOverride_e7e15b"
+      class="_container_996049 _gridLayoutOverride_d8388b"
     >
       <div
-        class="_home_e7e15b"
+        class="_home_d8388b"
       >
         <section
-          class="_heroWrapper_b04a84"
+          class="_heroWrapper_747411"
         >
           <div
-            class="_heroContainer_b04a84"
+            class="_heroContainer_747411"
           >
             <div
-              class="_hero_b04a84"
+              class="_hero_747411"
             >
               <h1>
                 Kulttuurin kummilapset
               </h1>
               <p
-                class="_bodyXl_b04a84"
+                class="_bodyXl_747411"
               >
                 Kaikki vuodesta 2020 eteenpäin syntyvät helsinkiläiset lapset kutsutaan kulttuurin kummilapsiksi. Kummilapset saavat kutsun vuosittain kahteen tapahtumaan, kunnes lapsi aloittaa koulun. Tapahtumat ovat maksuttomia.
               </p>
               <div
-                class="_buttonGroup_b04a84"
+                class="_buttonGroup_747411"
               >
                 <button
-                  class="Button-module_button__1msFE Button-module_primary__2LfKB _registerButton_b04a84"
+                  class="Button-module_button__1msFE Button-module_primary__2LfKB _registerButton_747411"
                   style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                   type="button"
                 >
@@ -41,7 +41,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </span>
                 </button>
                 <button
-                  class="Button-module_button__1msFE Button-module_secondary__1nABp _authenticateButton_b04a84"
+                  class="Button-module_button__1msFE Button-module_secondary__1nABp _authenticateButton_747411"
                   style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: var(--color-white); --background-color-focus: var(--color-white); --background-color-hover-focus: var(--color-white); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                   type="button"
                 >
@@ -53,18 +53,18 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
             </div>
           </div>
           <div
-            class="_kidsImageContainer_b04a84"
+            class="_kidsImageContainer_747411"
           >
             <div
-              class="_kidsImage_b04a84"
+              class="_kidsImage_747411"
             />
           </div>
         </section>
         <section
-          class="_wrapper_557708"
+          class="_wrapper_82283c"
         >
           <div
-            class="_innerwrapper_557708"
+            class="_innerwrapper_82283c"
           >
             <h2>
               Lisätietoa palvelusta eri kielillä
@@ -73,7 +73,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
               Lataa lisätietoa Kulttuurin kummilapset -palvelusta omalla kielelläsi.
             </p>
             <div
-              class="_link_0c660e"
+              class="_link_9bce3b"
             >
               <a
                 href="/brochures/fr.pdf"
@@ -87,7 +87,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -107,7 +107,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -127,7 +127,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -147,7 +147,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -167,7 +167,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -187,7 +187,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -207,7 +207,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -227,7 +227,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -247,7 +247,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -267,7 +267,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -287,7 +287,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -307,7 +307,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -327,7 +327,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -347,7 +347,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -367,7 +367,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -387,7 +387,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -407,7 +407,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                    
                 </span>
                 <span
-                  class="_localizedLanguage_0c660e"
+                  class="_localizedLanguage_9bce3b"
                   lang="fi"
                 >
                   (
@@ -419,22 +419,22 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
           </div>
         </section>
         <section
-          class="_wrapper_f9e21e"
+          class="_wrapper_733c12"
         >
           <div
-            class="_instructions_f9e21e"
+            class="_instructions_733c12"
           >
             <h2>
               Miten pääset mukaan toimintaan?
             </h2>
             <div
-              class="_iconContainer_f9e21e"
+              class="_iconContainer_733c12"
             >
               <div
-                class="_iconBox_f9e21e"
+                class="_iconBox_733c12"
               >
                 <div
-                  class="_imgWrapper_73ff55 _icon_f9e21e"
+                  class="_imgWrapper_1fbb90 _icon_733c12"
                 >
                   <img
                     alt=""
@@ -446,12 +446,12 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </p>
               </div>
               <div
-                class="_iconBox_f9e21e"
+                class="_iconBox_733c12"
               >
                 <svg
                   aria-hidden="true"
                   aria-label="ticket"
-                  class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _icon_f9e21e"
+                  class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_small__gTGkU icon_hds-icon--size-s__2Lkik _icon_733c12"
                   role="img"
                   viewBox="0 0 24 24"
                   xmlns="http://www.w3.org/2000/svg"
@@ -468,10 +468,10 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </p>
               </div>
               <div
-                class="_iconBox_f9e21e"
+                class="_iconBox_733c12"
               >
                 <div
-                  class="_imgWrapper_73ff55 _icon_f9e21e"
+                  class="_imgWrapper_1fbb90 _icon_733c12"
                 >
                   <img
                     alt=""
@@ -486,14 +486,14 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
           </div>
         </section>
         <section
-          class="_wrapper_1e8528"
+          class="_wrapper_d82fc5"
           id="register"
         >
           <div
-            class="_homeForm_1e8528"
+            class="_homeForm_d82fc5"
           >
             <div
-              class="_heading_1e8528"
+              class="_heading_d82fc5"
             >
               <h2>
                 Tule mukaan
@@ -508,11 +508,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
               novalidate=""
             >
               <div
-                class="_inputWrapper_1e8528"
+                class="_inputWrapper_d82fc5"
               >
                 <div>
                   <div
-                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_69b114"
                   >
                     <label
                       class="FieldLabel-module_label__1zrXK "
@@ -542,7 +542,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </div>
                 <div>
                   <div
-                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_69b114"
                   >
                     <label
                       class="FieldLabel-module_label__1zrXK "
@@ -573,7 +573,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
               </div>
               <div>
                 <div
-                  class="Checkbox-module_checkbox__3r5uI _checkboxField_639ec5"
+                  class="Checkbox-module_checkbox__3r5uI _checkboxField_4c5c4f"
                   style="--background-hover: var(--color-summer-dark); --background-selected: var(--color-summer); --background-color-selected-hover: var(--color-summer-dark); --background-color-selected-focus: var(--color-summer-dark); --background-color-selected-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer-dark); --border-color-selected-hover-focus: var(--color-summer-dark); --icon-color-selected: var(--color-black);"
                 >
                   <input
@@ -593,7 +593,7 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </div>
               </div>
               <button
-                class="Button-module_button__1msFE Button-module_primary__2LfKB _submitButton_1e8528"
+                class="Button-module_button__1msFE Button-module_primary__2LfKB _submitButton_d82fc5"
                 disabled=""
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="submit"
@@ -606,13 +606,13 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
           </div>
         </section>
         <section
-          class="_wrapper_6eb765"
+          class="_wrapper_3fd32b"
         >
           <div
-            class="_innerwrapper_6eb765"
+            class="_innerwrapper_3fd32b"
           >
             <div
-              class="_embedContainer_6eb765"
+              class="_embedContainer_3fd32b"
             >
               <iframe
                 allowfullscreen=""
@@ -625,26 +625,26 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
           </div>
         </section>
         <section
-          class="_wrapper_1b4993"
+          class="_wrapper_cebf7d"
         >
           <div
-            class="_innerwrapper_1b4993"
+            class="_innerwrapper_cebf7d"
           >
             <h2>
               Yhteistyökumppanit
             </h2>
             <div
-              class="_partners_1b4993"
+              class="_partners_cebf7d"
             >
               <div
-                class="_big_46f5db"
+                class="_big_7e4182"
               >
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.hel.fi/fi/paatoksenteko-ja-hallinto/kaupungin-organisaatio/toimialat/kulttuurin-ja-vapaa-ajan-toimiala"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="home.partners.partner.hel"
@@ -653,11 +653,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db _jaes-icon_46f5db"
+                  class="_container_7e4182 _jaes-icon_7e4182"
                   href="https://jaes.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Jane ja Aatos Erkon säätiö"
@@ -667,14 +667,14 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                 </a>
               </div>
               <div
-                class="_small_46f5db"
+                class="_small_7e4182"
               >
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://amosrex.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Amos Rex"
@@ -683,11 +683,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://cirko.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Cirko – Uuden sirkuksen keskus"
@@ -696,11 +696,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://dotdot.fi/suomeksi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="DOT ry"
@@ -709,11 +709,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.designmuseum.fi/fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Designmuseo"
@@ -722,11 +722,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.hamhelsinki.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Helsingin taidemuseo HAM"
@@ -735,11 +735,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.helsinginkaupunginmuseo.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Helsingin kaupunginmuseo"
@@ -748,11 +748,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://helsinginkaupunginorkesteri.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Helsingin kaupunginorkesteri"
@@ -761,11 +761,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://hkt.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Helsingin Kaupunginteatteri"
@@ -774,11 +774,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.hotellijaravintolamuseo.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Hotelli- ja ravintolamuseo"
@@ -787,11 +787,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.hurjaruuth.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Tanssiteatteri Hurjaruuth"
@@ -800,11 +800,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.kaapelitehdas.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="home.partners.partner.kaapeli"
@@ -813,11 +813,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.kansallisgalleria.fi/fi/search?category=artwork&hasImage=true"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="home.partners.partner.kansallisgalleria"
@@ -826,11 +826,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.kansallismuseo.fi/fi/kansallismuseo"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Kansallismuseo"
@@ -839,11 +839,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://kansallisteatteri.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Kansallisteatteri"
@@ -852,11 +852,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.kulttuuriperintokasvatus.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Suomen Kulttuuriperintökasvatuksen seura"
@@ -865,11 +865,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.helsinki.fi/fi/tiedemuseo-liekki"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Tiedemuseo Liekki"
@@ -878,11 +878,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.mfa.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Arkkitehtuurimuseo"
@@ -891,11 +891,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://nukketeatterisampo.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Nukketeatteri Sampo"
@@ -904,11 +904,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://oopperabaletti.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Suomen kansallisooppera ja -baletti"
@@ -917,11 +917,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.q-teatteri.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Q-teatteri"
@@ -930,11 +930,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://svenskateatern.fi/fi/alku/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Svenska Teatern"
@@ -943,11 +943,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.sointijazzorchestra.com/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="home.partners.partner.sointijazzorchestra"
@@ -956,11 +956,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.tanssintalo.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Tanssin talo"
@@ -969,11 +969,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.teatteri-ilmio.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Teatteri ILMI Ö"
@@ -982,11 +982,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.teatterimuseo.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Teatterimuseo"
@@ -995,11 +995,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://www.valokuvataiteenmuseo.fi/fi"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="Suomen valokuvataiteen museo"
@@ -1008,11 +1008,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://umohelsinki.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="home.partners.partner.umo"
@@ -1021,11 +1021,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://dialogikasvatus.fi/fokus-ry/etusivu/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="home.partners.partner.fokus"
@@ -1034,11 +1034,11 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
                   </div>
                 </a>
                 <a
-                  class="_container_46f5db"
+                  class="_container_7e4182"
                   href="https://osiristeatteri.fi/"
                 >
                   <div
-                    class="_imgWrapper_73ff55 _icon_46f5db"
+                    class="_imgWrapper_1fbb90 _icon_7e4182"
                   >
                     <img
                       alt="home.partners.partner.osiris"
@@ -1051,19 +1051,19 @@ exports[`<Home /> > renders snapshot correctly 1`] = `
           </div>
         </section>
         <section
-          class="_wrapper_4c2f32"
+          class="_wrapper_b5fee3"
         >
           <div
-            class="_contact_4c2f32"
+            class="_contact_b5fee3"
           >
             <h2>
               Ota yhteyttä
             </h2>
             <div
-              class="_contactPersons_4c2f32"
+              class="_contactPersons_b5fee3"
             >
               <div
-                class="_service_4c2f32"
+                class="_service_b5fee3"
               >
                 <h3>
                   Kulttuurin kummilapset -palvelu

--- a/src/domain/home/moreInfo/__tests__/__snapshots__/HomeMoreInfo.test.tsx.snap
+++ b/src/domain/home/moreInfo/__tests__/__snapshots__/HomeMoreInfo.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <section
-    class="_wrapper_557708"
+    class="_wrapper_82283c"
   >
     <div
-      class="_innerwrapper_557708"
+      class="_innerwrapper_82283c"
     >
       <h2>
         Lisätietoa palvelusta eri kielillä
@@ -15,7 +15,7 @@ exports[`renders snapshot correctly 1`] = `
         Lataa lisätietoa Kulttuurin kummilapset -palvelusta omalla kielelläsi.
       </p>
       <div
-        class="_link_0c660e"
+        class="_link_9bce3b"
       >
         <a
           href="/brochures/fr.pdf"
@@ -29,7 +29,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -49,7 +49,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -69,7 +69,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -89,7 +89,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -109,7 +109,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -129,7 +129,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -149,7 +149,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -169,7 +169,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -189,7 +189,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -209,7 +209,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -229,7 +229,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -249,7 +249,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -269,7 +269,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -289,7 +289,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -309,7 +309,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -329,7 +329,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (
@@ -349,7 +349,7 @@ exports[`renders snapshot correctly 1`] = `
              
           </span>
           <span
-            class="_localizedLanguage_0c660e"
+            class="_localizedLanguage_9bce3b"
             lang="fi"
           >
             (

--- a/src/domain/home/moreInfo/__tests__/__snapshots__/MoreInfoLinkList.test.tsx.snap
+++ b/src/domain/home/moreInfo/__tests__/__snapshots__/MoreInfoLinkList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_link_0c660e"
+    class="_link_9bce3b"
   >
     <a
       href="/brochures/fr.pdf"
@@ -17,7 +17,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -37,7 +37,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -57,7 +57,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -77,7 +77,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -97,7 +97,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -117,7 +117,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -137,7 +137,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -157,7 +157,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -177,7 +177,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -197,7 +197,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -217,7 +217,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -237,7 +237,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -257,7 +257,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -277,7 +277,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -297,7 +297,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -317,7 +317,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (
@@ -337,7 +337,7 @@ exports[`renders snapshot correctly 1`] = `
          
       </span>
       <span
-        class="_localizedLanguage_0c660e"
+        class="_localizedLanguage_9bce3b"
         lang="fi"
       >
         (

--- a/src/domain/home/partners/__tests__/__snapshots__/HomePartners.test.tsx.snap
+++ b/src/domain/home/partners/__tests__/__snapshots__/HomePartners.test.tsx.snap
@@ -3,26 +3,26 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <section
-    class="_wrapper_1b4993"
+    class="_wrapper_cebf7d"
   >
     <div
-      class="_innerwrapper_1b4993"
+      class="_innerwrapper_cebf7d"
     >
       <h2>
         Yhteistyökumppanit
       </h2>
       <div
-        class="_partners_1b4993"
+        class="_partners_cebf7d"
       >
         <div
-          class="_big_46f5db"
+          class="_big_7e4182"
         >
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.hel.fi/fi/paatoksenteko-ja-hallinto/kaupungin-organisaatio/toimialat/kulttuurin-ja-vapaa-ajan-toimiala"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="home.partners.partner.hel"
@@ -31,11 +31,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db _jaes-icon_46f5db"
+            class="_container_7e4182 _jaes-icon_7e4182"
             href="https://jaes.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Jane ja Aatos Erkon säätiö"
@@ -45,14 +45,14 @@ exports[`renders snapshot correctly 1`] = `
           </a>
         </div>
         <div
-          class="_small_46f5db"
+          class="_small_7e4182"
         >
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://amosrex.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Amos Rex"
@@ -61,11 +61,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://cirko.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Cirko – Uuden sirkuksen keskus"
@@ -74,11 +74,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://dotdot.fi/suomeksi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="DOT ry"
@@ -87,11 +87,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.designmuseum.fi/fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Designmuseo"
@@ -100,11 +100,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.hamhelsinki.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Helsingin taidemuseo HAM"
@@ -113,11 +113,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.helsinginkaupunginmuseo.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Helsingin kaupunginmuseo"
@@ -126,11 +126,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://helsinginkaupunginorkesteri.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Helsingin kaupunginorkesteri"
@@ -139,11 +139,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://hkt.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Helsingin Kaupunginteatteri"
@@ -152,11 +152,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.hotellijaravintolamuseo.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Hotelli- ja ravintolamuseo"
@@ -165,11 +165,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.hurjaruuth.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Tanssiteatteri Hurjaruuth"
@@ -178,11 +178,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.kaapelitehdas.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="home.partners.partner.kaapeli"
@@ -191,11 +191,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.kansallisgalleria.fi/fi/search?category=artwork&hasImage=true"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="home.partners.partner.kansallisgalleria"
@@ -204,11 +204,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.kansallismuseo.fi/fi/kansallismuseo"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Kansallismuseo"
@@ -217,11 +217,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://kansallisteatteri.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Kansallisteatteri"
@@ -230,11 +230,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.kulttuuriperintokasvatus.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Suomen Kulttuuriperintökasvatuksen seura"
@@ -243,11 +243,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.helsinki.fi/fi/tiedemuseo-liekki"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Tiedemuseo Liekki"
@@ -256,11 +256,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.mfa.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Arkkitehtuurimuseo"
@@ -269,11 +269,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://nukketeatterisampo.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Nukketeatteri Sampo"
@@ -282,11 +282,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://oopperabaletti.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Suomen kansallisooppera ja -baletti"
@@ -295,11 +295,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.q-teatteri.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Q-teatteri"
@@ -308,11 +308,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://svenskateatern.fi/fi/alku/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Svenska Teatern"
@@ -321,11 +321,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.sointijazzorchestra.com/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="home.partners.partner.sointijazzorchestra"
@@ -334,11 +334,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.tanssintalo.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Tanssin talo"
@@ -347,11 +347,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.teatteri-ilmio.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Teatteri ILMI Ö"
@@ -360,11 +360,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.teatterimuseo.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Teatterimuseo"
@@ -373,11 +373,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://www.valokuvataiteenmuseo.fi/fi"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="Suomen valokuvataiteen museo"
@@ -386,11 +386,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://umohelsinki.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="home.partners.partner.umo"
@@ -399,11 +399,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://dialogikasvatus.fi/fokus-ry/etusivu/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="home.partners.partner.fokus"
@@ -412,11 +412,11 @@ exports[`renders snapshot correctly 1`] = `
             </div>
           </a>
           <a
-            class="_container_46f5db"
+            class="_container_7e4182"
             href="https://osiristeatteri.fi/"
           >
             <div
-              class="_imgWrapper_73ff55 _icon_46f5db"
+              class="_imgWrapper_1fbb90 _icon_7e4182"
             >
               <img
                 alt="home.partners.partner.osiris"

--- a/src/domain/home/partners/__tests__/__snapshots__/PartnersLogoList.test.tsx.snap
+++ b/src/domain/home/partners/__tests__/__snapshots__/PartnersLogoList.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_big_46f5db"
+    class="_big_7e4182"
   >
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.hel.fi/fi/paatoksenteko-ja-hallinto/kaupungin-organisaatio/toimialat/kulttuurin-ja-vapaa-ajan-toimiala"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="home.partners.partner.hel"
@@ -19,11 +19,11 @@ exports[`renders snapshot correctly 1`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db _jaes-icon_46f5db"
+      class="_container_7e4182 _jaes-icon_7e4182"
       href="https://jaes.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Jane ja Aatos Erkon säätiö"
@@ -38,14 +38,14 @@ exports[`renders snapshot correctly 1`] = `
 exports[`renders snapshot correctly 2`] = `
 <div>
   <div
-    class="_small_46f5db"
+    class="_small_7e4182"
   >
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://amosrex.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Amos Rex"
@@ -54,11 +54,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://cirko.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Cirko – Uuden sirkuksen keskus"
@@ -67,11 +67,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://dotdot.fi/suomeksi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="DOT ry"
@@ -80,11 +80,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.designmuseum.fi/fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Designmuseo"
@@ -93,11 +93,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.hamhelsinki.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Helsingin taidemuseo HAM"
@@ -106,11 +106,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.helsinginkaupunginmuseo.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Helsingin kaupunginmuseo"
@@ -119,11 +119,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://helsinginkaupunginorkesteri.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Helsingin kaupunginorkesteri"
@@ -132,11 +132,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://hkt.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Helsingin Kaupunginteatteri"
@@ -145,11 +145,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.hotellijaravintolamuseo.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Hotelli- ja ravintolamuseo"
@@ -158,11 +158,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.hurjaruuth.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Tanssiteatteri Hurjaruuth"
@@ -171,11 +171,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.kaapelitehdas.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="home.partners.partner.kaapeli"
@@ -184,11 +184,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.kansallisgalleria.fi/fi/search?category=artwork&hasImage=true"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="home.partners.partner.kansallisgalleria"
@@ -197,11 +197,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.kansallismuseo.fi/fi/kansallismuseo"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Kansallismuseo"
@@ -210,11 +210,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://kansallisteatteri.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Kansallisteatteri"
@@ -223,11 +223,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.kulttuuriperintokasvatus.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Suomen Kulttuuriperintökasvatuksen seura"
@@ -236,11 +236,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.helsinki.fi/fi/tiedemuseo-liekki"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Tiedemuseo Liekki"
@@ -249,11 +249,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.mfa.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Arkkitehtuurimuseo"
@@ -262,11 +262,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://nukketeatterisampo.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Nukketeatteri Sampo"
@@ -275,11 +275,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://oopperabaletti.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Suomen kansallisooppera ja -baletti"
@@ -288,11 +288,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.q-teatteri.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Q-teatteri"
@@ -301,11 +301,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://svenskateatern.fi/fi/alku/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Svenska Teatern"
@@ -314,11 +314,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.sointijazzorchestra.com/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="home.partners.partner.sointijazzorchestra"
@@ -327,11 +327,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.tanssintalo.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Tanssin talo"
@@ -340,11 +340,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.teatteri-ilmio.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Teatteri ILMI Ö"
@@ -353,11 +353,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.teatterimuseo.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Teatterimuseo"
@@ -366,11 +366,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://www.valokuvataiteenmuseo.fi/fi"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="Suomen valokuvataiteen museo"
@@ -379,11 +379,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://umohelsinki.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="home.partners.partner.umo"
@@ -392,11 +392,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://dialogikasvatus.fi/fokus-ry/etusivu/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="home.partners.partner.fokus"
@@ -405,11 +405,11 @@ exports[`renders snapshot correctly 2`] = `
       </div>
     </a>
     <a
-      class="_container_46f5db"
+      class="_container_7e4182"
       href="https://osiristeatteri.fi/"
     >
       <div
-        class="_imgWrapper_73ff55 _icon_46f5db"
+        class="_imgWrapper_1fbb90 _icon_7e4182"
       >
         <img
           alt="home.partners.partner.osiris"

--- a/src/domain/home/video/__tests__/__snapshots__/HomeVideo.test.tsx.snap
+++ b/src/domain/home/video/__tests__/__snapshots__/HomeVideo.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <section
-    class="_wrapper_6eb765"
+    class="_wrapper_3fd32b"
   >
     <div
-      class="_innerwrapper_6eb765"
+      class="_innerwrapper_3fd32b"
     >
       <div
-        class="_embedContainer_6eb765"
+        class="_embedContainer_3fd32b"
       >
         <iframe
           allowfullscreen=""

--- a/src/domain/profile/__tests__/__snapshots__/Profile.test.tsx.snap
+++ b/src/domain/profile/__tests__/__snapshots__/Profile.test.tsx.snap
@@ -3,31 +3,31 @@
 exports[`Profile > renders profile correctly 1`] = `
 <div>
   <div
-    class="_wrapper_70bd39"
+    class="_wrapper_d9c314"
   >
     <div
-      class="Container-module_container__18lps container_hds-container__ZG2BQ _container_70bd39"
+      class="Container-module_container__18lps container_hds-container__ZG2BQ _container_d9c314"
       role="main"
     >
       <div
-        class="_header_70bd39"
+        class="_header_d9c314"
       >
         <h1
-          class="_text_e4e173 _h1_e4e173 _headerTitle_70bd39"
+          class="_text_f7e7fb _h1_f7e7fb _headerTitle_d9c314"
         >
           Hei 
         </h1>
         <div
-          class="_headerContent_70bd39"
+          class="_headerContent_d9c314"
         >
           <p
-            class="_text_e4e173 _body-l_e4e173 "
+            class="_text_f7e7fb _body-l_f7e7fb "
           >
             Hienoa että olet mukana Kulttuurin kummilapset -toiminnassa! Täällä voit tarkastella tapahtumakutsuja ja ilmoittautua tapahtumiin. Kummilapsi voi osallistua vuosittain kahteen tapahtumaan, yhteen tapahtumaan keväällä ja yhteen tapahtumaan syksyllä. Joskus tapahtumia voi olla tarjolla enemmän, silloin ilmoitamme siitä erikseen. Nähdään kulttuurin parissa!
           </p>
         </div>
         <div
-          class="_headerActions_70bd39"
+          class="_headerActions_d9c314"
         >
           <button
             class="Button-module_button__1msFE Button-module_secondary__1nABp"
@@ -61,15 +61,15 @@ exports[`Profile > renders profile correctly 1`] = `
         </div>
       </div>
       <section
-        class="_layout_d7f7d5"
+        class="_layout_b3eb16"
       >
         <h2
-          class="_text_e4e173 _h2_e4e173 "
+          class="_text_f7e7fb _h2_f7e7fb "
         >
           Kummilapset
         </h2>
         <div
-          class="_noChild_d7f7d5"
+          class="_noChild_b3eb16"
         >
           <p>
             Ei kummilapsia

--- a/src/domain/profile/events/__tests__/__snapshots__/ProfileEvents.test.tsx.snap
+++ b/src/domain/profile/events/__tests__/__snapshots__/ProfileEvents.test.tsx.snap
@@ -3,16 +3,16 @@
 exports[`Renders "No events" when no events" 1`] = `
 <div>
   <div
-    class="_noEventWrapper_94137a"
+    class="_noEventWrapper_695780"
   >
     <h2>
       Tapahtumakutsut
     </h2>
     <div
-      class="_noEvent_94137a"
+      class="_noEvent_695780"
     >
       <div
-        class="_imgWrapper_73ff55 _envelopIcon_94137a"
+        class="_imgWrapper_1fbb90 _envelopIcon_695780"
       >
         <img
           alt=""
@@ -30,58 +30,58 @@ exports[`Renders "No events" when no events" 1`] = `
 exports[`Renders events list when events of any type 1`] = `
 <div>
   <ul
-    class="_list_a90dcd _spacing-xl_a90dcd"
+    class="_list_8754a1 _spacing-xl_8754a1"
   >
     <li
-      class="_item_a90dcd"
+      class="_item_8754a1"
     >
       <h2
-        class="_text_e4e173 _h2_e4e173 "
+        class="_text_f7e7fb _h2_f7e7fb "
       >
         Tulevat tapahtumasi
       </h2>
       <ul
-        class="_list_a90dcd _spacing-layout-2-xs_a90dcd"
+        class="_list_8754a1 _spacing-layout-2-xs_8754a1"
       >
         <li
-          class="_item_a90dcd"
+          class="_item_8754a1"
         >
           <div
-            class="_wrapper_f3c708"
+            class="_wrapper_2a19a2"
             role="button"
             tabindex="0"
           >
             <div
-              class="_image_f3c708 _fullHeight_f3c708"
+              class="_image_2a19a2 _fullHeight_2a19a2"
             >
               <div
-                class="_qrWrapper_e3c7ac"
+                class="_qrWrapper_6fff92"
               >
                 <div />
               </div>
             </div>
             <div
-              class="_content_f3c708"
+              class="_content_2a19a2"
             >
               <h3
-                class="_text_e4e173 _h3_e4e173 _title_f3c708"
+                class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
               >
                 pentti
               </h3>
               <p
-                class="_text_e4e173 _body_e4e173 "
+                class="_text_f7e7fb _body_f7e7fb "
               >
                 eventti
               </p>
               <div
-                class="_focalPoint_f3c708"
+                class="_focalPoint_2a19a2"
               >
                 <span>
                   <div
-                    class="_row_e93b69"
+                    class="_row_9e1f4e"
                   >
                     <div
-                      class="_label_e93b69 _fullWidth_e93b69"
+                      class="_label_9e1f4e _fullWidth_9e1f4e"
                       id="venue"
                     >
                       <svg
@@ -101,12 +101,12 @@ exports[`Renders events list when events of any type 1`] = `
                       </svg>
                       <div>
                         <p
-                          class="_text_e4e173 _body_e4e173 _label_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
                         />
                       </div>
                     </div>
                     <div
-                      class="_label_e93b69"
+                      class="_label_9e1f4e"
                       id="time"
                     >
                       <svg
@@ -126,14 +126,14 @@ exports[`Renders events list when events of any type 1`] = `
                       </svg>
                       <div>
                         <p
-                          class="_text_e4e173 _body_e4e173 _label_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
                         >
                           24.2.2020
                         </p>
                       </div>
                     </div>
                     <div
-                      class="_label_e93b69"
+                      class="_label_9e1f4e"
                       id="duration"
                     >
                       <svg
@@ -153,7 +153,7 @@ exports[`Renders events list when events of any type 1`] = `
                       </svg>
                       <div>
                         <p
-                          class="_text_e4e173 _body_e4e173 _label_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
                         >
                           09:07 - 09:19
                         </p>
@@ -164,11 +164,11 @@ exports[`Renders events list when events of any type 1`] = `
               </div>
             </div>
             <div
-              class="_cta_f3c708"
+              class="_cta_2a19a2"
             >
               <button
                 aria-label="Näytä tapahtuman tiedot"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >
@@ -196,51 +196,51 @@ exports[`Renders events list when events of any type 1`] = `
       </ul>
     </li>
     <li
-      class="_item_a90dcd"
+      class="_item_8754a1"
     >
       <h2
-        class="_text_e4e173 _h2_e4e173 "
+        class="_text_f7e7fb _h2_f7e7fb "
       >
         Tapahtumakutsut
       </h2>
       <ul
-        class="_list_a90dcd _spacing-layout-2-xs_a90dcd"
+        class="_list_8754a1 _spacing-layout-2-xs_8754a1"
       >
         <li
-          class="_item_a90dcd"
+          class="_item_8754a1"
         >
           <div
-            class="_wrapper_f3c708"
+            class="_wrapper_2a19a2"
             role="button"
             tabindex="0"
           >
             <div
-              class="_image_f3c708 _fullHeight_f3c708"
+              class="_image_2a19a2 _fullHeight_2a19a2"
             >
               <img
                 alt="uooo"
-                class="_image_f3c708"
+                class="_image_2a19a2"
                 src="http://localhost:8081/media/2020-02-15-184035_1920x1080_scrot.png"
               />
             </div>
             <div
-              class="_content_f3c708"
+              class="_content_2a19a2"
             >
               <h3
-                class="_text_e4e173 _h3_e4e173 _title_f3c708"
+                class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
               >
                 pentti
               </h3>
               <p
-                class="_text_e4e173 _body_e4e173 "
+                class="_text_f7e7fb _body_f7e7fb "
               >
                 eventti
               </p>
               <div
-                class="_focalPoint_f3c708"
+                class="_focalPoint_2a19a2"
               >
                 <button
-                  class="Button-module_button__1msFE Button-module_primary__2LfKB _primaryActionButton_f3c708"
+                  class="Button-module_button__1msFE Button-module_primary__2LfKB _primaryActionButton_2a19a2"
                   style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                   tabindex="0"
                   type="button"
@@ -253,11 +253,11 @@ exports[`Renders events list when events of any type 1`] = `
               </div>
             </div>
             <div
-              class="_cta_f3c708"
+              class="_cta_2a19a2"
             >
               <button
                 aria-label="Lue lisää"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >
@@ -285,58 +285,58 @@ exports[`Renders events list when events of any type 1`] = `
       </ul>
     </li>
     <li
-      class="_item_a90dcd"
+      class="_item_8754a1"
     >
       <h2
-        class="_text_e4e173 _h2_e4e173 "
+        class="_text_f7e7fb _h2_f7e7fb "
       >
         Menneet tapahtumat
       </h2>
       <ul
-        class="_list_a90dcd _spacing-layout-2-xs_a90dcd"
+        class="_list_8754a1 _spacing-layout-2-xs_8754a1"
       >
         <li
-          class="_item_a90dcd"
+          class="_item_8754a1"
         >
           <div
-            class="_wrapper_f3c708"
+            class="_wrapper_2a19a2"
             role="button"
             tabindex="0"
           >
             <div
-              class="_image_f3c708 _fullHeight_f3c708"
+              class="_image_2a19a2 _fullHeight_2a19a2"
             >
               <img
                 alt="uooo"
-                class="_image_f3c708"
+                class="_image_2a19a2"
                 src="http://localhost:8081/media/2020-02-15-184035_1920x1080_scrot.png"
               />
             </div>
             <div
-              class="_content_f3c708"
+              class="_content_2a19a2"
             >
               <h3
-                class="_text_e4e173 _h3_e4e173 _title_f3c708"
+                class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
               >
                 pentti
               </h3>
               <p
-                class="_text_e4e173 _body_e4e173 "
+                class="_text_f7e7fb _body_f7e7fb "
               >
                 eventti
               </p>
               <div
-                class="_focalPoint_f3c708"
+                class="_focalPoint_2a19a2"
               >
                 <span />
               </div>
             </div>
             <div
-              class="_cta_f3c708"
+              class="_cta_2a19a2"
             >
               <button
                 aria-label="Näytä tapahtuman tiedot"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >
@@ -370,58 +370,58 @@ exports[`Renders events list when events of any type 1`] = `
 exports[`Renders events list when only enrolments 1`] = `
 <div>
   <ul
-    class="_list_a90dcd _spacing-xl_a90dcd"
+    class="_list_8754a1 _spacing-xl_8754a1"
   >
     <li
-      class="_item_a90dcd"
+      class="_item_8754a1"
     >
       <h2
-        class="_text_e4e173 _h2_e4e173 "
+        class="_text_f7e7fb _h2_f7e7fb "
       >
         Tulevat tapahtumasi
       </h2>
       <ul
-        class="_list_a90dcd _spacing-layout-2-xs_a90dcd"
+        class="_list_8754a1 _spacing-layout-2-xs_8754a1"
       >
         <li
-          class="_item_a90dcd"
+          class="_item_8754a1"
         >
           <div
-            class="_wrapper_f3c708"
+            class="_wrapper_2a19a2"
             role="button"
             tabindex="0"
           >
             <div
-              class="_image_f3c708 _fullHeight_f3c708"
+              class="_image_2a19a2 _fullHeight_2a19a2"
             >
               <div
-                class="_qrWrapper_e3c7ac"
+                class="_qrWrapper_6fff92"
               >
                 <div />
               </div>
             </div>
             <div
-              class="_content_f3c708"
+              class="_content_2a19a2"
             >
               <h3
-                class="_text_e4e173 _h3_e4e173 _title_f3c708"
+                class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
               >
                 pentti
               </h3>
               <p
-                class="_text_e4e173 _body_e4e173 "
+                class="_text_f7e7fb _body_f7e7fb "
               >
                 eventti
               </p>
               <div
-                class="_focalPoint_f3c708"
+                class="_focalPoint_2a19a2"
               >
                 <span>
                   <div
-                    class="_row_e93b69"
+                    class="_row_9e1f4e"
                   >
                     <div
-                      class="_label_e93b69 _fullWidth_e93b69"
+                      class="_label_9e1f4e _fullWidth_9e1f4e"
                       id="venue"
                     >
                       <svg
@@ -441,12 +441,12 @@ exports[`Renders events list when only enrolments 1`] = `
                       </svg>
                       <div>
                         <p
-                          class="_text_e4e173 _body_e4e173 _label_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
                         />
                       </div>
                     </div>
                     <div
-                      class="_label_e93b69"
+                      class="_label_9e1f4e"
                       id="time"
                     >
                       <svg
@@ -466,14 +466,14 @@ exports[`Renders events list when only enrolments 1`] = `
                       </svg>
                       <div>
                         <p
-                          class="_text_e4e173 _body_e4e173 _label_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
                         >
                           24.2.2020
                         </p>
                       </div>
                     </div>
                     <div
-                      class="_label_e93b69"
+                      class="_label_9e1f4e"
                       id="duration"
                     >
                       <svg
@@ -493,7 +493,7 @@ exports[`Renders events list when only enrolments 1`] = `
                       </svg>
                       <div>
                         <p
-                          class="_text_e4e173 _body_e4e173 _label_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
                         >
                           11:09 - 11:21
                         </p>
@@ -504,11 +504,11 @@ exports[`Renders events list when only enrolments 1`] = `
               </div>
             </div>
             <div
-              class="_cta_f3c708"
+              class="_cta_2a19a2"
             >
               <button
                 aria-label="Näytä tapahtuman tiedot"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >
@@ -542,61 +542,61 @@ exports[`Renders events list when only enrolments 1`] = `
 exports[`Renders events list when only past events 1`] = `
 <div>
   <ul
-    class="_list_a90dcd _spacing-xl_a90dcd"
+    class="_list_8754a1 _spacing-xl_8754a1"
   >
     <li
-      class="_item_a90dcd"
+      class="_item_8754a1"
     >
       <h2
-        class="_text_e4e173 _h2_e4e173 "
+        class="_text_f7e7fb _h2_f7e7fb "
       >
         Menneet tapahtumat
       </h2>
       <ul
-        class="_list_a90dcd _spacing-layout-2-xs_a90dcd"
+        class="_list_8754a1 _spacing-layout-2-xs_8754a1"
       >
         <li
-          class="_item_a90dcd"
+          class="_item_8754a1"
         >
           <div
-            class="_wrapper_f3c708"
+            class="_wrapper_2a19a2"
             role="button"
             tabindex="0"
           >
             <div
-              class="_image_f3c708 _fullHeight_f3c708"
+              class="_image_2a19a2 _fullHeight_2a19a2"
             >
               <img
                 alt="uooo"
-                class="_image_f3c708"
+                class="_image_2a19a2"
                 src="http://localhost:8081/media/2020-02-15-184035_1920x1080_scrot.png"
               />
             </div>
             <div
-              class="_content_f3c708"
+              class="_content_2a19a2"
             >
               <h3
-                class="_text_e4e173 _h3_e4e173 _title_f3c708"
+                class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
               >
                 pentti
               </h3>
               <p
-                class="_text_e4e173 _body_e4e173 "
+                class="_text_f7e7fb _body_f7e7fb "
               >
                 eventti
               </p>
               <div
-                class="_focalPoint_f3c708"
+                class="_focalPoint_2a19a2"
               >
                 <span />
               </div>
             </div>
             <div
-              class="_cta_f3c708"
+              class="_cta_2a19a2"
             >
               <button
                 aria-label="Näytä tapahtuman tiedot"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >
@@ -630,54 +630,54 @@ exports[`Renders events list when only past events 1`] = `
 exports[`Renders events list when only upcomingEventsAndEventGroups 1`] = `
 <div>
   <ul
-    class="_list_a90dcd _spacing-xl_a90dcd"
+    class="_list_8754a1 _spacing-xl_8754a1"
   >
     <li
-      class="_item_a90dcd"
+      class="_item_8754a1"
     >
       <h2
-        class="_text_e4e173 _h2_e4e173 "
+        class="_text_f7e7fb _h2_f7e7fb "
       >
         Tapahtumakutsut
       </h2>
       <ul
-        class="_list_a90dcd _spacing-layout-2-xs_a90dcd"
+        class="_list_8754a1 _spacing-layout-2-xs_8754a1"
       >
         <li
-          class="_item_a90dcd"
+          class="_item_8754a1"
         >
           <div
-            class="_wrapper_f3c708"
+            class="_wrapper_2a19a2"
             role="button"
             tabindex="0"
           >
             <div
-              class="_image_f3c708 _fullHeight_f3c708"
+              class="_image_2a19a2 _fullHeight_2a19a2"
             >
               <img
                 alt="uooo"
-                class="_image_f3c708"
+                class="_image_2a19a2"
                 src="http://localhost:8081/media/2020-02-15-184035_1920x1080_scrot.png"
               />
             </div>
             <div
-              class="_content_f3c708"
+              class="_content_2a19a2"
             >
               <h3
-                class="_text_e4e173 _h3_e4e173 _title_f3c708"
+                class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
               >
                 pentti
               </h3>
               <p
-                class="_text_e4e173 _body_e4e173 "
+                class="_text_f7e7fb _body_f7e7fb "
               >
                 eventti
               </p>
               <div
-                class="_focalPoint_f3c708"
+                class="_focalPoint_2a19a2"
               >
                 <button
-                  class="Button-module_button__1msFE Button-module_primary__2LfKB _primaryActionButton_f3c708"
+                  class="Button-module_button__1msFE Button-module_primary__2LfKB _primaryActionButton_2a19a2"
                   style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                   tabindex="0"
                   type="button"
@@ -690,11 +690,11 @@ exports[`Renders events list when only upcomingEventsAndEventGroups 1`] = `
               </div>
             </div>
             <div
-              class="_cta_f3c708"
+              class="_cta_2a19a2"
             >
               <button
                 aria-label="Lue lisää"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >

--- a/src/domain/profile/events/__tests__/__snapshots__/ProfileEventsList.test.tsx.snap
+++ b/src/domain/profile/events/__tests__/__snapshots__/ProfileEventsList.test.tsx.snap
@@ -3,58 +3,58 @@
 exports[`Renders snapshot correctly 1`] = `
 <div>
   <ul
-    class="_list_a90dcd _spacing-xl_a90dcd"
+    class="_list_8754a1 _spacing-xl_8754a1"
   >
     <li
-      class="_item_a90dcd"
+      class="_item_8754a1"
     >
       <h2
-        class="_text_e4e173 _h2_e4e173 "
+        class="_text_f7e7fb _h2_f7e7fb "
       >
         Tulevat tapahtumasi
       </h2>
       <ul
-        class="_list_a90dcd _spacing-layout-2-xs_a90dcd"
+        class="_list_8754a1 _spacing-layout-2-xs_8754a1"
       >
         <li
-          class="_item_a90dcd"
+          class="_item_8754a1"
         >
           <div
-            class="_wrapper_f3c708"
+            class="_wrapper_2a19a2"
             role="button"
             tabindex="0"
           >
             <div
-              class="_image_f3c708 _fullHeight_f3c708"
+              class="_image_2a19a2 _fullHeight_2a19a2"
             >
               <div
-                class="_qrWrapper_e3c7ac"
+                class="_qrWrapper_6fff92"
               >
                 <div />
               </div>
             </div>
             <div
-              class="_content_f3c708"
+              class="_content_2a19a2"
             >
               <h3
-                class="_text_e4e173 _h3_e4e173 _title_f3c708"
+                class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
               >
                 pentti
               </h3>
               <p
-                class="_text_e4e173 _body_e4e173 "
+                class="_text_f7e7fb _body_f7e7fb "
               >
                 eventti
               </p>
               <div
-                class="_focalPoint_f3c708"
+                class="_focalPoint_2a19a2"
               >
                 <span>
                   <div
-                    class="_row_e93b69"
+                    class="_row_9e1f4e"
                   >
                     <div
-                      class="_label_e93b69 _fullWidth_e93b69"
+                      class="_label_9e1f4e _fullWidth_9e1f4e"
                       id="venue"
                     >
                       <svg
@@ -74,19 +74,19 @@ exports[`Renders snapshot correctly 1`] = `
                       </svg>
                       <div>
                         <p
-                          class="_text_e4e173 _body_e4e173 _label_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
                         >
                           aa
                         </p>
                         <p
-                          class="_text_e4e173 _body_e4e173 _description_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _description_9e1f4e"
                         >
                           ssfas uus 12
                         </p>
                       </div>
                     </div>
                     <div
-                      class="_label_e93b69"
+                      class="_label_9e1f4e"
                       id="time"
                     >
                       <svg
@@ -106,14 +106,14 @@ exports[`Renders snapshot correctly 1`] = `
                       </svg>
                       <div>
                         <p
-                          class="_text_e4e173 _body_e4e173 _label_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
                         >
                           24.2.2020
                         </p>
                       </div>
                     </div>
                     <div
-                      class="_label_e93b69"
+                      class="_label_9e1f4e"
                       id="duration"
                     >
                       <svg
@@ -133,7 +133,7 @@ exports[`Renders snapshot correctly 1`] = `
                       </svg>
                       <div>
                         <p
-                          class="_text_e4e173 _body_e4e173 _label_e93b69"
+                          class="_text_f7e7fb _body_f7e7fb _label_9e1f4e"
                         >
                           11:09 - 12:09
                         </p>
@@ -144,11 +144,11 @@ exports[`Renders snapshot correctly 1`] = `
               </div>
             </div>
             <div
-              class="_cta_f3c708"
+              class="_cta_2a19a2"
             >
               <button
                 aria-label="Näytä tapahtuman tiedot"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >
@@ -176,51 +176,51 @@ exports[`Renders snapshot correctly 1`] = `
       </ul>
     </li>
     <li
-      class="_item_a90dcd"
+      class="_item_8754a1"
     >
       <h2
-        class="_text_e4e173 _h2_e4e173 "
+        class="_text_f7e7fb _h2_f7e7fb "
       >
         Tapahtumakutsut
       </h2>
       <ul
-        class="_list_a90dcd _spacing-layout-2-xs_a90dcd"
+        class="_list_8754a1 _spacing-layout-2-xs_8754a1"
       >
         <li
-          class="_item_a90dcd"
+          class="_item_8754a1"
         >
           <div
-            class="_wrapper_f3c708"
+            class="_wrapper_2a19a2"
             role="button"
             tabindex="0"
           >
             <div
-              class="_image_f3c708 _fullHeight_f3c708"
+              class="_image_2a19a2 _fullHeight_2a19a2"
             >
               <img
                 alt="huhuu"
-                class="_image_f3c708"
+                class="_image_2a19a2"
                 src="http://localhost:8081/media/2020-02-15-184035_1920x1080_scrot.png"
               />
             </div>
             <div
-              class="_content_f3c708"
+              class="_content_2a19a2"
             >
               <h3
-                class="_text_e4e173 _h3_e4e173 _title_f3c708"
+                class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
               >
                 pentti
               </h3>
               <p
-                class="_text_e4e173 _body_e4e173 "
+                class="_text_f7e7fb _body_f7e7fb "
               >
                 eventti
               </p>
               <div
-                class="_focalPoint_f3c708"
+                class="_focalPoint_2a19a2"
               >
                 <button
-                  class="Button-module_button__1msFE Button-module_primary__2LfKB _primaryActionButton_f3c708"
+                  class="Button-module_button__1msFE Button-module_primary__2LfKB _primaryActionButton_2a19a2"
                   style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                   tabindex="0"
                   type="button"
@@ -233,11 +233,11 @@ exports[`Renders snapshot correctly 1`] = `
               </div>
             </div>
             <div
-              class="_cta_f3c708"
+              class="_cta_2a19a2"
             >
               <button
                 aria-label="Lue lisää"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >
@@ -265,58 +265,58 @@ exports[`Renders snapshot correctly 1`] = `
       </ul>
     </li>
     <li
-      class="_item_a90dcd"
+      class="_item_8754a1"
     >
       <h2
-        class="_text_e4e173 _h2_e4e173 "
+        class="_text_f7e7fb _h2_f7e7fb "
       >
         Menneet tapahtumat
       </h2>
       <ul
-        class="_list_a90dcd _spacing-layout-2-xs_a90dcd"
+        class="_list_8754a1 _spacing-layout-2-xs_8754a1"
       >
         <li
-          class="_item_a90dcd"
+          class="_item_8754a1"
         >
           <div
-            class="_wrapper_f3c708"
+            class="_wrapper_2a19a2"
             role="button"
             tabindex="0"
           >
             <div
-              class="_image_f3c708 _fullHeight_f3c708"
+              class="_image_2a19a2 _fullHeight_2a19a2"
             >
               <img
                 alt="huhuu"
-                class="_image_f3c708"
+                class="_image_2a19a2"
                 src="http://localhost:8081/media/2020-02-15-184035_1920x1080_scrot.png"
               />
             </div>
             <div
-              class="_content_f3c708"
+              class="_content_2a19a2"
             >
               <h3
-                class="_text_e4e173 _h3_e4e173 _title_f3c708"
+                class="_text_f7e7fb _h3_f7e7fb _title_2a19a2"
               >
                 pentti
               </h3>
               <p
-                class="_text_e4e173 _body_e4e173 "
+                class="_text_f7e7fb _body_f7e7fb "
               >
                 eventti
               </p>
               <div
-                class="_focalPoint_f3c708"
+                class="_focalPoint_2a19a2"
               >
                 <span />
               </div>
             </div>
             <div
-              class="_cta_f3c708"
+              class="_cta_2a19a2"
             >
               <button
                 aria-label="Näytä tapahtuman tiedot"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_f3c708"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _actionWrapper_2a19a2"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >

--- a/src/domain/profile/modal/__tests__/__snapshots__/EditProfileModal.test.tsx.snap
+++ b/src/domain/profile/modal/__tests__/__snapshots__/EditProfileModal.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`renders snapshot correctly 1`] = `
 <div>
   <div>
     <div
-      class="_modalWrapper_7e0fff"
+      class="_modalWrapper_b8f964"
     />
   </div>
 </div>

--- a/src/domain/registration/form/__tests__/__snapshots__/RegistrationForm.test.tsx.snap
+++ b/src/domain/registration/form/__tests__/__snapshots__/RegistrationForm.test.tsx.snap
@@ -3,42 +3,42 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_pageWrapper_e42bcd _grayBackground_72244b"
+    class="_pageWrapper_4ba3e3 _grayBackground_140e51"
   >
     <div
-      class="_container_533ff0"
+      class="_container_996049"
     >
       <div
-        class="_registrationFormContainer_72244b"
+        class="_registrationFormContainer_140e51"
       >
         <div
-          class="_registrationForm_72244b"
+          class="_registrationForm_140e51"
         >
           <form
             data-testid="registrationForm"
             id="registrationForm"
           >
             <div
-              class="_registrationGrayContainer_72244b"
+              class="_registrationGrayContainer_140e51"
             >
               <h1>
                 Tule mukaan
               </h1>
             </div>
             <div
-              class="_childrenInfo_72244b _registrationWhiteContainer_72244b"
+              class="_childrenInfo_140e51 _registrationWhiteContainer_140e51"
             >
               <div
-                class="_childFields_284205"
+                class="_childFields_87b5a0"
               >
                 <div
-                  class="_childInfo_284205"
+                  class="_childInfo_87b5a0"
                 >
                   <div
-                    class="_heading_284205"
+                    class="_heading_87b5a0"
                   >
                     <div
-                      class="_imgWrapper_73ff55 _childImage_284205"
+                      class="_imgWrapper_1fbb90 _childImage_87b5a0"
                     >
                       <img
                         alt=""
@@ -49,11 +49,11 @@ exports[`renders snapshot correctly 1`] = `
                       Lapsen tiedot
                     </h2>
                     <p
-                      class="_right_8fd5d0"
+                      class="_right_409a23"
                       data-testid="mandatory-field-legend"
                     >
                       <span
-                        class="_bold_8fd5d0"
+                        class="_bold_409a23"
                       >
                         *
                       </span>
@@ -64,10 +64,10 @@ exports[`renders snapshot correctly 1`] = `
                     </p>
                   </div>
                   <div
-                    class="_childFixedInfo_284205"
+                    class="_childFixedInfo_87b5a0"
                   >
                     <div
-                      class="_childBirthyear_284205"
+                      class="_childBirthyear_87b5a0"
                     >
                       <label>
                         Lapsen syntymävuosi
@@ -77,7 +77,7 @@ exports[`renders snapshot correctly 1`] = `
                       </p>
                     </div>
                     <div
-                      class="_childHomeCity_284205"
+                      class="_childHomeCity_87b5a0"
                     >
                       <label>
                         Lapsen kotipaikkakunta
@@ -86,11 +86,11 @@ exports[`renders snapshot correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="_childName_284205"
+                    class="_childName_87b5a0"
                   >
                     <div>
                       <div
-                        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                        class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_69b114"
                       >
                         <label
                           class="FieldLabel-module_label__1zrXK "
@@ -116,7 +116,7 @@ exports[`renders snapshot correctly 1`] = `
                   </div>
                   <div>
                     <div
-                      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_69b114"
                     >
                       <label
                         class="FieldLabel-module_label__1zrXK "
@@ -145,7 +145,7 @@ exports[`renders snapshot correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="_formField_b4a938 Select-module_root__-GjU5"
+                    class="_formField_69b114 Select-module_root__-GjU5"
                     id="children[0].relationship.type"
                     name="children[0].relationship.type"
                     tabindex="-1"
@@ -240,11 +240,11 @@ exports[`renders snapshot correctly 1`] = `
               </div>
             </div>
             <div
-              class="_registrationGrayContainer_72244b"
+              class="_registrationGrayContainer_140e51"
             >
               <button
                 aria-label="Lisää lapsi"
-                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _addNewChildButton_72244b"
+                class="Button-module_button__1msFE Button-module_supplementary__3YKiS _addNewChildButton_140e51"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: transparent; --background-color-hover: transparent; --background-color-focus: transparent; --background-color-hover-focus: transparent; --background-selected: var(--color-summer); --border-color: none; --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="button"
               >
@@ -274,13 +274,13 @@ exports[`renders snapshot correctly 1`] = `
               </button>
             </div>
             <div
-              class="_guardianInfo_72244b _registrationWhiteContainer_72244b"
+              class="_guardianInfo_140e51 _registrationWhiteContainer_140e51"
             >
               <div
-                class="_heading_72244b"
+                class="_heading_140e51"
               >
                 <div
-                  class="_imgWrapper_73ff55 _childImage_72244b"
+                  class="_imgWrapper_1fbb90 _childImage_140e51"
                 >
                   <img
                     alt=""
@@ -291,11 +291,11 @@ exports[`renders snapshot correctly 1`] = `
                   Lähiaikuisen tiedot
                 </h2>
                 <p
-                  class="_right_8fd5d0"
+                  class="_right_409a23"
                   data-testid="mandatory-field-legend"
                 >
                   <span
-                    class="_bold_8fd5d0"
+                    class="_bold_409a23"
                   >
                     *
                   </span>
@@ -307,7 +307,7 @@ exports[`renders snapshot correctly 1`] = `
               </div>
               <div>
                 <div
-                  class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                  class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_69b114"
                 >
                   <label
                     class="FieldLabel-module_label__1zrXK "
@@ -339,7 +339,7 @@ exports[`renders snapshot correctly 1`] = `
               </div>
               <div>
                 <div
-                  class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                  class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_69b114"
                 >
                   <label
                     class="FieldLabel-module_label__1zrXK "
@@ -368,11 +368,11 @@ exports[`renders snapshot correctly 1`] = `
                 </div>
               </div>
               <div
-                class="_guardianName_72244b"
+                class="_guardianName_140e51"
               >
                 <div>
                   <div
-                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_69b114"
                   >
                     <label
                       class="FieldLabel-module_label__1zrXK "
@@ -402,7 +402,7 @@ exports[`renders snapshot correctly 1`] = `
                 </div>
                 <div>
                   <div
-                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_b4a938"
+                    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq _formField_69b114"
                   >
                     <label
                       class="FieldLabel-module_label__1zrXK "
@@ -432,7 +432,7 @@ exports[`renders snapshot correctly 1`] = `
                 </div>
               </div>
               <div
-                class="_formField_b4a938 Select-module_root__-GjU5"
+                class="_formField_69b114 Select-module_root__-GjU5"
                 id="preferLanguage"
                 name="preferLanguage"
                 tabindex="-1"
@@ -523,7 +523,7 @@ exports[`renders snapshot correctly 1`] = `
                 />
               </div>
               <div
-                class="_formField_b4a938 Select-module_root__-GjU5"
+                class="_formField_69b114 Select-module_root__-GjU5"
                 id="languagesSpokenAtHome"
                 name="guardian.languagesSpokenAtHome"
                 tabindex="-1"
@@ -609,7 +609,7 @@ exports[`renders snapshot correctly 1`] = `
               </div>
               <div>
                 <div
-                  class="Checkbox-module_checkbox__3r5uI _checkboxField_639ec5"
+                  class="Checkbox-module_checkbox__3r5uI _checkboxField_4c5c4f"
                   style="--background-hover: var(--color-summer-dark); --background-selected: var(--color-summer); --background-color-selected-hover: var(--color-summer-dark); --background-color-selected-focus: var(--color-summer-dark); --background-color-selected-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer-dark); --border-color-selected-hover-focus: var(--color-summer-dark); --icon-color-selected: var(--color-black);"
                 >
                   <input
@@ -629,11 +629,11 @@ exports[`renders snapshot correctly 1`] = `
                 </div>
               </div>
               <div
-                class="_agreeContainer_72244b"
+                class="_agreeContainer_140e51"
               >
                 <div>
                   <div
-                    class="Checkbox-module_checkbox__3r5uI _checkboxField_639ec5"
+                    class="Checkbox-module_checkbox__3r5uI _checkboxField_4c5c4f"
                     style="--background-hover: var(--color-summer-dark); --background-selected: var(--color-summer); --background-color-selected-hover: var(--color-summer-dark); --background-color-selected-focus: var(--color-summer-dark); --background-color-selected-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer-dark); --border-color-selected-hover-focus: var(--color-summer-dark); --icon-color-selected: var(--color-black);"
                   >
                     <input
@@ -652,7 +652,7 @@ exports[`renders snapshot correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="_agreeLabel_72244b"
+                  class="_agreeLabel_140e51"
                 >
                   Olen tutustunut 
                   <a
@@ -674,14 +674,14 @@ exports[`renders snapshot correctly 1`] = `
                   </a>
                   . Minuun voidaan olla yhteydessä antamieni tietojen avulla.
                   <span
-                    class="_required_72244b"
+                    class="_required_140e51"
                   >
                      *
                   </span>
                 </div>
               </div>
               <button
-                class="Button-module_button__1msFE Button-module_primary__2LfKB _submitButton_72244b"
+                class="Button-module_button__1msFE Button-module_primary__2LfKB _submitButton_140e51"
                 style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
                 type="submit"
               >

--- a/src/domain/registration/modal/__tests__/__snapshots__/AddNewChildFormModal.test.tsx.snap
+++ b/src/domain/registration/modal/__tests__/__snapshots__/AddNewChildFormModal.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`renders snapshot correctly 1`] = `
 <div>
   <div>
     <div
-      class="_modalWrapper_7e0fff"
+      class="_modalWrapper_b8f964"
     />
   </div>
 </div>

--- a/src/domain/registration/notEligible/__tests__/__snapshots__/NotEligible.test.tsx.snap
+++ b/src/domain/registration/notEligible/__tests__/__snapshots__/NotEligible.test.tsx.snap
@@ -3,17 +3,17 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_pageWrapper_e42bcd"
+    class="_pageWrapper_4ba3e3"
   >
     <div
-      class="_container_533ff0"
+      class="_container_996049"
     >
       <div>
         <div
-          class="_notEligible_cca70d"
+          class="_notEligible_3932a8"
         >
           <div
-            class="_imgWrapper_73ff55 _notEligibleFace_cca70d"
+            class="_imgWrapper_1fbb90 _notEligibleFace_3932a8"
           >
             <img
               alt=""
@@ -28,7 +28,7 @@ exports[`renders snapshot correctly 1`] = `
             target="_blank"
           >
             <button
-              class="Button-module_button__1msFE Button-module_primary__2LfKB _goBackButton_cca70d"
+              class="Button-module_button__1msFE Button-module_primary__2LfKB _goBackButton_3932a8"
               style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
               type="button"
             >

--- a/src/domain/registration/welcome/__tests__/__snapshots__/Welcome.test.tsx.snap
+++ b/src/domain/registration/welcome/__tests__/__snapshots__/Welcome.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`renders snapshot correctly 1`] = `
 <div>
   <div
-    class="_pageWrapper_e42bcd"
+    class="_pageWrapper_4ba3e3"
   >
     <div
-      class="_container_533ff0"
+      class="_container_996049"
     >
       <div
-        class="_welcome_51b81c"
+        class="_welcome_850791"
       >
         <h1>
           Tervetuloa kulttuurin kummilapseksi!
         </h1>
         <div
-          class="_imgWrapper_73ff55 _tada_51b81c"
+          class="_imgWrapper_1fbb90 _tada_850791"
         >
           <img
             alt=""
@@ -24,7 +24,7 @@ exports[`renders snapshot correctly 1`] = `
         </div>
         <button
           aria-label="Oma kummilapsiprofiili"
-          class="Button-module_button__1msFE Button-module_primary__2LfKB _submitButton_51b81c"
+          class="Button-module_button__1msFE Button-module_primary__2LfKB _submitButton_850791"
           style="--color: var(--color-black); --color-hover: var(--color-black); --color-focus: var(--color-black-90); --color-hover-focus: var(--color-black-90); --background-color: var(--color-summer); --background-color-hover: var(--color-summer-dark); --background-color-focus: var(--color-summer); --background-color-hover-focus: var(--color-summer-dark); --background-selected: var(--color-summer); --border-color: var(--color-summer); --border-color-hover: var(--color-summer-dark); --border-color-focus: var(--color-summer-dark); --border-color-hover-focus: var(--color-summer-dark); --border-color-selected: var(--color-summer); --border-color-selected-hover: var(--color-summer-dark); --border-color-selected-focus: var(--color-summer); --border-color-selected-hover-focus: var(--color-summer);"
           type="button"
         >

--- a/tests/vitest-setup.ts
+++ b/tests/vitest-setup.ts
@@ -2,6 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require('dotenv').config({ path: './.env.test' });
 
+import { VirtualConsole } from 'jsdom';
 import Modal from 'react-modal';
 import { beforeAll, afterEach, afterAll, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
@@ -10,6 +11,19 @@ import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev';
 import setLocale from '../src/common/localization/setLocale';
 import { server } from '../src/test/msw/server';
 import '../src/common/test/testi18nInit';
+
+// Suppress jsdom CSS parse errors at the VirtualConsole level
+const originalEmit = VirtualConsole.prototype.emit;
+VirtualConsole.prototype.emit = function (event: string, ...args: unknown[]) {
+  if (
+    event === 'jsdomError' &&
+    args[0] instanceof Error &&
+    args[0].message.includes('Could not parse CSS stylesheet')
+  ) {
+    return false;
+  }
+  return originalEmit.call(this, event, ...args);
+};
 
 // Load error messages for Apollo client so it's easier to debug errors
 loadDevMessages();
@@ -24,11 +38,13 @@ loadErrorMessages();
 // but you can opt-out by setting `ariaHideApp={false}`."
 Modal.setAppElement(document.createElement('div'));
 
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mockScrollTo = vi.fn((x?: number | ScrollToOptions, y?: number) => {});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,9 @@
 import path from 'path';
 
 import eslint from '@nabla/vite-plugin-eslint';
-import react from '@vitejs/plugin-react-swc';
+import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
-import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(() => {
   return {
@@ -20,6 +19,7 @@ export default defineConfig(() => {
     },
     envPrefix: 'VITE_',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '~styles': path.resolve(__dirname, './src/assets/styles'),
         '~hds-design-tokens': path.resolve(
@@ -45,7 +45,6 @@ export default defineConfig(() => {
     plugins: [
       react(),
       eslint(),
-      viteTsconfigPaths(),
       // svgr options: https://react-svgr.com/docs/options/
       svgr({ svgrOptions: { icon: true } }),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8418,15 +8418,10 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-"lodash@4.6.1 || ^4.16.1", lodash@^4.14.0, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.1:
+"lodash@4.6.1 || ^4.16.1", lodash@>=4.18.0, lodash@^4.14.0, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.1, lodash@~4.17.0:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
-
-lodash@~4.17.0:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 log-symbols@^4.0.0, log-symbols@^4.1.0:
   version "4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.1.tgz#2447a230bfe072c1659e6815129c03cf170710e3"
   integrity sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==
 
-"@ampproject/remapping@^2.2.0", "@ampproject/remapping@^2.3.0":
+"@ampproject/remapping@^2.2.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
   integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
@@ -137,10 +137,24 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
+  integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.28.5"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.20.5", "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.26.5":
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.5.tgz#df93ac37f4417854130e21d72c66ff3d4b897fc7"
   integrity sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==
+
+"@babel/compat-data@^7.28.6":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.0.tgz#00d03e8c0ac24dd9be942c5370990cbe1f17d88d"
+  integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
 "@babel/core@^7.14.0", "@babel/core@^7.21.3", "@babel/core@^7.22.9", "@babel/core@^7.23.2":
   version "7.26.7"
@@ -163,6 +177,27 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
+"@babel/core@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.0.tgz#5286ad785df7f79d656e88ce86e650d16ca5f322"
+  integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
+  dependencies:
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-module-transforms" "^7.28.6"
+    "@babel/helpers" "^7.28.6"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/traverse" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
 "@babel/generator@^7.14.0", "@babel/generator@^7.18.13", "@babel/generator@^7.26.5":
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.5.tgz#e44d4ab3176bbcaf78a5725da5f1dc28802a9458"
@@ -172,6 +207,17 @@
     "@babel/types" "^7.26.5"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
+
+"@babel/generator@^7.29.0":
+  version "7.29.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.1.tgz#d09876290111abbb00ef962a7b83a5307fba0d50"
+  integrity sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==
+  dependencies:
+    "@babel/parser" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
 "@babel/helper-annotate-as-pure@^7.25.9":
@@ -188,6 +234,17 @@
   dependencies:
     "@babel/compat-data" "^7.26.5"
     "@babel/helper-validator-option" "^7.25.9"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-compilation-targets@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz#32c4a3f41f12ed1532179b108a4d746e105c2b25"
+  integrity sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==
+  dependencies:
+    "@babel/compat-data" "^7.28.6"
+    "@babel/helper-validator-option" "^7.27.1"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
@@ -247,6 +304,11 @@
     lodash.debounce "^4.0.8"
     resolve "^1.14.2"
 
+"@babel/helper-globals@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
+  integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
+
 "@babel/helper-member-expression-to-functions@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz#9dfffe46f727005a5ea29051ac835fb735e4c1a3"
@@ -263,6 +325,14 @@
     "@babel/traverse" "^7.25.9"
     "@babel/types" "^7.25.9"
 
+"@babel/helper-module-imports@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz#60632cbd6ffb70b22823187201116762a03e2d5c"
+  integrity sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==
+  dependencies:
+    "@babel/traverse" "^7.28.6"
+    "@babel/types" "^7.28.6"
+
 "@babel/helper-module-transforms@^7.25.9", "@babel/helper-module-transforms@^7.26.0":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz#8ce54ec9d592695e58d84cd884b7b5c6a2fdeeae"
@@ -271,6 +341,15 @@
     "@babel/helper-module-imports" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
     "@babel/traverse" "^7.25.9"
+
+"@babel/helper-module-transforms@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz#9312d9d9e56edc35aeb6e95c25d4106b50b9eb1e"
+  integrity sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.28.6"
+    "@babel/helper-validator-identifier" "^7.28.5"
+    "@babel/traverse" "^7.28.6"
 
 "@babel/helper-optimise-call-expression@^7.25.9":
   version "7.25.9"
@@ -283,6 +362,11 @@
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz#18580d00c9934117ad719392c4f6585c9333cc35"
   integrity sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==
+
+"@babel/helper-plugin-utils@^7.27.1":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz#6f13ea251b68c8532e985fd532f28741a8af9ac8"
+  integrity sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==
 
 "@babel/helper-remap-async-to-generator@^7.25.9":
   version "7.25.9"
@@ -315,6 +399,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
   integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
 
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
 "@babel/helper-validator-identifier@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
@@ -329,6 +418,11 @@
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz#86e45bd8a49ab7e03f276577f96179653d41da72"
   integrity sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==
+
+"@babel/helper-validator-option@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
+  integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
 
 "@babel/helper-wrap-function@^7.25.9":
   version "7.25.9"
@@ -347,7 +441,22 @@
     "@babel/template" "^7.27.0"
     "@babel/types" "^7.27.0"
 
-"@babel/parser@^7.14.0", "@babel/parser@^7.16.8", "@babel/parser@^7.25.4", "@babel/parser@^7.25.9", "@babel/parser@^7.26.5", "@babel/parser@^7.26.7":
+"@babel/helpers@^7.28.6":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.2.tgz#9cfbccb02b8e229892c0b07038052cc1a8709c49"
+  integrity sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==
+  dependencies:
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.28.6", "@babel/parser@^7.29.0":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.2.tgz#58bd50b9a7951d134988a1ae177a35ef9a703ba1"
+  integrity sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
+  dependencies:
+    "@babel/types" "^7.29.0"
+
+"@babel/parser@^7.14.0", "@babel/parser@^7.16.8", "@babel/parser@^7.25.9", "@babel/parser@^7.26.5", "@babel/parser@^7.26.7":
   version "7.26.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.7.tgz#e114cd099e5f7d17b05368678da0fb9f69b3385c"
   integrity sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==
@@ -823,6 +932,20 @@
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.25.9"
 
+"@babel/plugin-transform-react-jsx-self@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz#af678d8506acf52c577cac73ff7fe6615c85fc92"
+  integrity sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-react-jsx-source@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz#dcfe2c24094bb757bf73960374e7c55e434f19f0"
+  integrity sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
 "@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz#06367940d8325b36edff5e2b9cbe782947ca4166"
@@ -1072,6 +1195,15 @@
     "@babel/parser" "^7.27.0"
     "@babel/types" "^7.27.0"
 
+"@babel/template@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.28.6.tgz#0e7e56ecedb78aeef66ce7972b082fce76a23e57"
+  integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
+  dependencies:
+    "@babel/code-frame" "^7.28.6"
+    "@babel/parser" "^7.28.6"
+    "@babel/types" "^7.28.6"
+
 "@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.7":
   version "7.26.7"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.7.tgz#99a0a136f6a75e7fb8b0a1ace421e0b25994b8bb"
@@ -1085,13 +1217,34 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.18.13", "@babel/types@^7.21.3", "@babel/types@^7.25.4", "@babel/types@^7.25.9", "@babel/types@^7.26.5", "@babel/types@^7.26.7", "@babel/types@^7.4.4":
+"@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
+  integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
+  dependencies:
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
+    debug "^4.3.1"
+
+"@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.18.13", "@babel/types@^7.21.3", "@babel/types@^7.25.9", "@babel/types@^7.26.5", "@babel/types@^7.26.7", "@babel/types@^7.4.4":
   version "7.26.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.7.tgz#5e2b89c0768e874d4d061961f3a5a153d71dc17a"
   integrity sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
+
+"@babel/types@^7.20.7", "@babel/types@^7.28.2", "@babel/types@^7.28.6", "@babel/types@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
 
 "@babel/types@^7.27.0":
   version "7.27.0"
@@ -1429,136 +1582,6 @@
   integrity sha512-IPjmgSc4KpQRlO4qbEDnBEixvtb06WDmjKfi/7fkZaryh5HuOmTtixe1EupQI5XfXO8joc3d27uUZ0QdC++euA==
   dependencies:
     tslib "^2.5.0"
-
-"@esbuild/aix-ppc64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz#ee6b7163a13528e099ecf562b972f2bcebe0aa97"
-  integrity sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==
-
-"@esbuild/android-arm64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz#115fc76631e82dd06811bfaf2db0d4979c16e2cb"
-  integrity sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==
-
-"@esbuild/android-arm@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.10.tgz#8d5811912da77f615398611e5bbc1333fe321aa9"
-  integrity sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==
-
-"@esbuild/android-x64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.10.tgz#e3e96516b2d50d74105bb92594c473e30ddc16b1"
-  integrity sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==
-
-"@esbuild/darwin-arm64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz#6af6bb1d05887dac515de1b162b59dc71212ed76"
-  integrity sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==
-
-"@esbuild/darwin-x64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz#99ae82347fbd336fc2d28ffd4f05694e6e5b723d"
-  integrity sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==
-
-"@esbuild/freebsd-arm64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz#0c6d5558a6322b0bdb17f7025c19bd7d2359437d"
-  integrity sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==
-
-"@esbuild/freebsd-x64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz#8c35873fab8c0857a75300a3dcce4324ca0b9844"
-  integrity sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==
-
-"@esbuild/linux-arm64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz#3edc2f87b889a15b4cedaf65f498c2bed7b16b90"
-  integrity sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==
-
-"@esbuild/linux-arm@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz#86501cfdfb3d110176d80c41b27ed4611471cde7"
-  integrity sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==
-
-"@esbuild/linux-ia32@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz#e6589877876142537c6864680cd5d26a622b9d97"
-  integrity sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==
-
-"@esbuild/linux-loong64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz#11119e18781f136d8083ea10eb6be73db7532de8"
-  integrity sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==
-
-"@esbuild/linux-mips64el@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz#3052f5436b0c0c67a25658d5fc87f045e7def9e6"
-  integrity sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==
-
-"@esbuild/linux-ppc64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz#2f098920ee5be2ce799f35e367b28709925a8744"
-  integrity sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==
-
-"@esbuild/linux-riscv64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz#fa51d7fd0a22a62b51b4b94b405a3198cf7405dd"
-  integrity sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==
-
-"@esbuild/linux-s390x@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz#a27642e36fc282748fdb38954bd3ef4f85791e8a"
-  integrity sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==
-
-"@esbuild/linux-x64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz#9d9b09c0033d17529570ced6d813f98315dfe4e9"
-  integrity sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==
-
-"@esbuild/netbsd-arm64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz#25c09a659c97e8af19e3f2afd1c9190435802151"
-  integrity sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==
-
-"@esbuild/netbsd-x64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz#7fa5f6ffc19be3a0f6f5fd32c90df3dc2506937a"
-  integrity sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==
-
-"@esbuild/openbsd-arm64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz#8faa6aa1afca0c6d024398321d6cb1c18e72a1c3"
-  integrity sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==
-
-"@esbuild/openbsd-x64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz#a42979b016f29559a8453d32440d3c8cd420af5e"
-  integrity sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==
-
-"@esbuild/openharmony-arm64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz#fd87bfeadd7eeb3aa384bbba907459ffa3197cb1"
-  integrity sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==
-
-"@esbuild/sunos-x64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz#3a18f590e36cb78ae7397976b760b2b8c74407f4"
-  integrity sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==
-
-"@esbuild/win32-arm64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz#e71741a251e3fd971408827a529d2325551f530c"
-  integrity sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==
-
-"@esbuild/win32-ia32@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz#c6f010b5d3b943d8901a0c87ea55f93b8b54bf94"
-  integrity sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==
-
-"@esbuild/win32-x64@0.25.10":
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz#e4b3e255a1b4aea84f6e1d2ae0b73f826c3785bd"
-  integrity sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==
 
 "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
@@ -2272,23 +2295,6 @@
   resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-3.0.2.tgz#baff9f8d70947181deb36772cd9a5b6876d3e60c"
   integrity sha512-ZhQ4TvhwHZF+lGhQ2O/rsjo80XoZR5/5qhOY3t6FJuX5XBg5Be8YzYTvaUGJnc12AUGI2nr4QSUE4PhKSigx7g==
 
-"@isaacs/cliui@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
-  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
-  dependencies:
-    string-width "^5.1.2"
-    string-width-cjs "npm:string-width@^4.2.0"
-    strip-ansi "^7.0.1"
-    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
-    wrap-ansi "^8.1.0"
-    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
-
-"@istanbuljs/schema@^0.1.2":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
-  integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
-
 "@jest/environment-jsdom-abstract@30.2.0":
   version "30.2.0"
   resolved "https://registry.yarnpkg.com/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.2.0.tgz#1313f9b3b509c31298c241203161b36622865181"
@@ -2364,6 +2370,14 @@
   resolved "https://registry.yarnpkg.com/@jonkoops/matomo-tracker/-/matomo-tracker-0.7.0.tgz#38bd15352cd6a2115eb863a9ba582a1c0f52fc32"
   integrity sha512-ppCXiDaVytTQOP6hNZIBwjUph5IrGgDoQw4IF5sBoA3PBpMAc5tWtPExbVWTR5pJWpTcp11dv2M83n9pm7LpeQ==
 
+"@jridgewell/gen-mapping@^0.3.12":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
@@ -2371,6 +2385,14 @@
   dependencies:
     "@jridgewell/set-array" "^1.2.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/remapping@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
 "@jridgewell/resolve-uri@^3.1.0":
@@ -2383,15 +2405,28 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
-"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+"@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.28", "@jridgewell/trace-mapping@^0.3.31":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -2592,11 +2627,6 @@
     "@parcel/watcher-win32-arm64" "2.5.1"
     "@parcel/watcher-win32-ia32" "2.5.1"
     "@parcel/watcher-win32-x64" "2.5.1"
-
-"@pkgjs/parseargs@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
-  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@pkgr/core@^0.1.0":
   version "0.1.1"
@@ -2805,7 +2835,12 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz#74163aec62fa51cee18d62709483963dceb3f6dc"
   integrity sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==
 
-"@rollup/pluginutils@^5.2.0":
+"@rolldown/pluginutils@1.0.0-rc.3":
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz#8a88cc92a0f741befc7bc109cb1a4c6b9408e1c5"
+  integrity sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==
+
+"@rollup/pluginutils@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.3.0.tgz#57ba1b0cbda8e7a3c597a4853c807b156e21a7b4"
   integrity sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==
@@ -2813,131 +2848,6 @@
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
-
-"@rollup/rollup-android-arm-eabi@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz#043f145716234529052ef9e1ce1d847ffbe9e674"
-  integrity sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==
-
-"@rollup/rollup-android-arm64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz#023e1bd146e7519087dfd9e8b29e4cf9f8ecd35c"
-  integrity sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==
-
-"@rollup/rollup-darwin-arm64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz#55ccb5487c02419954c57a7a80602885d616e1ee"
-  integrity sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==
-
-"@rollup/rollup-darwin-x64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz#254b65404b14488c83225e88b8819376ad71a784"
-  integrity sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==
-
-"@rollup/rollup-freebsd-arm64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz#6377ff38c052c76fcaffb7b2728d3172fe676fe6"
-  integrity sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==
-
-"@rollup/rollup-freebsd-x64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz#ba3902309d088eaf7139b916f09b7140b28b406d"
-  integrity sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz#e011b9a14638267e53b446286e838dbdaf53f167"
-  integrity sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==
-
-"@rollup/rollup-linux-arm-musleabihf@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz#0bce9ce9a009490abd28fd922dd97ed521311afe"
-  integrity sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==
-
-"@rollup/rollup-linux-arm64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz#6f6cfbbf324fbb4ceff213abdf7f322fd45d25ff"
-  integrity sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==
-
-"@rollup/rollup-linux-arm64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz#f7cb3eecaea9c151ef77342af05f38ae924bf795"
-  integrity sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==
-
-"@rollup/rollup-linux-loong64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz#499bfac6bb669fd88bb664357bf6be996a28b92f"
-  integrity sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==
-
-"@rollup/rollup-linux-loong64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz#127dfac08764764396bbe04453c545d38a3ab518"
-  integrity sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==
-
-"@rollup/rollup-linux-ppc64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz#6a72f4d95852aac18326c5bf708393e8f3a41b70"
-  integrity sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==
-
-"@rollup/rollup-linux-ppc64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz#ba8674666b00d6f9066cb9a5771a8430c34d2de6"
-  integrity sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==
-
-"@rollup/rollup-linux-riscv64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz#17cc38b2a71e302547cad29bcf78d0db2618c922"
-  integrity sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==
-
-"@rollup/rollup-linux-riscv64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz#e36a41e2d8bd247331bd5cfc13b8c951d33454a2"
-  integrity sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==
-
-"@rollup/rollup-linux-s390x-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz#1687265f1f4bdea0726c761a58c2db9933609d68"
-  integrity sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==
-
-"@rollup/rollup-linux-x64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz#56a6a0d9076f2a05a976031493b24a20ddcc0e77"
-  integrity sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==
-
-"@rollup/rollup-linux-x64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz#bc240ebb5b9fd8d41ca8a80cb458452e8c187e0f"
-  integrity sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==
-
-"@rollup/rollup-openbsd-x64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz#6f80d48a006c4b2ffa7724e95a3e33f6975872af"
-  integrity sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==
-
-"@rollup/rollup-openharmony-arm64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz#8f6db6f70d0a48abd833b263cd6dd3e7199c4c0e"
-  integrity sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==
-
-"@rollup/rollup-win32-arm64-msvc@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz#b68989bfa815d0b3d4e302ecd90bda744438b177"
-  integrity sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==
-
-"@rollup/rollup-win32-ia32-msvc@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz#c098e45338c50f22f1b288476354f025b746285b"
-  integrity sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==
-
-"@rollup/rollup-win32-x64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz#2c9e15be155b79d05999953b1737b2903842e903"
-  integrity sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==
-
-"@rollup/rollup-win32-x64-msvc@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz#23b860113e9f87eea015d1fa3a4240a52b42fcd4"
-  integrity sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -3008,6 +2918,11 @@
   integrity sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
+
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
 "@stylistic/eslint-plugin-js@^3.1.0":
   version "3.1.0"
@@ -3100,93 +3015,12 @@
     "@svgr/hast-util-to-babel-ast" "8.0.0"
     svg-parser "^2.0.4"
 
-"@swc/core-darwin-arm64@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.11.tgz#37e79f35f1d0226465d4b5fe8e1c957e35661bd5"
-  integrity sha512-ZpgEaNcx2e5D+Pd0yZGVbpSrEDOEubn7r2JXoNBf0O85lPjUm3HDzGRfLlV/MwxRPAkwm93eLP4l7gYnc50l3g==
-
-"@swc/core-darwin-x64@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.10.11.tgz#da0354121088d73808634efb213a264400587c8f"
-  integrity sha512-szObinnq2o7spXMDU5pdunmUeLrfV67Q77rV+DyojAiGJI1RSbEQotLOk+ONOLpoapwGUxOijFG4IuX1xiwQ2g==
-
-"@swc/core-linux-arm-gnueabihf@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.11.tgz#4357c4f8fd1a4d53020c2e5caf048ff5ca134eec"
-  integrity sha512-tVE8aXQwd8JUB9fOGLawFJa76nrpvp3dvErjozMmWSKWqtoeO7HV83aOrVtc8G66cj4Vq7FjTE9pOJeV1FbKRw==
-
-"@swc/core-linux-arm64-gnu@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.11.tgz#2b92ddb2500c1292a999fc617044bed8318ac0dc"
-  integrity sha512-geFkENU5GMEKO7FqHOaw9HVlpQEW10nICoM6ubFc0hXBv8dwRXU4vQbh9s/isLSFRftw1m4jEEWixAnXSw8bxQ==
-
-"@swc/core-linux-arm64-musl@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.11.tgz#8545fd335bd5234522bc23a8a11582ff549e26eb"
-  integrity sha512-2mMscXe/ivq8c4tO3eQSbQDFBvagMJGlalXCspn0DgDImLYTEnt/8KHMUMGVfh0gMJTZ9q4FlGLo7mlnbx99MQ==
-
-"@swc/core-linux-x64-gnu@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.11.tgz#79e94f3d59e29016c8294d401d8b35bc13d6586a"
-  integrity sha512-eu2apgDbC4xwsigpl6LS+iyw6a3mL6kB4I+6PZMbFF2nIb1Dh7RGnu70Ai6mMn1o80fTmRSKsCT3CKMfVdeNFg==
-
-"@swc/core-linux-x64-musl@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.11.tgz#edceb8cf38ad00d82db56349b919d4482bc5ba96"
-  integrity sha512-0n+wPWpDigwqRay4IL2JIvAqSKCXv6nKxPig9M7+epAlEQlqX+8Oq/Ap3yHtuhjNPb7HmnqNJLCXT1Wx+BZo0w==
-
-"@swc/core-win32-arm64-msvc@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.11.tgz#000e82ccd079a7eab382b9124b216e2310d7d013"
-  integrity sha512-7+bMSIoqcbXKosIVd314YjckDRPneA4OpG1cb3/GrkQTEDXmWT3pFBBlJf82hzJfw7b6lfv6rDVEFBX7/PJoLA==
-
-"@swc/core-win32-ia32-msvc@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.11.tgz#6138bdf97a221d2194f4181bf87255063520210d"
-  integrity sha512-6hkLl4+3KjP/OFTryWxpW7YFN+w4R689TSPwiII4fFgsFNupyEmLWWakKfkGgV2JVA59L4Oi02elHy/O1sbgtw==
-
-"@swc/core-win32-x64-msvc@1.10.11":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.11.tgz#d1571d46a5c0efe17ef12898bc605e301d266b2d"
-  integrity sha512-kKNE2BGu/La2k2WFHovenqZvGQAHRIU+rd2/6a7D6EiQ6EyimtbhUqjCCZ+N1f5fIAnvM+sMdLiQJq4jdd/oOQ==
-
-"@swc/core@^1.7.26":
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.10.11.tgz#cbc72a940b127dd6313b5c6c5ab67a746cd39751"
-  integrity sha512-3zGU5y3S20cAwot9ZcsxVFNsSVaptG+dKdmAxORSE3EX7ixe1Xn5kUwLlgIsM4qrwTUWCJDLNhRS+2HLFivcDg==
-  dependencies:
-    "@swc/counter" "^0.1.3"
-    "@swc/types" "^0.1.17"
-  optionalDependencies:
-    "@swc/core-darwin-arm64" "1.10.11"
-    "@swc/core-darwin-x64" "1.10.11"
-    "@swc/core-linux-arm-gnueabihf" "1.10.11"
-    "@swc/core-linux-arm64-gnu" "1.10.11"
-    "@swc/core-linux-arm64-musl" "1.10.11"
-    "@swc/core-linux-x64-gnu" "1.10.11"
-    "@swc/core-linux-x64-musl" "1.10.11"
-    "@swc/core-win32-arm64-msvc" "1.10.11"
-    "@swc/core-win32-ia32-msvc" "1.10.11"
-    "@swc/core-win32-x64-msvc" "1.10.11"
-
-"@swc/counter@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
-  integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
-
 "@swc/helpers@^0.5.0":
   version "0.5.15"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
   integrity sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==
   dependencies:
     tslib "^2.8.0"
-
-"@swc/types@^0.1.17":
-  version "0.1.17"
-  resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.17.tgz#bd1d94e73497f27341bf141abdf4c85230d41e7c"
-  integrity sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==
-  dependencies:
-    "@swc/counter" "^0.1.3"
 
 "@testing-library/dom@^8.19.0":
   version "8.20.1"
@@ -3261,6 +3095,47 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
   integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
+"@types/babel__core@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
+  integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
+  dependencies:
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.27.0.tgz#b5819294c51179957afaec341442f9341e4108a9"
+  integrity sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.4.tgz#5672513701c1b2199bc6dad636a9d7491586766f"
+  integrity sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.28.0.tgz#07d713d6cce0d265c9849db0cbe62d3f61f36f74"
+  integrity sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==
+  dependencies:
+    "@babel/types" "^7.28.2"
+
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
 "@types/conventional-commits-parser@^5.0.0":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz#8cb81cf170853496cbc501a3b32dcf5e46ffb61a"
@@ -3284,6 +3159,11 @@
   integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
   dependencies:
     "@types/ms" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/eslint@*":
   version "9.6.1"
@@ -3310,7 +3190,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
   integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
 
-"@types/estree@1.0.8", "@types/estree@^1.0.6":
+"@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -3585,6 +3465,15 @@
     "@typescript-eslint/types" "^8.57.1"
     debug "^4.4.3"
 
+"@typescript-eslint/project-service@8.58.1":
+  version "8.58.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.58.1.tgz#c78781b1ca1ec1e7bc6522efba89318c6d249feb"
+  integrity sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==
+  dependencies:
+    "@typescript-eslint/tsconfig-utils" "^8.58.1"
+    "@typescript-eslint/types" "^8.58.1"
+    debug "^4.4.3"
+
 "@typescript-eslint/scope-manager@6.21.0":
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz#ea8a9bfc8f1504a6ac5d59a6df308d3a0630a2b1"
@@ -3593,7 +3482,7 @@
     "@typescript-eslint/types" "6.21.0"
     "@typescript-eslint/visitor-keys" "6.21.0"
 
-"@typescript-eslint/scope-manager@8.57.1", "@typescript-eslint/scope-manager@^8.55.0", "@typescript-eslint/scope-manager@^8.56.0":
+"@typescript-eslint/scope-manager@8.57.1", "@typescript-eslint/scope-manager@^8.56.0":
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz#4524d7e7b420cb501807499684d435ae129aaf35"
   integrity sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==
@@ -3601,10 +3490,23 @@
     "@typescript-eslint/types" "8.57.1"
     "@typescript-eslint/visitor-keys" "8.57.1"
 
+"@typescript-eslint/scope-manager@8.58.1", "@typescript-eslint/scope-manager@^8.58.0":
+  version "8.58.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz#35168f561bab4e3fd10dd6b03e8b83c157479211"
+  integrity sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==
+  dependencies:
+    "@typescript-eslint/types" "8.58.1"
+    "@typescript-eslint/visitor-keys" "8.58.1"
+
 "@typescript-eslint/tsconfig-utils@8.57.1", "@typescript-eslint/tsconfig-utils@^8.57.1":
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz#9233443ec716882a6f9e240fd900a73f0235f3d7"
   integrity sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==
+
+"@typescript-eslint/tsconfig-utils@8.58.1", "@typescript-eslint/tsconfig-utils@^8.58.1":
+  version "8.58.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz#eb16792c579300c7bfb3c74b0f5e1dfbb0a2454d"
+  integrity sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==
 
 "@typescript-eslint/type-utils@8.57.1":
   version "8.57.1"
@@ -3626,6 +3528,11 @@
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.57.1.tgz#54b27a8a25a7b45b4f978c3f8e00c4c78f11142c"
   integrity sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==
+
+"@typescript-eslint/types@8.58.1", "@typescript-eslint/types@^8.58.1":
+  version "8.58.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.58.1.tgz#9dfb4723fcd2b13737d8b03d941354cf73190313"
+  integrity sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==
 
 "@typescript-eslint/typescript-estree@6.21.0":
   version "6.21.0"
@@ -3656,7 +3563,22 @@
     tinyglobby "^0.2.15"
     ts-api-utils "^2.4.0"
 
-"@typescript-eslint/utils@8.57.1", "@typescript-eslint/utils@^8.55.0", "@typescript-eslint/utils@^8.56.0":
+"@typescript-eslint/typescript-estree@8.58.1":
+  version "8.58.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz#8230cc9628d2cffef101e298c62807c4b9bf2fe9"
+  integrity sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==
+  dependencies:
+    "@typescript-eslint/project-service" "8.58.1"
+    "@typescript-eslint/tsconfig-utils" "8.58.1"
+    "@typescript-eslint/types" "8.58.1"
+    "@typescript-eslint/visitor-keys" "8.58.1"
+    debug "^4.4.3"
+    minimatch "^10.2.2"
+    semver "^7.7.3"
+    tinyglobby "^0.2.15"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/utils@8.57.1", "@typescript-eslint/utils@^8.56.0":
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.57.1.tgz#e40f5a7fcff02fd24092a7b52bd6ec029fb50465"
   integrity sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==
@@ -3665,6 +3587,16 @@
     "@typescript-eslint/scope-manager" "8.57.1"
     "@typescript-eslint/types" "8.57.1"
     "@typescript-eslint/typescript-estree" "8.57.1"
+
+"@typescript-eslint/utils@^8.58.0":
+  version "8.58.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.58.1.tgz#099a327b04ed921e6ee3988cde9ef34bc4b5435a"
+  integrity sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/scope-manager" "8.58.1"
+    "@typescript-eslint/types" "8.58.1"
+    "@typescript-eslint/typescript-estree" "8.58.1"
 
 "@typescript-eslint/visitor-keys@6.21.0":
   version "6.21.0"
@@ -3680,6 +3612,14 @@
   integrity sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==
   dependencies:
     "@typescript-eslint/types" "8.57.1"
+    eslint-visitor-keys "^5.0.0"
+
+"@typescript-eslint/visitor-keys@8.58.1":
+  version "8.58.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz#7c197533177f1ba9b8249f55f7f685e32bb6f204"
+  integrity sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==
+  dependencies:
+    "@typescript-eslint/types" "8.58.1"
     eslint-visitor-keys "^5.0.0"
 
 "@uiw/copy-to-clipboard@~1.0.12":
@@ -3837,97 +3777,101 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
-"@vitejs/plugin-react-swc@^3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.2.tgz#b0958dd44c48dbd37b5ef887bdb8b8d1276f24cd"
-  integrity sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==
+"@vitejs/plugin-react@^5.0.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz#108bd0f566f288ce3566982df4eff137ded7b15f"
+  integrity sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==
   dependencies:
-    "@swc/core" "^1.7.26"
+    "@babel/core" "^7.29.0"
+    "@babel/plugin-transform-react-jsx-self" "^7.27.1"
+    "@babel/plugin-transform-react-jsx-source" "^7.27.1"
+    "@rolldown/pluginutils" "1.0.0-rc.3"
+    "@types/babel__core" "^7.20.5"
+    react-refresh "^0.18.0"
 
-"@vitest/coverage-v8@^3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-3.0.7.tgz#44768ff9f6c541c5ea66ce8a3ed56a79a0e7f518"
-  integrity sha512-Av8WgBJLTrfLOer0uy3CxjlVuWK4CzcLBndW1Nm2vI+3hZ2ozHututkfc7Blu1u6waeQ7J8gzPK/AsBRnWA5mQ==
+"@vitest/coverage-v8@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz#2617f76d12065d2caadedb92bb7bb86cd2af1131"
+  integrity sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==
   dependencies:
-    "@ampproject/remapping" "^2.3.0"
     "@bcoe/v8-coverage" "^1.0.2"
-    debug "^4.4.0"
+    "@vitest/utils" "4.1.2"
+    ast-v8-to-istanbul "^1.0.0"
     istanbul-lib-coverage "^3.2.2"
     istanbul-lib-report "^3.0.1"
-    istanbul-lib-source-maps "^5.0.6"
-    istanbul-reports "^3.1.7"
-    magic-string "^0.30.17"
-    magicast "^0.3.5"
-    std-env "^3.8.0"
-    test-exclude "^7.0.1"
-    tinyrainbow "^2.0.0"
+    istanbul-reports "^3.2.0"
+    magicast "^0.5.2"
+    obug "^2.1.1"
+    std-env "^4.0.0-rc.1"
+    tinyrainbow "^3.1.0"
 
-"@vitest/eslint-plugin@^1.6.13":
-  version "1.6.13"
-  resolved "https://registry.yarnpkg.com/@vitest/eslint-plugin/-/eslint-plugin-1.6.13.tgz#3e1106d8df65d0afd6250251f5bb7583398b6bcc"
-  integrity sha512-ui7JGWBoQpS5NKKW0FDb1eTuFEZ5EupEv2Psemuyfba7DfA5K52SeDLelt6P4pQJJ/4UGkker/BgMk/KrjH3WQ==
+"@vitest/eslint-plugin@^1.6.14":
+  version "1.6.14"
+  resolved "https://registry.yarnpkg.com/@vitest/eslint-plugin/-/eslint-plugin-1.6.14.tgz#278d91ed07eb9e59e922db0fec3c54741d99f4a4"
+  integrity sha512-PXZ5ysw4eHU9h8nDtBvVcGC7Z2C/T9CFdheqSw1NNXFYqViojub0V9bgdYI67iBTOcra2mwD0EYldlY9bGPf2Q==
   dependencies:
-    "@typescript-eslint/scope-manager" "^8.55.0"
-    "@typescript-eslint/utils" "^8.55.0"
+    "@typescript-eslint/scope-manager" "^8.58.0"
+    "@typescript-eslint/utils" "^8.58.0"
 
-"@vitest/expect@3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.0.7.tgz#3490936bc1e97fc21d53441518d51cb7116c698a"
-  integrity sha512-QP25f+YJhzPfHrHfYHtvRn+uvkCFCqFtW9CktfBxmB+25QqWsx7VB2As6f4GmwllHLDhXNHvqedwhvMmSnNmjw==
+"@vitest/expect@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.2.tgz#2aec02233db4eac14777e6a7d14a535c63ae2d9b"
+  integrity sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==
   dependencies:
-    "@vitest/spy" "3.0.7"
-    "@vitest/utils" "3.0.7"
-    chai "^5.2.0"
-    tinyrainbow "^2.0.0"
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.2"
+    "@vitest/utils" "4.1.2"
+    chai "^6.2.2"
+    tinyrainbow "^3.1.0"
 
-"@vitest/mocker@3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.0.7.tgz#49a99e300bcb64dc514a43a92325fce51cd88099"
-  integrity sha512-qui+3BLz9Eonx4EAuR/i+QlCX6AUZ35taDQgwGkK/Tw6/WgwodSrjN1X2xf69IA/643ZX5zNKIn2svvtZDrs4w==
+"@vitest/mocker@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.2.tgz#3f23523697f9ab9e851b58b2213c4ab6181aa0e6"
+  integrity sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==
   dependencies:
-    "@vitest/spy" "3.0.7"
+    "@vitest/spy" "4.1.2"
     estree-walker "^3.0.3"
-    magic-string "^0.30.17"
+    magic-string "^0.30.21"
 
-"@vitest/pretty-format@3.0.7", "@vitest/pretty-format@^3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.0.7.tgz#1780516ebb4e40dd89e60b9fc7ffcbd9cba0fc22"
-  integrity sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==
+"@vitest/pretty-format@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.2.tgz#c2671aa1c931dc8f2759589fc87ea4b2602892c5"
+  integrity sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==
   dependencies:
-    tinyrainbow "^2.0.0"
+    tinyrainbow "^3.1.0"
 
-"@vitest/runner@3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.0.7.tgz#65b64ba5f3291fdca4670bf9e50627200ea33b7b"
-  integrity sha512-WeEl38Z0S2ZcuRTeyYqaZtm4e26tq6ZFqh5y8YD9YxfWuu0OFiGFUbnxNynwLjNRHPsXyee2M9tV7YxOTPZl2g==
+"@vitest/runner@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.2.tgz#6f744fa0d92d31f4c8c255b64bbe073cb75fd96e"
+  integrity sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==
   dependencies:
-    "@vitest/utils" "3.0.7"
+    "@vitest/utils" "4.1.2"
     pathe "^2.0.3"
 
-"@vitest/snapshot@3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.0.7.tgz#df34e3c5820bdd54bba8919291a182df5c6b8c6f"
-  integrity sha512-eqTUryJWQN0Rtf5yqCGTQWsCFOQe4eNz5Twsu21xYEcnFJtMU5XvmG0vgebhdLlrHQTSq5p8vWHJIeJQV8ovsA==
+"@vitest/snapshot@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.2.tgz#3972b8ed7a311133e12cb833bf86463d26cdd455"
+  integrity sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==
   dependencies:
-    "@vitest/pretty-format" "3.0.7"
-    magic-string "^0.30.17"
+    "@vitest/pretty-format" "4.1.2"
+    "@vitest/utils" "4.1.2"
+    magic-string "^0.30.21"
     pathe "^2.0.3"
 
-"@vitest/spy@3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.0.7.tgz#6fcc100c23fb50b5e2d1d09a333245586364f67b"
-  integrity sha512-4T4WcsibB0B6hrKdAZTM37ekuyFZt2cGbEGd2+L0P8ov15J1/HUsUaqkXEQPNAWr4BtPPe1gI+FYfMHhEKfR8w==
-  dependencies:
-    tinyspy "^3.0.2"
+"@vitest/spy@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.2.tgz#1f312cef5756256639b4c0614f74c8ad9a036ef9"
+  integrity sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==
 
-"@vitest/utils@3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.0.7.tgz#56268acac1027ead938150eceb2527c61d2fa204"
-  integrity sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==
+"@vitest/utils@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.2.tgz#32be8f42eb6683a598b1c61d7ec9f55596c60ecb"
+  integrity sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==
   dependencies:
-    "@vitest/pretty-format" "3.0.7"
-    loupe "^3.1.3"
-    tinyrainbow "^2.0.0"
+    "@vitest/pretty-format" "4.1.2"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.1.0"
 
 "@whatwg-node/disposablestack@^0.0.5":
   version "0.0.5"
@@ -4117,7 +4061,7 @@ ansi-styles@^5.0.0, ansi-styles@^5.2.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
+ansi-styles@^6.0.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -4278,6 +4222,15 @@ ast-types-flow@^0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.8.tgz#0a85e1c92695769ac13a428bb653e7538bea27d6"
   integrity sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==
+
+ast-v8-to-istanbul@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz#d1e8bfc79fa9c452972ff91897633bda4e5e7577"
+  integrity sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.31"
+    estree-walker "^3.0.3"
+    js-tokens "^10.0.0"
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -4493,7 +4446,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1, brace-expansion@^2.0.2:
+brace-expansion@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"
   integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
@@ -4555,11 +4508,6 @@ busboy@^1.6.0:
   integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
   dependencies:
     streamsearch "^1.1.0"
-
-cac@^6.7.14:
-  version "6.7.14"
-  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
-  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
 
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1:
   version "1.0.1"
@@ -4667,16 +4615,10 @@ chai@4.3.4:
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
-chai@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-5.2.0.tgz#1358ee106763624114addf84ab02697e411c9c05"
-  integrity sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==
-  dependencies:
-    assertion-error "^2.0.1"
-    check-error "^2.1.1"
-    deep-eql "^5.0.1"
-    loupe "^3.1.0"
-    pathval "^2.0.0"
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chalk@^2.3.0, chalk@^2.4.0:
   version "2.4.2"
@@ -4788,11 +4730,6 @@ check-error@^1.0.2:
   integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
   dependencies:
     get-func-name "^2.0.2"
-
-check-error@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
-  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
 chokidar@^4.0.0:
   version "4.0.3"
@@ -5317,11 +5254,6 @@ deep-eql@^3.0.1:
   dependencies:
     type-detect "^4.0.0"
 
-deep-eql@^5.0.1:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
-  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
-
 deep-equal@^2.0.5:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.3.tgz#af89dafb23a396c7da3e862abc0be27cf51d56e1"
@@ -5609,11 +5541,6 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
-eastasianwidth@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
-  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
@@ -5816,10 +5743,10 @@ es-iterator-helpers@^1.2.1:
     iterator.prototype "^1.1.4"
     safe-array-concat "^1.1.3"
 
-es-module-lexer@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.6.0.tgz#da49f587fd9e68ee2404fe4e256c0c7d3a81be21"
-  integrity sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==
+es-module-lexer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.0.0.tgz#f657cd7a9448dcdda9c070a3cb75e5dc1e85f5b1"
+  integrity sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
@@ -5853,38 +5780,6 @@ es-to-primitive@^1.3.0:
     is-callable "^1.2.7"
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
-
-esbuild@^0.25.0:
-  version "0.25.10"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.10.tgz#37f5aa5cd14500f141be121c01b096ca83ac34a9"
-  integrity sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==
-  optionalDependencies:
-    "@esbuild/aix-ppc64" "0.25.10"
-    "@esbuild/android-arm" "0.25.10"
-    "@esbuild/android-arm64" "0.25.10"
-    "@esbuild/android-x64" "0.25.10"
-    "@esbuild/darwin-arm64" "0.25.10"
-    "@esbuild/darwin-x64" "0.25.10"
-    "@esbuild/freebsd-arm64" "0.25.10"
-    "@esbuild/freebsd-x64" "0.25.10"
-    "@esbuild/linux-arm" "0.25.10"
-    "@esbuild/linux-arm64" "0.25.10"
-    "@esbuild/linux-ia32" "0.25.10"
-    "@esbuild/linux-loong64" "0.25.10"
-    "@esbuild/linux-mips64el" "0.25.10"
-    "@esbuild/linux-ppc64" "0.25.10"
-    "@esbuild/linux-riscv64" "0.25.10"
-    "@esbuild/linux-s390x" "0.25.10"
-    "@esbuild/linux-x64" "0.25.10"
-    "@esbuild/netbsd-arm64" "0.25.10"
-    "@esbuild/netbsd-x64" "0.25.10"
-    "@esbuild/openbsd-arm64" "0.25.10"
-    "@esbuild/openbsd-x64" "0.25.10"
-    "@esbuild/openharmony-arm64" "0.25.10"
-    "@esbuild/sunos-x64" "0.25.10"
-    "@esbuild/win32-arm64" "0.25.10"
-    "@esbuild/win32-ia32" "0.25.10"
-    "@esbuild/win32-x64" "0.25.10"
 
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
@@ -6258,10 +6153,10 @@ exit-on-epipe@~1.0.1:
   resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
   integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
-expect-type@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.1.0.tgz#a146e414250d13dfc49eafcfd1344a4060fa4c75"
-  integrity sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==
+expect-type@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
 extend@^3.0.0:
   version "3.0.2"
@@ -6369,7 +6264,7 @@ fbjs@^3.0.0:
     setimmediate "^1.0.5"
     ua-parser-js "^1.0.35"
 
-fdir@^6.4.4, fdir@^6.5.0:
+fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
@@ -6462,14 +6357,6 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.2.7"
 
-foreground-child@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.0.tgz#0ac8644c06e431439f8561db8ecf29a7b5519c77"
-  integrity sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==
-  dependencies:
-    cross-spawn "^7.0.0"
-    signal-exit "^4.0.1"
-
 format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
@@ -6510,7 +6397,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2, fsevents@~2.3.3:
+fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -6687,18 +6574,6 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^10.4.1:
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
-  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
-  dependencies:
-    foreground-child "^3.1.0"
-    jackspeak "^3.1.2"
-    minimatch "^9.0.4"
-    minipass "^7.1.2"
-    package-json-from-dist "^1.0.0"
-    path-scurry "^1.11.1"
-
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -6788,11 +6663,6 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
-
-globrex@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
-  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
@@ -7963,19 +7833,10 @@ istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
     make-dir "^4.0.0"
     supports-color "^7.1.0"
 
-istanbul-lib-source-maps@^5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz#acaef948df7747c8eb5fbf1265cb980f6353a441"
-  integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
-  dependencies:
-    "@jridgewell/trace-mapping" "^0.3.23"
-    debug "^4.1.1"
-    istanbul-lib-coverage "^3.0.0"
-
-istanbul-reports@^3.1.7:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.7.tgz#daed12b9e1dca518e15c056e1e537e741280fa0b"
-  integrity sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==
+istanbul-reports@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
@@ -7991,15 +7852,6 @@ iterator.prototype@^1.1.4:
     get-proto "^1.0.0"
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
-
-jackspeak@^3.1.2:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
-  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
-  dependencies:
-    "@isaacs/cliui" "^8.0.2"
-  optionalDependencies:
-    "@pkgjs/parseargs" "^0.11.0"
 
 jest-environment-jsdom@^30.2.0:
   version "30.2.0"
@@ -8077,6 +7929,11 @@ js-md4@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/js-md4/-/js-md4-0.3.2.tgz#cd3b3dc045b0c404556c81ddb5756c23e59d7cf5"
   integrity sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==
+
+js-tokens@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-10.0.0.tgz#dffe7599b4a8bb7fe30aff8d0235234dffb79831"
+  integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
 
 js-tokens@^3.0.0:
   version "3.0.2"
@@ -8627,16 +8484,6 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-loupe@^3.1.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.2.tgz#c86e0696804a02218f2206124c45d8b15291a240"
-  integrity sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==
-
-loupe@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
-  integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
-
 lower-case-first@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-2.0.2.tgz#64c2324a2250bf7c37c5901e76a5b5309301160b"
@@ -8661,7 +8508,7 @@ lru-cache@2.6.3:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.6.3.tgz#51ccd0b4fc0c843587d7a5709ce4d3b7629bedc5"
   integrity sha512-qkisDmHMe8gxKujmC1BdaqgkoFlioLDCUwaFBA3lX8Ilhr3YzsasbGYaiADMjxQnj+aiZUKgGKe/BN3skMwXWw==
 
-lru-cache@^10.2.0, lru-cache@^10.4.3:
+lru-cache@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -8695,21 +8542,21 @@ macos-release@^3.0.1:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-3.3.0.tgz#92cb67bc66d67c3fde4a9e14f5f909afa418b072"
   integrity sha512-tPJQ1HeyiU2vRruNGhZ+VleWuMQRro8iFtJxYgnS4NQe+EukKF6aGiIT+7flZhISAt2iaXBCfFGvAyif7/f8nQ==
 
-magic-string@^0.30.17:
-  version "0.30.17"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
-  integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
   dependencies:
-    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
-magicast@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.3.5.tgz#8301c3c7d66704a0771eb1bad74274f0ec036739"
-  integrity sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==
+magicast@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.5.2.tgz#70cea9df729c164485049ea5df85a390281dfb9d"
+  integrity sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==
   dependencies:
-    "@babel/parser" "^7.25.4"
-    "@babel/types" "^7.25.4"
-    source-map-js "^1.2.0"
+    "@babel/parser" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    source-map-js "^1.2.1"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -9481,13 +9328,6 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.4:
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
-  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
-  dependencies:
-    brace-expansion "^2.0.2"
-
 minimatch@^9.0.5:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.7.tgz#d76c4d0b3b527877016d6cc1b9922fc8e0ffe7b0"
@@ -9499,11 +9339,6 @@ minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
-  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 mkdirp@^0.5.1:
   version "0.5.6"
@@ -9771,6 +9606,11 @@ object.values@^1.1.6, object.values@^1.2.0, object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+obug@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
+  integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
+
 oidc-client-ts@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/oidc-client-ts/-/oidc-client-ts-2.4.1.tgz#5441cb90188bc07580bcab2b49ed2fd1fe1889d0"
@@ -9948,11 +9788,6 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-package-json-from-dist@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
-  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
-
 param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
@@ -10109,14 +9944,6 @@ path-root@^0.1.1:
   dependencies:
     path-root-regex "^0.1.0"
 
-path-scurry@^1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
-  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
-  dependencies:
-    lru-cache "^10.2.0"
-    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
-
 path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
@@ -10136,11 +9963,6 @@ pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
-
-pathval@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.0.tgz#7e2550b422601d4f6b8e26f1301bc8f15a741a25"
-  integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
 
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
@@ -10213,7 +10035,7 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
-postcss@^8.4.21, postcss@^8.5.3, postcss@^8.5.8:
+postcss@^8.4.21, postcss@^8.5.8:
   version "8.5.8"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.8.tgz#6230ecc8fb02e7a0f6982e53990937857e13f399"
   integrity sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==
@@ -10477,6 +10299,11 @@ react-redux@^9.2.0:
   dependencies:
     "@types/use-sync-external-store" "^0.0.6"
     use-sync-external-store "^1.4.0"
+
+react-refresh@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.18.0.tgz#2dce97f4fe932a4d8142fa1630e475c1729c8062"
+  integrity sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==
 
 react-router@^7.12.0:
   version "7.12.0"
@@ -11031,40 +10858,6 @@ rolldown@1.0.0-rc.12:
     "@rolldown/binding-win32-arm64-msvc" "1.0.0-rc.12"
     "@rolldown/binding-win32-x64-msvc" "1.0.0-rc.12"
 
-rollup@^4.34.9:
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.60.1.tgz#b4aa2bcb3a5e1437b5fad40d43fe42d4bde7a42d"
-  integrity sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==
-  dependencies:
-    "@types/estree" "1.0.8"
-  optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.60.1"
-    "@rollup/rollup-android-arm64" "4.60.1"
-    "@rollup/rollup-darwin-arm64" "4.60.1"
-    "@rollup/rollup-darwin-x64" "4.60.1"
-    "@rollup/rollup-freebsd-arm64" "4.60.1"
-    "@rollup/rollup-freebsd-x64" "4.60.1"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.60.1"
-    "@rollup/rollup-linux-arm-musleabihf" "4.60.1"
-    "@rollup/rollup-linux-arm64-gnu" "4.60.1"
-    "@rollup/rollup-linux-arm64-musl" "4.60.1"
-    "@rollup/rollup-linux-loong64-gnu" "4.60.1"
-    "@rollup/rollup-linux-loong64-musl" "4.60.1"
-    "@rollup/rollup-linux-ppc64-gnu" "4.60.1"
-    "@rollup/rollup-linux-ppc64-musl" "4.60.1"
-    "@rollup/rollup-linux-riscv64-gnu" "4.60.1"
-    "@rollup/rollup-linux-riscv64-musl" "4.60.1"
-    "@rollup/rollup-linux-s390x-gnu" "4.60.1"
-    "@rollup/rollup-linux-x64-gnu" "4.60.1"
-    "@rollup/rollup-linux-x64-musl" "4.60.1"
-    "@rollup/rollup-openbsd-x64" "4.60.1"
-    "@rollup/rollup-openharmony-arm64" "4.60.1"
-    "@rollup/rollup-win32-arm64-msvc" "4.60.1"
-    "@rollup/rollup-win32-ia32-msvc" "4.60.1"
-    "@rollup/rollup-win32-x64-gnu" "4.60.1"
-    "@rollup/rollup-win32-x64-msvc" "4.60.1"
-    fsevents "~2.3.2"
-
 rrweb-cssom@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
@@ -11323,7 +11116,7 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^4.0.1, signal-exit@^4.1.0:
+signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -11385,7 +11178,7 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.1, source-map-js@^1.2.0, source-map-js@^1.2.1:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -11452,10 +11245,10 @@ statuses@^2.0.2:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
   integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
-std-env@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.8.0.tgz#b56ffc1baf1a29dcc80a3bdf11d7fca7c315e7d5"
-  integrity sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==
+std-env@^4.0.0-rc.1:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.0.0.tgz#ba3dc31c3a46bc5ba21138aa20a6a4ceb5bb9b7e"
+  integrity sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==
 
 stop-iteration-iterator@^1.0.0:
   version "1.1.0"
@@ -11485,15 +11278,6 @@ string-env-interpolation@^1.0.1:
   resolved "https://registry.yarnpkg.com/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
   integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -11502,15 +11286,6 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
-
-string-width@^5.0.1, string-width@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
-  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
-  dependencies:
-    eastasianwidth "^0.2.0"
-    emoji-regex "^9.2.2"
-    strip-ansi "^7.0.1"
 
 string-width@^7.0.0:
   version "7.2.0"
@@ -11611,13 +11386,6 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -11625,7 +11393,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1, strip-ansi@^7.1.0:
+strip-ansi@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
   integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
@@ -11749,15 +11517,6 @@ tagged-tag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tagged-tag/-/tagged-tag-1.0.0.tgz#a0b5917c2864cba54841495abfa3f6b13edcf4d6"
   integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
-
-test-exclude@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-7.0.1.tgz#20b3ba4906ac20994e275bbcafd68d510264c2a2"
-  integrity sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==
-  dependencies:
-    "@istanbuljs/schema" "^0.1.2"
-    glob "^10.4.1"
-    minimatch "^9.0.4"
 
 testcafe-browser-tools@2.0.26:
   version "2.0.26"
@@ -12031,10 +11790,15 @@ tinybench@^2.9.0:
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
   integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
 
-tinyexec@^0.3.0, tinyexec@^0.3.2:
+tinyexec@^0.3.0:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
+tinyexec@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.1.1.tgz#e1ff45dfa60d1dedb91b734956b78f6c2a3e821b"
+  integrity sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==
 
 tinyglobby@^0.2.13, tinyglobby@^0.2.15:
   version "0.2.15"
@@ -12044,20 +11808,10 @@ tinyglobby@^0.2.13, tinyglobby@^0.2.15:
     fdir "^6.5.0"
     picomatch "^4.0.3"
 
-tinypool@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.2.tgz#706193cc532f4c100f66aa00b01c42173d9051b2"
-  integrity sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==
-
-tinyrainbow@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
-  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
-
-tinyspy@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
-  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
+tinyrainbow@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
+  integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
 
 title-case@^3.0.3:
   version "3.0.3"
@@ -12213,7 +11967,7 @@ ts-api-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz#bfc2215fe6528fecab2b0fba570a2e8a4263b064"
   integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
 
-ts-api-utils@^2.4.0:
+ts-api-utils@^2.4.0, ts-api-utils@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
@@ -12229,11 +11983,6 @@ ts-log@^2.2.3:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.7.tgz#4f4512144898b77c9984e91587076fcb8518688e"
   integrity sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==
-
-tsconfck@^3.0.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.1.4.tgz#de01a15334962e2feb526824339b51be26712229"
-  integrity sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==
 
 tsconfig-paths@^3.15.0:
   version "3.15.0"
@@ -12713,50 +12462,16 @@ vfile@^6.0.0:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
-vite-node@3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.0.7.tgz#f15bc1e0c343ac00115a52c7e110471a5a315c72"
-  integrity sha512-2fX0QwX4GkkkpULXdT1Pf4q0tC1i1lFOyseKoonavXUNlQ77KpW2XqBGGNIm/J4Ows4KxgGJzDguYVPKwG/n5A==
+vite-plugin-svgr@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-svgr/-/vite-plugin-svgr-5.2.0.tgz#6502d7988394e167822baa91e6d6369383815006"
+  integrity sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==
   dependencies:
-    cac "^6.7.14"
-    debug "^4.4.0"
-    es-module-lexer "^1.6.0"
-    pathe "^2.0.3"
-    vite "^5.0.0 || ^6.0.0"
-
-vite-plugin-svgr@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/vite-plugin-svgr/-/vite-plugin-svgr-5.0.0.tgz#3993ab856a994c9fdc03be6ce910504e75947330"
-  integrity sha512-CZFWDtbWSLnF6C+uv8u7E5Ao6UVQYBpJrS6212XsEod/Lm4ErhOoFc01/po4ie5hqvMCr5KYrlMrSGQQEtMtBg==
-  dependencies:
-    "@rollup/pluginutils" "^5.2.0"
+    "@rollup/pluginutils" "^5.3.0"
     "@svgr/core" "^8.1.0"
     "@svgr/plugin-jsx" "^8.1.0"
 
-vite-tsconfig-paths@^5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz#d9a71106a7ff2c1c840c6f1708042f76a9212ed4"
-  integrity sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==
-  dependencies:
-    debug "^4.1.1"
-    globrex "^0.1.2"
-    tsconfck "^3.0.3"
-
-"vite@^5.0.0 || ^6.0.0":
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.4.1.tgz#afbe14518cdd6887e240a4b0221ab6d0ce733f96"
-  integrity sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==
-  dependencies:
-    esbuild "^0.25.0"
-    fdir "^6.4.4"
-    picomatch "^4.0.2"
-    postcss "^8.5.3"
-    rollup "^4.34.9"
-    tinyglobby "^0.2.13"
-  optionalDependencies:
-    fsevents "~2.3.3"
-
-vite@^8.0.5:
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0", vite@^8.0.5:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/vite/-/vite-8.0.5.tgz#5f8648997359e18dbc1a9e151ce55434ce5d8a2f"
   integrity sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==
@@ -12769,35 +12484,35 @@ vite@^8.0.5:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest-sonar-reporter@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/vitest-sonar-reporter/-/vitest-sonar-reporter-2.0.0.tgz#6372e5faba2b2834eac0b2cd1283263d38d0e718"
-  integrity sha512-LorC3NnmrBrryx4+l3BEsNQjD0Y7wfmrD1y/+tHDuZUuVj7w8nOxRXCBSppDfmgfpToOhwchh0JcL4IGMKUKDA==
+vitest-sonar-reporter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vitest-sonar-reporter/-/vitest-sonar-reporter-3.0.0.tgz#3bb34a9a46390dce83a50de16135fc325c73359d"
+  integrity sha512-QRT5m9Z/3Kt0WVDVcFHm5LC9Ba89yDP4twlX2QUAJ9PdqfJBkLAh/kXj7m6U3i0k6GxnIEiwCc295bmAYokmZg==
 
-vitest@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.0.7.tgz#ed8f42e1b0e09e2179eaefd966cb58a8b75f0f6a"
-  integrity sha512-IP7gPK3LS3Fvn44x30X1dM9vtawm0aesAa2yBIZ9vQf+qB69NXC5776+Qmcr7ohUXIQuLhk7xQR0aSUIDPqavg==
+vitest@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.2.tgz#3f7b36838ddf1067160489bea9a21ef465496265"
+  integrity sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==
   dependencies:
-    "@vitest/expect" "3.0.7"
-    "@vitest/mocker" "3.0.7"
-    "@vitest/pretty-format" "^3.0.7"
-    "@vitest/runner" "3.0.7"
-    "@vitest/snapshot" "3.0.7"
-    "@vitest/spy" "3.0.7"
-    "@vitest/utils" "3.0.7"
-    chai "^5.2.0"
-    debug "^4.4.0"
-    expect-type "^1.1.0"
-    magic-string "^0.30.17"
+    "@vitest/expect" "4.1.2"
+    "@vitest/mocker" "4.1.2"
+    "@vitest/pretty-format" "4.1.2"
+    "@vitest/runner" "4.1.2"
+    "@vitest/snapshot" "4.1.2"
+    "@vitest/spy" "4.1.2"
+    "@vitest/utils" "4.1.2"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
     pathe "^2.0.3"
-    std-env "^3.8.0"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
     tinybench "^2.9.0"
-    tinyexec "^0.3.2"
-    tinypool "^1.0.2"
-    tinyrainbow "^2.0.0"
-    vite "^5.0.0 || ^6.0.0"
-    vite-node "3.0.7"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.1.0"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0"
     why-is-node-running "^2.3.0"
 
 void-elements@3.1.0:
@@ -13000,15 +12715,6 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
 wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -13026,15 +12732,6 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
-
-wrap-ansi@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
-  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
-  dependencies:
-    ansi-styles "^6.1.0"
-    string-width "^5.0.1"
-    strip-ansi "^7.0.1"
 
 wrap-ansi@^9.0.0:
   version "9.0.0"


### PR DESCRIPTION
## Summary

This PR addresses two key improvements to the project:

1. **Tooling Migration**: Migrate from SWC to Babel-based React plugin with updated test dependencies
2. **Security**: Add lodash version resolution to fix critical and moderate vulnerabilities

## Changes

### Refactor: Switch to Babel React plugin and update test setup

- Replace `@vitejs/plugin-react-swc` with `@vitejs/plugin-react`
- Use native Vite `tsconfigPaths` config instead of separate plugin
- Suppress jsdom CSS parse errors at VirtualConsole level
- Convert ResizeObserver mock to class-based implementation
- Update vitest, coverage, and related dependencies

### Fix (Security): Add lodash resolution to fix code injection vulnerabilities

- Add `lodash >=4.18.0` resolution to fix vulnerabilities through @graphql-codegen packages
- Fixes CVE-1115806: Code Injection via _.template imports with unsafe key names
- Fixes CVE-1115810: Prototype Pollution via array path bypass in _.unset and _.omit
- Document resolution rationale in package.json for future maintainers

## Related Issues

Refs KEH-281